### PR TITLE
Tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,7 @@ dmypy.json
 
 # PyCharm
 .idea/
+
+# More temporary files
+\#*\#
+*~

--- a/TOOLS.rst
+++ b/TOOLS.rst
@@ -15,9 +15,19 @@ The following is a list of "tool and commands runners":
 * **invoke** is used during development, to run tools and other
   pre-configured maintenance tasks inside the existing development
   environment
-* **tox** is used as a tool to run all **QA** tools and commands
-  across all supported enviroments, typically before push or by
-  continuous integration (CI) tools
+* **tox** is used as a tool to run all quality assurance (**QA**)
+  tools and commands across all supported enviroments, typically
+  before push or by continuous integration (CI) tools
+
+Install instructions
+--------------------
+
+Install all development tools by executing::
+
+  pip install -r requirements-dev.txt
+
+while being at the git archive root in your virtual environment or
+anaconda environment.
 
 Tool and command runners in more detail
 =======================================
@@ -56,10 +66,11 @@ Where are settings and arguments kept
 
 For settings and arguments for tools the following rules apply:
 
-* **setup.cfg** If the tool support defining them in the shared
-  configuration file ``setup.cfg``, then they belong there no-matter
-  how they are run. If not (settings may only be available at the
-  command line), see the next points.
+* **setup.cfg** (not to be confused with setup.py which is used for
+  bilding the package) If the tools support defining settings in the
+  shared configuration file ``setup.cfg``, then they belong there
+  no-matter how the tools are run. If not (settings may only be
+  available at the command line), see the next points.
 * **tox.ini** If the tool is run by both ``tox`` and ``invoke``, then
   the settings belong in the ``tox`` configuration file and ``invoke``
   will have to read them from there
@@ -94,10 +105,10 @@ Linux instructions
 
 On Linux systems this is done by sym-linking it into the proper
 folder. Starting at the base folder of the git archive it looks like
-this:
+this::
 
-$ cd .git/hooks
-$ ln -s ../../tools/hooks/pre-push .
+ $ cd .git/hooks
+ $ ln -s ../../tools/hooks/pre-push .
 
 Windows instructions
 --------------------
@@ -112,7 +123,7 @@ The next step is to copy the Windows specific hook into place, so
 locate the folder ``.git/hooks`` in the main folder of the git archive
 and copy the file ``tools/hooks/pre-push_windows_git_bash`` into that
 folder. (The interested reader will notice that the only difference
-between the Linux and the Windows version of the hooks is the line at
+between the Linux and the Windows version of the hook, is the line at
 the top that indicates the executable that should run the program).
 
 Then there is a bit of difference depending on how git is used. If the
@@ -124,39 +135,43 @@ If the development is done elsewhere, but still somehow relies on a
 virtual environment (either a separate virtual environment or an
 anaconda environment), and git is used via the Git Bash program that
 is installed along with Git for Windows, then a bit more work is
-required before. The problem is that Git Bash does not know about the
-path of the development tools, so that will have to be set manually.
+required. The problem is that Git Bash does not know about the path of
+the development tools, so that will have to be set manually.
 
 First we should locate the path of the tools. In case a separate
-virtual environment is used, located e.g. in c:\venv\ixdat, then
-c:\venv\ixdat\Scripts will be the path of tools. TODO anaconda.
+virtual environment is used, located e.g. in ``c:\venv\ixdat``, then
+``c:\venv\ixdat\Scripts`` will be the path of tools. TODO anaconda.
 
 Having found the path of the tools it needs to be added to the Bash
-configuration file like so:
+configuration file like so::
 
-$ cd
-$ pwd
-/c/Users/Kenneth Nielsen
-$ nano .bashrc
+ $ cd
+ $ pwd
+ /c/Users/Kenneth Nielsen
+ $ nano .bashrc
 
-Inside .bashrc add a line like this:
+The last line will open the ``.bashrc`` file in the terminal editor
+``nano`` (https://www.nano-editor.org/dist/latest/cheatsheet.html). In
+the editor, add this line to end of the file::
 
-export PATH=/c/venv/ixdat/Scripts:$PATH
+  export PATH=/c/venv/ixdat/Scripts:$PATH
 
-where the /c/venv/ixdat/Scripts is the path located before, but
-converted for Git Bash notation, where the C-driver is called /c and /
-is used for directory separation.
+and save the file and exit by pressing ``Ctrl-x`` followed by ``Y``
+(if your editor is in english) and ``Enter``. The
+``/c/venv/ixdat/Scripts`` part of that line is the path located
+before, but converted for Git Bash notation, where the C-drive is
+called ``/c`` and ``/`` is used for directory separation.
 
 After having done this all the development tools and the git hook
 should work. You can test the development tools by starting a new Git
-Bash shell, navigation to the git archive and executing the command:
+Bash shell, navigation to the git archive and executing the command::
 
-| $ invoke tox
-| GLOB sdist-make: C:\venv\ixdat\ixdat\setup.py
-| ___________________________________ summary ___________________________________
-|   py39: commands succeeded
-|   flake8: commands succeeded
-|   congratulations :)
+ $ invoke tox
+ GLOB sdist-make: C:\venv\ixdat\ixdat\setup.py
+ ___________________________________ summary ___________________________________
+   py39: commands succeeded
+   flake8: commands succeeded
+   congratulations :)
 
 Command quick tips
 ==================
@@ -164,38 +179,38 @@ Command quick tips
 tox
 ---
 
-To run all ``test environments`` simply run
+To run all ``test environments`` simply run::
 
-$ tox
+ $ tox
 
 To pick a specific one to run, use the ``-e`` flag followed by the
-name:
+name::
 
-$ tox -e flake8
+ $ tox -e flake8
 
-To list the enviroments do:
+To list the enviroments do::
 
-$ tox -l
+ $ tox -l
 
-To force recreation of all tox' virtual environments do
+To force recreation of all tox' virtual environments do::
 
-$ tox -r
+ $ tox -r
 
 invoke
 ------
 
-To see a list of all tasks:
+To see a list of all tasks::
 
-$ invoke --list
+ $ invoke --list
 
-To run a specific task, say linting, run:
+To run a specific task, say linting, run::
 
-$ invoke lint
+ $ invoke lint
 
-To run a command with an **invoke specific** argument do:
+To run a command with an **invoke specific** argument do::
 
-$ invoke clean --dryrun
+ $ invoke clean --dryrun
 
-To get help on a command, e.g. ``clean``, do:
+To get help on a command, e.g. ``clean``, do::
 
-$ invoke --help clean
+ $ invoke --help clean

--- a/TOOLS.rst
+++ b/TOOLS.rst
@@ -66,16 +66,14 @@ Where are settings and arguments kept
 
 For settings and arguments for tools the following rules apply:
 
-* **setup.cfg** (not to be confused with setup.py which is used for
-  bilding the package) If the tools support defining settings in the
-  shared configuration file ``setup.cfg``, then they belong there
-  no-matter how the tools are run. If not (settings may only be
-  available at the command line), see the next points.
-* **tox.ini** If the tool is run by both ``tox`` and ``invoke``, then
-  the settings belong in the ``tox`` configuration file and ``invoke``
-  will have to read them from there
-* **tasks.py** If the tool is ``invoke`` specific, then obviously the
-  configuration goes into its "configuration file" ``tasks.py``
+* **setup.cfg**) (not to be confused with setup.py, which is used for
+  building the package) If the tools support configuration in the
+  shared configuration file ``setup.cfg``, then it belong there
+  always!
+* **tox.ini** and **tasks.py**) If the tools only support
+  configuration on the command line, then it goes into the
+  configuration files of the tool runners, ``tox.ini`` for tox and
+  ``tasks.py`` for invoke.
 
 Non-tool related "settings"
 ```````````````````````````

--- a/TOOLS.rst
+++ b/TOOLS.rst
@@ -77,6 +77,24 @@ setup.py
 `requirements.txt` for package requirements and `requirements-dev.txt`
 for development requirements.
 
+Git hooks
+=========
+
+The version control system `git` has the option of having check done
+before certain important actions, like a commit or a push. These are
+referred to as `hooks`. For xidat a pre-push is recommended (as
+opposed to a pre-commit hook, which take time to run the tests on
+every commit). The pre-push hook is located in `tools/hooks`.
+
+Git hooks cannot be distributed automatically, so it will need to be
+"installed". On Linux systems this is done by sym-linking it into the
+proper folder:
+
+$ cd .git/hooks
+$ ln -s ../../tools/hooks/pre-push .
+
+Windows instructions TODO.
+
 Command quick tips
 ==================
 

--- a/TOOLS.rst
+++ b/TOOLS.rst
@@ -1,0 +1,119 @@
+This file explains the development tool chain around ixdat
+
+Tools used
+==========
+
+The following is a list of specific tools used during ixdat
+development:
+
+* **pytest** is used for running tests
+* **flake8** is used for linting
+* **sphinx** is used to build documentation
+
+The following is a list of "tool and commands runners":
+   
+* **invoke** is used during development, to run tools and other
+  pre-configured maintenance tasks inside the existing development
+  environment
+* **tox** is used as a tool to run all **QA** tools and commands
+  across all supported enviroments, typically before push or by
+  continuous integration (CI) tools
+
+Tool and command runners in more detail
+=======================================
+
+The reason there are two different tool runners is that they have very
+different purposes:
+
+**invoke** is used as general purpose, platform independent way of
+defining and running "tasks relevant for development" (reminiscent of
+the *makefiles* of olden times, commonly used for software development
+on Unix systems). These tasks can be something like running a linter,
+type checker, test runner or code formatter, building documentation,
+cleaning the repository of temporary files, building a package or
+updating the list of contributors from the git log.
+
+**tox** is tuned towards a specific purpose, which is to run
+specifically QA tools (something like linter, type checker, test
+runner or code formatter) in a clean environment, with a fresh install
+of code, across as many supported python versions as possible. `tox`
+can also be used in CI tools, such a Github Actions, to specify what
+to run as part of the CI, which eliminates the need to an extra
+configuration.
+
+Both tools share the purpose of hiding the details of the way the
+tools should be run (arguments, settings etc.) and defining a single
+place to define those.
+
+From the definitions above, however, it is obvious that the QA tools
+may be run by both. This is ok, because the purposes are different.
+But it raises the important concern of *where* the one true place to
+define the arguments and settings are for those. See definitions of
+that in the following section.
+
+Where are settings and arguments kept
+-------------------------------------
+
+For settings and arguments for tools the following rules apply:
+
+* **setup.cfg** If the tool support defining them in the shared
+  configuration file `setup.cfg`, then they belong there no-matter how
+  they are run. If not (settings may only be available at the command
+  line), see the next points.
+* **tox.ini** If the tool is run by both `tox` and `invoke`, then the
+  settings belong in the `tox` configuration file and `invoke` will
+  have to read them from there
+* **tasks.py** If the tool is `invoke` specific, then obviously the
+  configuration goes into its "configuration file" `tasks.py`
+
+Non-tool related "settings"
+```````````````````````````
+
+**Package metadata** goes into src/ixdat/__init__.py and README.rst
+and all remaining information about how to create a package goes into
+setup.py
+
+**requirements** goes into the two requirements files;
+`requirements.txt` for package requirements and `requirements-dev.txt`
+for development requirements.
+
+Command quick tips
+==================
+
+tox
+---
+
+To run all `test environments` simply run
+
+$ tox
+
+To pick a specific one to run, use the `-e` flag followed by the name:
+
+$ tox -e flake8
+
+To list the enviroments do:
+
+$ tox -l
+
+To force recreation of all tox' virtual environments do
+
+$ tox -r
+
+invoke
+------
+
+To see a list of all tasks:
+
+$ invoke --list
+
+To run a specific task, say linting, run:
+
+$ invoke lint
+
+To run a command with an **invoke specific** argument do:
+
+$ invoke clean --dryrun
+
+To get help on a command, e.g. `clean`, do:
+
+$ invoke --help clean

--- a/TOOLS.rst
+++ b/TOOLS.rst
@@ -36,7 +36,7 @@ updating the list of contributors from the git log.
 **tox** is tuned towards a specific purpose, which is to run
 specifically QA tools (something like linter, type checker, test
 runner or code formatter) in a clean environment, with a fresh install
-of code, across as many supported python versions as possible. `tox`
+of code, across as many supported python versions as possible. ``tox``
 can also be used in CI tools, such a Github Actions, to specify what
 to run as part of the CI, which eliminates the need to an extra
 configuration.
@@ -57,14 +57,14 @@ Where are settings and arguments kept
 For settings and arguments for tools the following rules apply:
 
 * **setup.cfg** If the tool support defining them in the shared
-  configuration file `setup.cfg`, then they belong there no-matter how
-  they are run. If not (settings may only be available at the command
-  line), see the next points.
-* **tox.ini** If the tool is run by both `tox` and `invoke`, then the
-  settings belong in the `tox` configuration file and `invoke` will
-  have to read them from there
-* **tasks.py** If the tool is `invoke` specific, then obviously the
-  configuration goes into its "configuration file" `tasks.py`
+  configuration file ``setup.cfg``, then they belong there no-matter
+  how they are run. If not (settings may only be available at the
+  command line), see the next points.
+* **tox.ini** If the tool is run by both ``tox`` and ``invoke``, then
+  the settings belong in the ``tox`` configuration file and ``invoke``
+  will have to read them from there
+* **tasks.py** If the tool is ``invoke`` specific, then obviously the
+  configuration goes into its "configuration file" ``tasks.py``
 
 Non-tool related "settings"
 ```````````````````````````
@@ -74,26 +74,89 @@ and all remaining information about how to create a package goes into
 setup.py
 
 **requirements** goes into the two requirements files;
-`requirements.txt` for package requirements and `requirements-dev.txt`
-for development requirements.
+``requirements.txt`` for package requirements and
+``requirements-dev.txt`` for development requirements.
 
 Git hooks
 =========
 
-The version control system `git` has the option of having check done
+The version control system ``git`` has the option of having check done
 before certain important actions, like a commit or a push. These are
-referred to as `hooks`. For xidat a pre-push is recommended (as
+referred to as ``hooks``. For xidat a pre-push is recommended (as
 opposed to a pre-commit hook, which take time to run the tests on
-every commit). The pre-push hook is located in `tools/hooks`.
+every commit). The pre-push hooks are located in ``tools/hooks``.
 
 Git hooks cannot be distributed automatically, so it will need to be
-"installed". On Linux systems this is done by sym-linking it into the
-proper folder:
+"installed".
+
+Linux instructions
+------------------
+
+On Linux systems this is done by sym-linking it into the proper
+folder. Starting at the base folder of the git archive it looks like
+this:
 
 $ cd .git/hooks
 $ ln -s ../../tools/hooks/pre-push .
 
-Windows instructions TODO.
+Windows instructions
+--------------------
+
+The pre-push hooks on Windows is dependent on a full Git installation,
+because it depends on the shell that is embedded in Git Bash. So if
+there isn't already a full Git for Windows installed, do that
+(https://git-scm.com/downloads) and afterwards confirm that the file
+``C:/Program\ Files/Git/usr/bin/sh.exe`` exists.
+
+The next step is to copy the Windows specific hook into place, so
+locate the folder ``.git/hooks`` in the main folder of the git archive
+and copy the file ``tools/hooks/pre-push_windows_git_bash`` into that
+folder. (The interested reader will notice that the only difference
+between the Linux and the Windows version of the hooks is the line at
+the top that indicates the executable that should run the program).
+
+Then there is a bit of difference depending on how git is used. If the
+main interface to git is via powershell (or mayby Command Prompt) and
+a virtual environment is being used and is active, then the commit
+hook will just work.
+
+If the development is done elsewhere, but still somehow relies on a
+virtual environment (either a separate virtual environment or an
+anaconda environment), and git is used via the Git Bash program that
+is installed along with Git for Windows, then a bit more work is
+required before. The problem is that Git Bash does not know about the
+path of the development tools, so that will have to be set manually.
+
+First we should locate the path of the tools. In case a separate
+virtual environment is used, located e.g. in c:\venv\ixdat, then
+c:\venv\ixdat\Scripts will be the path of tools. TODO anaconda.
+
+Having found the path of the tools it needs to be added to the Bash
+configuration file like so:
+
+$ cd
+$ pwd
+/c/Users/Kenneth Nielsen
+$ nano .bashrc
+
+Inside .bashrc add a line like this:
+
+export PATH=/c/venv/ixdat/Scripts:$PATH
+
+where the /c/venv/ixdat/Scripts is the path located before, but
+converted for Git Bash notation, where the C-driver is called /c and /
+is used for directory separation.
+
+After having done this all the development tools and the git hook
+should work. You can test the development tools by starting a new Git
+Bash shell, navigation to the git archive and executing the command:
+
+| $ invoke tox
+| GLOB sdist-make: C:\venv\ixdat\ixdat\setup.py
+| ___________________________________ summary ___________________________________
+|   py39: commands succeeded
+|   flake8: commands succeeded
+|   congratulations :)
 
 Command quick tips
 ==================
@@ -101,11 +164,12 @@ Command quick tips
 tox
 ---
 
-To run all `test environments` simply run
+To run all ``test environments`` simply run
 
 $ tox
 
-To pick a specific one to run, use the `-e` flag followed by the name:
+To pick a specific one to run, use the ``-e`` flag followed by the
+name:
 
 $ tox -e flake8
 
@@ -132,6 +196,6 @@ To run a command with an **invoke specific** argument do:
 
 $ invoke clean --dryrun
 
-To get help on a command, e.g. `clean`, do:
+To get help on a command, e.g. ``clean``, do:
 
 $ invoke --help clean

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,3 +4,7 @@ Sphinx
 sphinx-rtd-theme
 sphinx_automodapi
 EC_MS
+flake8
+tox
+pytest
+invoke

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,8 +1,12 @@
 [flake8]
 max-line-length = 95
 per-file-ignores =
+    # ignore the "module imported but unused" error for main __init__.py
     src/ixdat/readers/__init__.py:F401
 exclude =
+    # Exclude the main documentation configuration file from flake8
     docs/source/conf.py
+    # Likewise for all files in the .tox directory, which includes all
+    # the python source file of all dependencies etc.
     .tox
     

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,8 @@
+[flake8]
+max-line-length = 95
+per-file-ignores =
+    src/ixdat/readers/__init__.py:F401
+exclude =
+    docs/source/conf.py
+    .tox
+    

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,13 @@
 
 """Initial setup.py
 
-TODO: This file is very rudimentary and is setup purely to enable tox to
-run. None of the information in it reflects necessarily what it should be and
-will be updated to proper values by project owner.
+TODO: This file is rudimentary and setup mainly to enable tox to
+run. The main points missing are:
+
+* Proper and correct trove classifiers (https://pypi.org/classifiers/)
+* A read through of metadata in ``__init__.py``
+* Handling of data files (necessary for the package to run, not for
+  development) when we start to get those
 
 """
 
@@ -17,18 +21,35 @@ HERE = os.path.abspath(os.path.dirname(__file__))
 PACKAGES = setuptools.find_packages(where="./src")
 
 
+# The `read` and `find_meta` functions are shamelessly stolen from
+# https://hynek.me/articles/sharing-your-labor-of-love-pypi-quick-and-dirty/
+# and their doc strings adapted
+
+
 def read(*parts):
-    """
-    Build an absolute path from *parts* and and return the contents of the
-    resulting file.  Assume UTF-8 encoding.
+    """Build an absolute path from *parts* and return the contents of
+    the resulting file as a string.
+
+    Assume UTF-8 encoding.
+
     """
     with codecs.open(os.path.join(HERE, *parts), "rb", "utf-8") as f:
         return f.read()
 
 
+META_FILE = read(META_PATH)
+
+
 def find_meta(meta):
-    """
-    Extract __*meta*__ from META_FILE.
+    """Extract a piece of double underscore defined metadata from the
+    global META_FILE (defined above).
+
+    If e.g. in META_FILE there is the code::
+
+     __author__ = "Guido"
+
+    then find_meta("author") will return "Guido"
+
     """
     meta_match = re.search(
         r"^__{meta}__ = ['\"]([^'\"]*)['\"]".format(meta=meta),
@@ -40,8 +61,6 @@ def find_meta(meta):
         "Unable to find __{meta}__ string.".format(meta=meta)
     )
 
-
-META_FILE = read(META_PATH)
 
 setuptools.setup(
     name=find_meta("title"),

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,64 @@
+
+"""Initial setup.py
+
+TODO: This file is very rudimentary and is setup purely to enable tox to
+run. None of the information in it reflects necessarily what it should be and
+will be updated to proper values by project owner.
+
+"""
+
+import os
+import re
+import codecs
+import setuptools
+
+META_PATH = os.path.join("src", "ixdat", "__init__.py")
+HERE = os.path.abspath(os.path.dirname(__file__))
+PACKAGES = setuptools.find_packages(where="./src")
+
+
+def read(*parts):
+    """
+    Build an absolute path from *parts* and and return the contents of the
+    resulting file.  Assume UTF-8 encoding.
+    """
+    with codecs.open(os.path.join(HERE, *parts), "rb", "utf-8") as f:
+        return f.read()
+
+
+def find_meta(meta):
+    """
+    Extract __*meta*__ from META_FILE.
+    """
+    meta_match = re.search(
+        r"^__{meta}__ = ['\"]([^'\"]*)['\"]".format(meta=meta),
+        META_FILE, re.M
+    )
+    if meta_match:
+        return meta_match.group(1)
+    raise RuntimeError(
+        "Unable to find __{meta}__ string.".format(meta=meta)
+    )
+
+
+META_FILE = read(META_PATH)
+
+setuptools.setup(
+    name=find_meta("title"),
+    version=find_meta("version"),
+    license=find_meta("license"),
+    author=find_meta("author"),
+    author_email=find_meta("email"),
+    description=find_meta("description"),
+    long_description=read("README.rst"),
+    long_description_content_type="text/x-rst",
+    url="https://github.com/ixdat/ixdat",
+    packages=PACKAGES,
+    package_dir={"": "src"},
+    classifiers=[
+        "Programming Language :: Python :: 3",
+        "License :: OSI Approved :: MIT License",
+        "Operating System :: OS Independent",
+    ],
+    python_requires='>=3.6',
+)

--- a/tasks.py
+++ b/tasks.py
@@ -1,0 +1,117 @@
+
+"""Definition of invoke tasks"""
+
+import configparser
+from shutil import rmtree
+from invoke import task
+from pathlib import Path
+from subprocess import check_call, CalledProcessError
+
+
+THIS_DIR = Path(__file__).parent
+SOURCE_DIR = THIS_DIR / "src" / "ixdat"
+CLEAN_PATTERNS = ("__pycache__", "*.pyc", "*.pyo", ".mypy_cache")
+
+
+tox_config = configparser.ConfigParser()
+tox_config.read("tox.ini")
+
+
+def extract_first_command_from_tox_env(environment):
+    """Extract the first command from list of commands from tox.ini"""
+    commands_string = tox_config[environment]["commands"]
+    commands = commands_string.split("\n")
+    if commands[0].strip() == "" and len(commands) > 0:
+        commands = commands[1:]
+    return commands[0]
+
+
+# ### QA tasks
+
+
+@task(aliases=["lint"])
+def flake8(context):
+    """Run the flake8 task"""
+    command = extract_first_command_from_tox_env("testenv:flake8")
+    print("# flake8")
+    return context.run(command).return_code
+
+
+@task(aliases=["test", "tests"])
+def pytest(context):
+    """Run the pytest task"""
+    command = extract_first_command_from_tox_env("testenv")
+    print("# pytest")
+    return context.run(command).return_code
+
+
+@task(aliases=["QA", "qa", "check"])
+def checks(context):
+    """Run all QA checks"""
+    combined_return_code = flake8(context)
+    combined_return_code += pytest(context)
+    if combined_return_code == 0:
+        print()
+        print(r"+----------+")
+        print(r"| All good |")
+        print(r"+----------+")
+
+
+@task
+def tox(context):
+    """Run tox for the python interpreters available on your system"""
+    environments = tox_config["tox"]["envlist"].split(", ")
+    environments_to_run = []
+
+    # Check which pythons are available on the system
+
+    # TODO this almost certainly is Linux and possibly MacOS specific
+    # and will need a Windows port
+    for environment in environments:
+        if environment.startswith("py"):
+            if environment.startswith("pypy"):
+                command = environment
+            else:
+                # The environments look like: py36
+                command = "python{}.{}".format(*environment[2: 4])
+
+            # Check that the executable exists
+            try:
+                check_call([command, "--version"])
+            except (CalledProcessError, FileNotFoundError):
+                continue
+
+            # Certain version of Ubuntu may have a old "reduced"
+            # Python version, with an "m" suffix. It is unsifficient
+            # for tox so check that it isn't there.
+            try:
+                check_call([command + "m", "--version"])
+                continue
+            except (CalledProcessError, FileNotFoundError):
+                pass
+
+            environments_to_run.append(environment)
+        else:
+            environments_to_run.append(environment)
+
+    context.run("tox -e " + ",".join(environments_to_run))
+
+
+# ### Maintenance tasks
+
+
+@task
+def clean(c, dryrun=False):
+    """Clean the repository of temporary files and caches"""
+    if dryrun:
+        print("CLEANING DRYRUN")
+    for clean_pattern in CLEAN_PATTERNS:
+        for cleanpath in THIS_DIR.glob("**/" + clean_pattern):
+            if cleanpath.is_dir():
+                print("DELETE DIR :", cleanpath)
+                if not dryrun:
+                    rmtree(cleanpath)
+            else:
+                print("DELETE FILE:", cleanpath)
+                if not dryrun:
+                    cleanpath.unlink()

--- a/tasks.py
+++ b/tasks.py
@@ -12,39 +12,12 @@ from subprocess import check_call, CalledProcessError, check_output, DEVNULL
 
 THIS_DIR = Path(__file__).parent
 SOURCE_DIR = THIS_DIR / "src" / "ixdat"
+# Patterns to match for files of directories that should be deleted in the clean task
 CLEAN_PATTERNS = ("__pycache__", "*.pyc", "*.pyo", ".mypy_cache")
 
 
 tox_config = configparser.ConfigParser()
 tox_config.read(THIS_DIR / "tox.ini")
-
-
-def extract_first_command_from_tox_env(environment):
-    """Extract the first command from the list of commands from tox.ini
-    configuration file
-
-    This function is used to extract the command used to run a tool
-    from the tox.ini configuration file. The reason for this is that
-    the QA tools needs to be run both by invoke and by tox. So to
-    prevent the proliferation of settings they are written only in the
-    tox configuration file and read here.
-
-    """
-    commands_string = tox_config[environment]["commands"]
-    # The commands key contain potentially a list of commands
-    # (although there is often only one). In .ini files they look like
-    # this:
-    #
-    # commands =
-    #     command1
-    #     command2
-    #
-    # and so it commonly begins with a newline and the elements are
-    # separated by newline. Hence the parsing below.
-    commands = commands_string.split("\n")
-    if commands[0].strip() == "" and len(commands) > 0:
-        commands = commands[1:]
-    return commands[0]
 
 
 # ### QA tasks
@@ -59,9 +32,8 @@ def flake8(context):
     http://docs.pyinvoke.org/en/stable/api/context.html for details.
 
     """
-    command = extract_first_command_from_tox_env("testenv:flake8")
     print("# flake8")
-    return context.run(command).return_code
+    return context.run("flake8").return_code
 
 
 @task(aliases=["test", "tests"])
@@ -71,9 +43,8 @@ def pytest(context):
     See docstring of :func:`flake8` for explanation of `context` argument
 
     """
-    command = extract_first_command_from_tox_env("testenv")
     print("# pytest")
-    return context.run(command).return_code
+    return context.run("pytest").return_code
 
 
 @task(aliases=["QA", "qa", "check"])

--- a/tasks.py
+++ b/tasks.py
@@ -14,7 +14,7 @@ CLEAN_PATTERNS = ("__pycache__", "*.pyc", "*.pyo", ".mypy_cache")
 
 
 tox_config = configparser.ConfigParser()
-tox_config.read("tox.ini")
+tox_config.read(THIS_DIR / "tox.ini")
 
 
 def extract_first_command_from_tox_env(environment):
@@ -94,7 +94,7 @@ def tox(context):
         else:
             environments_to_run.append(environment)
 
-    context.run("tox -e " + ",".join(environments_to_run))
+    context.run("tox -p auto -e " + ",".join(environments_to_run))
 
 
 # ### Maintenance tasks

--- a/tests/test_dummy.py
+++ b/tests/test_dummy.py
@@ -1,0 +1,6 @@
+
+"""Dummy test file, should be deleted as soon as we have the first real test"""
+
+
+def test_dummy():
+    pass

--- a/tools/hooks/pre-push
+++ b/tools/hooks/pre-push
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+# An example hook script to verify what is about to be pushed.  Called by "git
+# push" after it has checked the remote status, but before anything has been
+# pushed.  If this script exits with a non-zero status nothing will be pushed.
+#
+# This hook is called with the following parameters:
+#
+# $1 -- Name of the remote to which the push is being done
+# $2 -- URL to which the push is being done
+#
+# If pushing without using a named remote those arguments will be equal.
+#
+# Information about the commits which are being pushed is supplied as lines to
+# the standard input in the form:
+#
+#   <local ref> <local sha1> <remote ref> <remote sha1>
+#
+# This script should be copied or better yet sym-linked into .git/hooks/
+
+invoke tox
+exit $?

--- a/tools/hooks/pre-push
+++ b/tools/hooks/pre-push
@@ -18,5 +18,5 @@
 #
 # This script should be copied or better yet sym-linked into .git/hooks/
 
-invoke tox
+invoke tox --single
 exit $?

--- a/tools/hooks/pre-push_windows_git_bash
+++ b/tools/hooks/pre-push_windows_git_bash
@@ -1,0 +1,22 @@
+#!C:/Program\ Files/Git/usr/bin/sh.exe
+
+# An example hook script to verify what is about to be pushed.  Called by "git
+# push" after it has checked the remote status, but before anything has been
+# pushed.  If this script exits with a non-zero status nothing will be pushed.
+#
+# This hook is called with the following parameters:
+#
+# $1 -- Name of the remote to which the push is being done
+# $2 -- URL to which the push is being done
+#
+# If pushing without using a named remote those arguments will be equal.
+#
+# Information about the commits which are being pushed is supplied as lines to
+# the standard input in the form:
+#
+#   <local ref> <local sha1> <remote ref> <remote sha1>
+#
+# This script should be copied or better yet sym-linked into .git/hooks/
+
+invoke tox
+exit $?

--- a/tools/hooks/pre-push_windows_git_bash
+++ b/tools/hooks/pre-push_windows_git_bash
@@ -18,5 +18,5 @@
 #
 # This script should be copied or better yet sym-linked into .git/hooks/
 
-invoke tox
+invoke tox --single
 exit $?

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,8 @@
 # file will run the test suite on all supported python versions. To
 # use it, "pip install tox" and then run "tox" from this directory.
 
+# Keep pypy last in the envlist, so it isn't the first one found in
+# invoke's tox task
 [tox]
 envlist = py36, py37, py38, py39, pypy3, flake8
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,19 @@
+# tox (https://tox.readthedocs.io/) is a tool for running tests
+# in multiple virtualenvs. This configuration file will run the
+# test suite on all supported python versions. To use it, "pip install tox"
+# and then run "tox" from this directory.
+
+[tox]
+envlist = py36, py37, py38, py39, pypy3, flake8
+
+[testenv]
+deps =
+    pytest
+commands =
+    pytest
+
+[testenv:flake8]
+deps =
+    flake8
+commands =
+    flake8

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
-# tox (https://tox.readthedocs.io/) is a tool for running tests
-# in multiple virtualenvs. This configuration file will run the
-# test suite on all supported python versions. To use it, "pip install tox"
-# and then run "tox" from this directory.
+# tox (https://tox.readthedocs.io/) is a tool for running tests in
+# multiple virtualenvs and QA tools in general. This configuration
+# file will run the test suite on all supported python versions. To
+# use it, "pip install tox" and then run "tox" from this directory.
 
 [tox]
 envlist = py36, py37, py38, py39, pypy3, flake8


### PR DESCRIPTION
This PR introduces parts of my standard python development tool chain into ixdat for evaluation. The tools falls into two different categories, "tools" and something which I generally call "tool runners".

Of tools this introduces only `pytest`as a test runner and `flake8` as a linter (takes care of some coding errors and coding style related stuff). flake8 is more or less standard if you want a fast and not too opinionated linter and I have over time come to prefer that over something like pylint. I did not include `black` to the configuration just yet, as I wanted to see if you are happy with it first.

**Tool runners** is likely the more interesting category, because those types of tools may not be too well known for scientists. These are tools to run your tools and perform tasks for you. You may ask, "why would I want a tool to run a tool?". The answer is that it can help you remember worthwhile options and in general make sure that it is run in an consistent manner and that tasks are performed easier and consistently.

As tools runners I have introduced `invoke` (http://www.pyinvoke.org/). The purpose of invoke is to easily make it possible and easy to do all the things/perform all the tasks, you need during development. Whenever you need to do something, you should check if invoke has a task for it and ask it to do it. If you perform a task that invoke hasn't been configured for and you do it more than twice, you should probably just go ahead and define an invoke task for it. In the olden days Unix developers would often use something like makefiles for this (https://en.wikipedia.org/wiki/Makefile), but they don't work on Windows which is the reason something like sphinx has both a makefile and a make bat file to compile the docs. Invoke aims to bridge that gap by providing as much of a platform independent command execution environment available as possible and by making its configuration file a pure python file, which means that you can yourself program your way around the whatever platform difference issues you may run into.

During development invoke commands to commonly use could be something like:

```bash
invoke lint
```
to run the linter

```bash
invoke tests
```
to run the tests

```bash
invoke checks
```
to run all the standard code checks (lint and test for now)

```bash
invoke clean
```
to delete all the temporary and cache files

```bash
invoke build-docs
```
to build the docs (not yet implemented)

to see a list of all available tasks do:
```bash
invoke --list
```

The second tool runner is `tox` (https://tox.readthedocs.io/en/latest/). tox is a tool to run all your QA tools in as consistent a manner as possible across as many of the supported python version as possible. It runs the QA tools in a virtual environment on a freshly installed version of your code. Because tox is meant mainly for continuous integration environments, it will try and perform all the tests on all the supported python versions. If they are unavailable, it will report an error, for this purpose I have configured an invoke task to run tox only on the python version that are available.

To run tox purely do:
```bash
tox
```

to run in parallel do:
```bash
tox -p auto
```

To run tox only on available python versions do
```bash
invoke tox
```

I tried to gather all the information that developers will needs about the tools in the TOOLS.rst file. Please give that a look.

NOTE: This is WIP since I know it has a directory conflict with #2, which I will resolve here when #2 is merged.

EDIT: I completely forgot to mention that the PR also includes a git hook, which is a mechanism to run tests and checks before pushing commits to a remote branch. Please see the details of it and installation instructions in TOOLS.rst.