### PR TITLE
Minor improvements after DWS3 and first #6 rev.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,6 @@
 numpy>=1.16
 matplotlib>=3.2
+EC_MS>=0.7.4  # Temporary! For Zilien reading.
+scipy>=1.5  # for deconvolution (should be plugin?)
+mpmath>=1  # for deconvolution (should be plugin?
+

--- a/src/ixdat/exporters/csv_exporter.py
+++ b/src/ixdat/exporters/csv_exporter.py
@@ -41,7 +41,7 @@ class CSVExporter:
             path_to_file = path_to_file.with_suffix(".csv")
         for v_name in v_list:
             t_name = measurement[v_name].tseries.name
-            t, v = measurement.get_t_and_v(v_name, tspan=tspan)
+            t, v = measurement.grab(v_name, tspan=tspan)
             if t_name not in columns_data:
                 columns_data[t_name] = t
                 s_list.append(t_name)

--- a/src/ixdat/measurements.py
+++ b/src/ixdat/measurements.py
@@ -146,7 +146,7 @@ class Measurement(Saveable):
             from .readers import READER_CLASSES
 
             reader = READER_CLASSES[reader]()
-        return reader.read(path_to_file, **kwargs)
+        return reader.read(path_to_file, **kwargs)  # TODO: take cls as kwarg
 
     @property
     def metadata_json_string(self):
@@ -394,6 +394,9 @@ class Measurement(Saveable):
         The method finds all time intervals for which `self[series_name] == value`
         It then cuts the measurement according to each time interval and adds these
         segments together. TODO: This can be done better, i.e. without chopping series.
+
+        TODO: greater-than and less-than kwargs.
+            Ideally you should be able to say e.g., `select(cycle=1, 0.5<potential<1)`
         """
         if len(args) >= 1:
             if not self.sel_str:

--- a/src/ixdat/measurements.py
+++ b/src/ixdat/measurements.py
@@ -128,8 +128,16 @@ class Measurement(Saveable):
                 del obj_as_dict[object_name_str]
 
         if obj_as_dict["technique"] in TECHNIQUE_CLASSES:
+            # This makes it so that from_dict() can be used to initiate for any more
+            # derived technique, so long as obj_as_dict specifies the technique name!
             technique_class = TECHNIQUE_CLASSES[obj_as_dict["technique"]]
+            if not issubclass(technique_class, cls):
+                # But we never want obj_as_dict["technique"] to take us to a *less*
+                # specific technique, if the user has been intentional about which
+                # class they call `as_dict` from (e.g. via a Reader)!
+                technique_class = cls
         else:
+            # Normally, we're going to want to make sure that we're in
             technique_class = cls
         try:
             measurement = technique_class(**obj_as_dict)
@@ -146,7 +154,8 @@ class Measurement(Saveable):
             from .readers import READER_CLASSES
 
             reader = READER_CLASSES[reader]()
-        return reader.read(path_to_file, **kwargs)  # TODO: take cls as kwarg
+        # print(f"{__name__}. cls={cls}")  # debugging
+        return reader.read(path_to_file, cls=cls, **kwargs)
 
     @property
     def metadata_json_string(self):

--- a/src/ixdat/measurements.py
+++ b/src/ixdat/measurements.py
@@ -279,7 +279,7 @@ class Measurement(Saveable):
                 new_series_list.append(s)
         self._series_list = new_series_list
 
-    def get_t_and_v(self, item, tspan=None):
+    def grab(self, item, tspan=None):
         """Return the time and value vectors for a given VSeries name cut by tspan"""
         vseries = self[item]
         tseries = vseries.tseries
@@ -422,7 +422,7 @@ class Measurement(Saveable):
         new_measurement = self
         ((series_name, value),) = kwargs.items()
 
-        t, v = self.get_t_and_v(series_name)
+        t, v = self.grab(series_name)
         mask = v == value  # linter doesn't realize this is a np array
         mask_prev = np.append(False, mask[:-1])
         mask_next = np.append(mask[1:], False)

--- a/src/ixdat/plotters/ec_plotter.py
+++ b/src/ixdat/plotters/ec_plotter.py
@@ -57,8 +57,8 @@ class ECPlotter:
         J_str = J_str or (
             measurement.J_str if measurement.A_el is not None else measurement.I_str
         )
-        t_v, v = measurement.get_t_and_v(V_str, tspan=tspan)
-        t_j, j = measurement.get_t_and_v(J_str, tspan=tspan)
+        t_v, v = measurement.grab(V_str, tspan=tspan)
+        t_j, j = measurement.grab(J_str, tspan=tspan)
         if axes:
             ax1, ax2 = axes
         else:
@@ -111,8 +111,8 @@ class ECPlotter:
         J_str = J_str or (
             measurement.J_str if measurement.A_el is not None else measurement.I_str
         )
-        t_v, v = measurement.get_t_and_v(V_str, tspan=tspan)
-        t_j, j = measurement.get_t_and_v(J_str, tspan=tspan)
+        t_v, v = measurement.grab(V_str, tspan=tspan)
+        t_j, j = measurement.grab(J_str, tspan=tspan)
 
         j_v = np.interp(t_v, t_j, j)
         if not ax:

--- a/src/ixdat/plotters/value_plotter.py
+++ b/src/ixdat/plotters/value_plotter.py
@@ -33,7 +33,7 @@ class ValuePlotter:
 
         for v_name in v_list:
             try:
-                v, t = measurement.get_t_and_v(v_name, tspan=tspan)
+                v, t = measurement.grab(v_name, tspan=tspan)
             except SeriesNotFoundError as e:
                 print(f"WARNING!!! {e}")
                 continue

--- a/src/ixdat/readers/biologic.py
+++ b/src/ixdat/readers/biologic.py
@@ -75,7 +75,7 @@ class BiologicMPTReader:
         self.file_has_been_read = False
         self.measurement = None
 
-    def read(self, path_to_file, name=None, **kwargs):
+    def read(self, path_to_file, name=None, cls=None, **kwargs):
         """Return an ECMeasurement with the data and metadata recorded in path_to_file
 
         This loops through the lines of the file, processing one at a time. For header
@@ -100,6 +100,7 @@ class BiologicMPTReader:
             )
             return self.measurement
         self.name = name or path_to_file.name
+        self.measurement_class = cls or ECMeasurement
         self.path_to_file = path_to_file
         with open(path_to_file) as f:
             for line in f:
@@ -130,7 +131,7 @@ class BiologicMPTReader:
             )
             data_series_list.append(vseries)
 
-        init_kwargs = dict(
+        obj_as_dict = dict(
             name=self.name,
             technique="EC",
             reader=self,
@@ -138,9 +139,9 @@ class BiologicMPTReader:
             tstamp=self.tstamp,
             ec_technique=self.ec_technique,
         )
-        init_kwargs.update(kwargs)
+        obj_as_dict.update(kwargs)
 
-        self.measurement = ECMeasurement(**init_kwargs)  # cls.from_dict(**init_kwargs)
+        self.measurement = self.measurement_class.from_dict(obj_as_dict)
         self.file_has_been_read = True
 
         return self.measurement

--- a/src/ixdat/readers/biologic.py
+++ b/src/ixdat/readers/biologic.py
@@ -277,10 +277,10 @@ if __name__ == "__main__":
         path_to_file=path_to_test_file,
     )
 
-    t, v = ec_measurement.get_potential(tspan=[0, 100])
+    t, v = ec_measurement.grab_potential(tspan=[0, 100])
 
     ec_measurement.tstamp -= 20
-    t_shift, v_shift = ec_measurement.get_potential(tspan=[0, 100])
+    t_shift, v_shift = ec_measurement.grab_potential(tspan=[0, 100])
 
     fig, ax = plt.subplots()
     ax.plot(t, v, "k", label="original tstamp")

--- a/src/ixdat/readers/biologic.py
+++ b/src/ixdat/readers/biologic.py
@@ -140,7 +140,7 @@ class BiologicMPTReader:
         )
         init_kwargs.update(kwargs)
 
-        self.measurement = ECMeasurement(**init_kwargs)
+        self.measurement = ECMeasurement(**init_kwargs)  # cls.from_dict(**init_kwargs)
         self.file_has_been_read = True
 
         return self.measurement

--- a/src/ixdat/readers/ec_ms_pkl.py
+++ b/src/ixdat/readers/ec_ms_pkl.py
@@ -2,7 +2,6 @@ from . import TECHNIQUE_CLASSES
 import pickle
 from ..data_series import TimeSeries, ValueSeries
 from ..measurements import Measurement
-from ..techniques.ec_ms import ECMSMeasurement
 
 
 ECMSMeasruement = TECHNIQUE_CLASSES["EC-MS"]

--- a/src/ixdat/readers/ec_ms_pkl.py
+++ b/src/ixdat/readers/ec_ms_pkl.py
@@ -14,7 +14,7 @@ class EC_MS_CONVERTER:
     def __init__(self):
         print("Reader of old ECMS .pkl files")
 
-    def read(self, file_path):
+    def read(self, file_path, cls=None):
         """Return an ECMSMeasurement with the data recorded in path_to_file
         # TODO: Always returns ECMS class even when read with DecoMeasurement.read()
         This loops through the keys of the EC-MS dict and searches for MS and
@@ -56,12 +56,15 @@ class EC_MS_CONVERTER:
                     ValueSeries(col, "A", data[col], tseries=measurement["time/s"])
                 )
 
-        measurement = ECMSMeasurement(
-            file_path,
+        obj_as_dict = dict(
+            name=file_path,
             technique="EC_MS",
             series_list=cols_list,
             reader=self,
             tstamp=data["tstamp"],
         )
+        # print(f"{__name__}. cls={cls}")  # debugging
+
+        measurement = cls.from_dict(obj_as_dict)
 
         return measurement

--- a/src/ixdat/techniques/__init__.py
+++ b/src/ixdat/techniques/__init__.py
@@ -13,6 +13,8 @@ from .ms import MSMeasurement
 from .ec_ms import ECMSMeasurement
 from ..measurements import Measurement  # for importing in the technique modules
 
+# TODO: Is something like DecoMeasurement a Measurement or something else?
+
 TECHNIQUE_CLASSES = {
     "simple": Measurement,
     "EC": ECMeasurement,

--- a/src/ixdat/techniques/deconvolution.py
+++ b/src/ixdat/techniques/deconvolution.py
@@ -20,7 +20,7 @@ class DecoMeasurement(ECMSMeasurement):
             name (str): The name of the measurement"""
         super().__init__(name, **kwargs)
 
-    def get_partial_current(
+    def grab_partial_current(
         self, signal_name, kernel_obj, tspan=None, t_bg=None, snr=10
     ):
         """Return the deconvoluted partial current for a given signal
@@ -35,7 +35,7 @@ class DecoMeasurement(ECMSMeasurement):
             snr (int): signal-to-noise ratio used for Wiener deconvolution.
         """
 
-        t_sig, v_sig = self.get_calib_signal(signal_name, tspan=tspan, t_bg=t_bg)
+        t_sig, v_sig = self.grab_cal_signal(signal_name, tspan=tspan, t_bg=t_bg)
 
         kernel = kernel_obj.calculate_kernel(dt=t_sig[1] - t_sig[0])
         kernel = np.hstack((kernel, np.zeros(len(v_sig) - len(kernel))))
@@ -60,9 +60,9 @@ class DecoMeasurement(ECMSMeasurement):
                 extracted.
             t_bg (list): Timespan that corresponds to the background signal.
         """
-        x_curr, y_curr = self.get_current(tspan=tspan)
-        x_pot, y_pot = self.get_potential(tspan=tspan)
-        x_sig, y_sig = self.get_signal(signal_name, tspan=tspan, t_bg=t_bg)
+        x_curr, y_curr = self.grab_current(tspan=tspan)
+        x_pot, y_pot = self.grab_potential(tspan=tspan)
+        x_sig, y_sig = self.grab_signal(signal_name, tspan=tspan, t_bg=t_bg)
 
         if signal_name == "M32":
             t0 = x_curr[np.argmax(y_pot > cutoff_pot)]  # time of impulse

--- a/src/ixdat/techniques/deconvolution.py
+++ b/src/ixdat/techniques/deconvolution.py
@@ -1,12 +1,12 @@
 """Module for deconvolution of mass transport effects."""
 
 from .ec_ms import ECMSMeasurement
-from scipy.optimize import curve_fit
-from scipy.interpolate import interp1d
-from scipy import signal
-from mpmath import invertlaplace, sinh, cosh, sqrt, exp, erfc, pi, tanh, coth
+from scipy.optimize import curve_fit  # noqa
+from scipy.interpolate import interp1d  # noqa
+from scipy import signal  # noqa
+from mpmath import invertlaplace, sinh, cosh, sqrt, exp, erfc, pi, tanh, coth  # noqa
 import matplotlib.pyplot as plt
-from numpy.fft import fft, ifft, ifftshift, fftfreq
+from numpy.fft import fft, ifft, ifftshift, fftfreq  # noqa
 import numpy as np
 
 
@@ -161,7 +161,7 @@ class Kernel:
             fig1 = plt.figure()
             ax = fig1.add_subplot(111)
 
-        if self.type is "functional":
+        if self.type == "functional":
             t_kernel = np.arange(0, duration, dt)
             ax.plot(
                 t_kernel,
@@ -169,7 +169,7 @@ class Kernel:
                 **kwargs,
             )
 
-        elif self.type is "measured":
+        elif self.type == "measured":
             ax.plot(
                 self.MS_data[0],
                 self.calculate_kernel(dt=dt, duration=duration, norm=norm),
@@ -194,7 +194,7 @@ class Kernel:
             matrix (bool): If true the circulant matrix constructed from the kernel/
                 impulse reponse is returned.
         """
-        if self.type is "functional":
+        if self.type == "functional":
 
             t_kernel = np.arange(0, duration, dt)
             t_kernel[0] = 1e-6
@@ -206,18 +206,20 @@ class Kernel:
             henry_vola = self.params["henry_vola"]
 
             tdiff = t_kernel * diff_const / (work_dist ** 2)
-            fs = lambda s: 1 / (
-                sqrt(s) * sinh(sqrt(s))
-                + (vol_gas * henry_vola / 0.196e-4 / work_dist)
-                * (s + volflow_cap / vol_gas * work_dist ** 2 / diff_const)
-                * cosh(sqrt(s))
-            )
+
+            def fs(s):
+                return 1 / (
+                    sqrt(s) * sinh(sqrt(s))
+                    + (vol_gas * henry_vola / 0.196e-4 / work_dist)
+                    * (s + volflow_cap / vol_gas * work_dist ** 2 / diff_const)
+                    * cosh(sqrt(s))
+                )
 
             kernel = np.zeros(len(t_kernel))
             for i in range(len(t_kernel)):
                 kernel[i] = invertlaplace(fs, tdiff[i], method="talbot")
 
-        elif self.type is "measured":
+        elif self.type == "measured":
             kernel = self.MS_data[1]
             t_kernel = self.MS_data[0]
 

--- a/src/ixdat/techniques/ec.py
+++ b/src/ixdat/techniques/ec.py
@@ -457,29 +457,19 @@ class ECMeasurement(Measurement):
                 tseries=raw_current.tseries,
             )
 
-    def get_potential(self, tspan=None):
-        """Return the time [s] and potential [V] vectors cut by tspan
+    def grab_potential(self, tspan=None, cal=True):
+        """Return t and potential (if cal else raw_potential) [V] vectors cut by tspan"""
+        if cal:
+            return self.grab("potential", tspan=tspan)
+        else:
+            return self.grab("raw_potential", tspan=tspan)
 
-        TODO: I think this is identical, now that __getitem__ finds potential, to
-            self.get_t_and_v("potential", tspan=tspan)
-        """
-        t = self.potential.t.copy()
-        v = self.potential.data.copy()
-        if tspan:
-            mask = np.logical_and(tspan[0] < t, t < tspan[-1])
-            t = t[mask]
-            v = v[mask]
-        return t, v
-
-    def get_current(self, tspan=None):
-        """Return the time [s] and current ([mA] or [mA/cm^2]) vectors cut by tspan"""
-        t = self.current.t.copy()
-        j = self.current.data.copy()
-        if tspan:
-            mask = np.logical_and(tspan[0] < t, t < tspan[-1])
-            t = t[mask]
-            j = j[mask]
-        return t, j
+    def grab_current(self, tspan=None, norm=True):
+        """Return t [s] and current (if cal else raw_current) [V] vectors cut by tspan"""
+        if norm:
+            return self.grab("current", tspan=tspan)
+        else:
+            return self.grab("raw_current", tspan=tspan)
 
     @property
     def t(self):

--- a/src/ixdat/techniques/ms.py
+++ b/src/ixdat/techniques/ms.py
@@ -17,7 +17,7 @@ class MSMeasurement(Measurement):
         super().__init__(name, **kwargs)
         self.calibration = None  # TODO: Not final implementation
 
-    def get_signal(self, signal_name, tspan=None, t_bg=None):
+    def grab_signal(self, signal_name, tspan=None, t_bg=None):
         """Returns raw signal for a given signal name
 
         Args:
@@ -26,16 +26,16 @@ class MSMeasurement(Measurement):
             t_bg (list): Timespan that corresponds to the background signal.
                 If not given, no background is subtracted.
         """
-        time, value = self.get_t_and_v(signal_name, tspan=tspan)
+        time, value = self.grab(signal_name, tspan=tspan)
 
         if t_bg is None:
             return time, value
 
         else:
-            _, bg = self.get_t_and_v(signal_name, tspan=t_bg)
+            _, bg = self.grab(signal_name, tspan=t_bg)
             return time, value - np.average(bg)
 
-    def get_calib_signal(self, signal_name, tspan=None, t_bg=None):
+    def grab_cal_signal(self, signal_name, tspan=None, t_bg=None):
         """Returns a calibrated signal for a given signal name. Only works if
         calibration dict is not None.
 
@@ -50,6 +50,6 @@ class MSMeasurement(Measurement):
             print("No calibration dict found.")
             return
 
-        time, value = self.get_signal(signal_name, tspan=tspan, t_bg=t_bg)
+        time, value = self.grab_signal(signal_name, tspan=tspan, t_bg=t_bg)
 
         return time, value * self.calibration[signal_name]


### PR DESCRIPTION
Hi @kkrempl ,
Here are some updates for your [deconvolution] branch following our design workshop (DSW3), your initial comments on #6, and running all the scripts in the [Krempl2021](https://github.com/kkrempl/Dynamic-Interfacial-Reaction-Rates) repository.
The changes included just deal with small interface changes and debugging of ixdat core, not with redoing anything in the deconvolution implementation. Notably:
- The super cool but too funky `measurement.__class__ = DecoMeasurement` is no longer needed. A `TechniqueMeasurement.read()` now returns an object of class `TechniqueMeasurement` - or an inheriting class if the reader specifies it.
- `get_xxx` methods are renamed to `grab_xxx` to avoid the normal convention with "get" (see, e.g., [here](https://www.python-course.eu/python3_properties.php)). This change excludes the deconvolution module (though I think ultimately `get_xxx` methods in that module should also be renamed to e.g. `calc_xxx`)

I also made some small style edits so that it could pass flake8 and thus get through Kenneth's pre-push hook. The Krempl2021 repository runs with these changes, given some minor changes of its own which I will PR to you there momentarily.
