### PR TITLE
Additions for smoother EC-MS functionality

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -102,15 +102,21 @@ Article repositories
 ``ixdat`` is shown in practice in a growing number of open repositories of data and analysis
 for academic publications:
 
-- Tracking oxygen atoms in electrochemical CO oxidation - Part II: Lattice oxygen reactivity in oxides of Pt and Ir
+- Soren B. Scott, et al.  **Tracking oxygen atoms in electrochemical CO oxidation –Part I: Oxygen exchange via CO2 hydration**. `Electrochimica Acta, 374, 137842 <https://doi.org/10.1016/j.electacta.2021.137842>`_, **2021**.
 
-  - Article: https://doi.org/10.1016/j.electacta.2021.137844
-  - Repository: https://github.com/ScottSoren/pyCOox_public
+  Repository: https://github.com/ScottSoren/pyCOox_public
 
-- Dynamic Interfacial Reaction Rates from Electrochemistry - Mass Spectrometry
+- Soren B. Scott, et al.  **Tracking oxygen atoms in electrochemical CO oxidation –Part II: Lattice oxygen reactivity in oxides of Pt and Ir**. `Electrochimica Acta, 374, 137844 <https://doi.org/10.1016/j.electacta.2021.137844>`_, **2021**.
 
-  - Article: https://doi.org/10.1021/acs.analchem.1c00110
-  - Repository: https://github.com/kkrempl/Dynamic-Interfacial-Reaction-Rates
+  Repository: https://github.com/ScottSoren/pyCOox_public
+
+- Kevin Krempl, et al. **Dynamic Interfacial Reaction Rates from Electrochemistry - Mass Spectrometry**. `Journal of Analytical Chemistry. 93, 7022-7028 <https://doi.org/10.1021/acs.analchem.1c00110>`_, **2021**
+
+  Repository: https://github.com/kkrempl/Dynamic-Interfacial-Reaction-Rates
+
+- Junheng Huang, et al. **Online Electrochemistry−Mass Spectrometry Evaluation of the Acidic Oxygen Evolution Reaction at Supported Catalysts**. `ACS Catal. 11, 12745-12753 <https://doi.org/10.1021/acscatal.1c03430>`_, **2021**
+
+  Repository: https://github.com/ScottSoren/Huang2021
 
 
 Join us

--- a/development_scripts/reader_testers/test_zilien_reader.py
+++ b/development_scripts/reader_testers/test_zilien_reader.py
@@ -1,18 +1,24 @@
-from ixdat.techniques import ECMeasurement
+from pathlib import Path
 
-path_to_file = (
-    "../test_data/biologic_mpt_and_zilien_tsv/"
-    "2020-07-29 10_30_39 Pt_poly_cv_01_02_CVA_C01.mpt"
+from ixdat import Measurement
+from ixdat.techniques import MSMeasurement
+
+data_dir = Path(r"C:\Users\scott\Dropbox\ixdat_resources\test_data\zilien_with_ec")
+
+path_to_file = data_dir / "2021-02-01 17_44_12.tsv"
+
+# This imports it with the EC data
+ecms = Measurement.read(path_to_file, reader="zilien")
+ecms.plot_measurement()
+
+# This imports it without the EC data:
+ms = MSMeasurement.read(path_to_file, reader="zilien")
+ms.plot_measurement()  # nice. one panel, no MS :)
+
+# This adds in the EC data from Biologic:
+
+ec = Measurement.read_set(
+    data_dir / "2021-02-01 17_44_12", reader="biologic", suffix=".mpt"
 )
-
-m = ECMeasurement.read(path_to_file, reader="biologic", name="ec_tools_test",)
-
-# ax = m.plot()
-
-m.save()
-i = m.id
-del m
-
-m1 = ECMeasurement.get(i)
-
-m1.plot()
+ecms_2 = ec + ms
+ecms_2.plot_measurement()

--- a/docs/source/technique_docs/ec_ms.rst
+++ b/docs/source/technique_docs/ec_ms.rst
@@ -8,9 +8,8 @@ The main class for EC-MS data is the ECMSMeasurement.
 It comes with the :ref:`EC-MS plotter <ecms-plotter>` which makes EC-MS plots like this one:
 
 .. figure:: ../figures/ec_ms_annotated.svg
-    :width: 600
-
-    ``ECMSMeasurement.plot_measurement()``. Data from Trimarco, 2018.
+   :width: 600
+   ``ECMSMeasurement.plot_measurement()``. Data from Trimarco, 2018.
 
 Other than that it doesn't have much but inherits from both ``ECMeasurement`` and ``MSMeasurement``.
 An ``ECMSMeasurement`` can be created either by adding an ``ECMeasurement`` and an ``MSMeasurement``
@@ -21,28 +20,40 @@ such as "zilien".
 based on an electrochemical cyclic voltammatry program that are implemented in ``CyclicVoltammogram``
 (see :ref:`cyclic_voltammetry`).
 
-Deconvolution, described in a publication under review, is implemented in the deconvolution module,
-in a class inheriting from ``ECMSMeasurement``.
+.. Deconvolution, described in a `recent publication <https://doi.org/10.1021/acs.analchem.1c00110>`_,
+is implemented in the deconvolution module, in a class inheriting from ``ECMSMeasurement``.
 
-``ixdat`` will soon have all the functionality and more for EC-MS data and analysis as the
+``ixdat`` has all the functionality and more for EC-MS data and analysis as the
 legacy `EC_MS <https://github.com/ScottSoren/EC_MS>`_ package. This includes the tools
 behind the EC-MS analysis and visualization in the puplications:
 
-- Daniel B. Trimarco and Soren B. Scott, et al. **Enabling real-time detection of electrochemical desorption phenomena with sub-monolayer sensitivity**. `Electrochimica Acta, 2018 <https://doi.org/10.1016/j.electacta.2018.02.060>`_.
+- Daniel B. Trimarco and Soren B. Scott, et al. **Enabling real-time detection of electrochemical desorption phenomena with sub-monolayer sensitivity**. `Electrochimica Acta, 268, 520-530  <https://doi.org/10.1016/j.electacta.2018.02.060>`_, **2018**
 
-- Claudie Roy, Bela Sebok, Soren B. Scott, et al.  **Impact of nanoparticle size and lattice oxygen on water oxidation on NiFeOxHy**. `Nature Catalysis, 2018 <https://doi.org/10.1038/s41929-018-0162-x>`_.
+- Claudie Roy, Bela Sebok, Soren B. Scott, et al.  **Impact of nanoparticle size and lattice oxygen on water oxidation on NiFeOxHy**. `Nature Catalysis, 1(11), 820-829  <https://doi.org/10.1038/s41929-018-0162-x>`_, **2018**
 
-- Anna Winiwarter and Luca Silvioli, et al. **Towards an Atomistic Understanding of Electrocatalytic Partial Hydrocarbon Oxidation: Propene on Palladium**. `Energy and Environmental Science, 2019 <https://doi.org/10.1039/C8EE03426E>`_.
+- Anna Winiwarter and Luca Silvioli, et al. **Towards an Atomistic Understanding of Electrocatalytic Partial Hydrocarbon Oxidation: Propene on Palladium**. `Energy and Environmental Science, 12, 1055-1067 <https://doi.org/10.1039/C8EE03426E>`_, **2019**
 
-- Soren B. Scott and Albert Engstfeld, et al.  **Anodic molecular hydrogen formation on Ru and Cu electrodes**. `Catalysis Science & Technology, 2020 <https://doi.org/10.1039/d0cy01213k>`_.
+- Soren B. Scott and Albert Engstfeld, et al.  **Anodic molecular hydrogen formation on Ru and Cu electrodes**. `Catalysis Science and Technology, 10, 6870-6878 <https://doi.org/10.1039/d0cy01213k>`_, **2020**
 
-- Anna Winiwarter, et al.  **CO as a Probe Molecule to Study Surface Adsorbates during Electrochemical Oxidation of Propene**. `ChemElectroChem, 2021 <https://doi.org/10.1002/celc.202001162>`_.
+- Anna Winiwarter, et al.  **CO as a Probe Molecule to Study Surface Adsorbates during Electrochemical Oxidation of Propene**. `ChemElectroChem, 8, 250-256 <https://doi.org/10.1002/celc.202001162>`_, **2021**
 
-``ixdat`` is used for the following articles:
+``ixdat`` is used for the following EC-MS articles:
 
-- Soren B. Scott, et al.  **Tracking oxygen atoms in electrochemical CO oxidation –Part I: Oxygen exchange via CO2 hydration**. `Electrochimica Acta, 2021a <https://doi.org/10.1016/j.electacta.2021.137842>`_.
+- Soren B. Scott, et al.  **Tracking oxygen atoms in electrochemical CO oxidation –Part I: Oxygen exchange via CO2 hydration**. `Electrochimica Acta, 374, 137842 <https://doi.org/10.1016/j.electacta.2021.137842>`_, **2021**.
 
-- Soren B. Scott, et al.  **Tracking oxygen atoms in electrochemical CO oxidation –Part II: Lattice oxygen reactivity in oxides of Pt and Ir**. `Electrochimica Acta, 2021b <https://doi.org/10.1016/j.electacta.2021.137844>`_.
+  Repository: https://github.com/ScottSoren/pyCOox_public
+
+- Soren B. Scott, et al.  **Tracking oxygen atoms in electrochemical CO oxidation –Part II: Lattice oxygen reactivity in oxides of Pt and Ir**. `Electrochimica Acta, 374, 137844 <https://doi.org/10.1016/j.electacta.2021.137844>`_, **2021**.
+
+  Repository: https://github.com/ScottSoren/pyCOox_public
+
+- Kevin Krempl, et al. **Dynamic Interfacial Reaction Rates from Electrochemistry - Mass Spectrometry**. `Journal of Analytical Chemistry. 93, 7022-7028 <https://doi.org/10.1021/acs.analchem.1c00110>`_, **2021**
+
+  Repository: https://github.com/kkrempl/Dynamic-Interfacial-Reaction-Rates
+
+- Junheng Huang, et al. **Online Electrochemistry−Mass Spectrometry Evaluation of the Acidic Oxygen Evolution Reaction at Supported Catalysts**. `ACS Catal. 11, 12745-12753 <https://doi.org/10.1021/acscatal.1c03430>`_, **2021**
+
+  Repository: https://github.com/ScottSoren/Huang2021
 
 
 The ``ec_ms`` module

--- a/docs/source/tutorials.rst
+++ b/docs/source/tutorials.rst
@@ -61,11 +61,18 @@ Article repositories
 
 Calibrating EC-MS data
 **********************
-See these two examples, respectively, for making and using an ixdat EC-MS calibration:
+See these two examples, respectively, for making and using an ixdat EC-MS calibration (here with isotope-labeled data):
 
 - https://github.com/ScottSoren/pyCOox_public/blob/main/paper_I_fig_S1/paper_I_fig_S1.py
 
 - https://github.com/ScottSoren/pyCOox_public/blob/main/paper_I_fig_2/paper_I_fig_2.py
+
+EC-MS data analysis
+*******************
+
+This article has examples of analyzing and manually plotting data imported by ixdat
+
+https://github.com/ScottSoren/Huang2021
 
 
 Development scripts

--- a/src/ixdat/__init__.py
+++ b/src/ixdat/__init__.py
@@ -1,6 +1,6 @@
 """initialize ixdat, giving top-level access to a few of the important structures
 """
-__version__ = "0.1.5"
+__version__ = "0.1.6"
 __title__ = "ixdat"
 __description__ = "The in-situ experimental data tool"
 __url__ = "https://github.com/ixdat/ixdat"

--- a/src/ixdat/exporters/ecms_exporter.py
+++ b/src/ixdat/exporters/ecms_exporter.py
@@ -14,3 +14,24 @@ class ECMSExporter(CSVExporter):
         )
 
         return v_list
+
+    def export(
+            self,
+            path_to_file=None,
+            measurement=None,
+            v_list=None,
+            tspan=None,
+            mass_list=None,
+            mol_list=None,
+    ):
+        if not v_list:
+            if mass_list:
+                v_list = ECExporter(measurement=self.measurement).default_v_list
+            else:
+                v_list = self.default_v_list
+        if mass_list:
+            v_list += mass_list
+        if mol_list:
+            v_list += [f"n_dot_{mol}" for mol in mol_list]
+        return super().export(path_to_file, measurement, v_list, tspan)
+

--- a/src/ixdat/measurements.py
+++ b/src/ixdat/measurements.py
@@ -456,11 +456,11 @@ class Measurement(Saveable):
             name=value_name,
             unit_name=old_vseries.unit_name,
             data=new_data,
-            tseries=old_vseries.tseries
+            tseries=old_vseries.tseries,
         )
         self[value_name] = new_vseries
 
-    def grab(self, item, tspan=None, include_endpoints=False):
+    def grab(self, item, tspan=None, include_endpoints=False, tspan_bg=None):
         """Return a value vector with the corresponding time vector
 
         Grab is the *canonical* way to retrieve numerical time-dependent data from a
@@ -482,6 +482,9 @@ class Measurement(Saveable):
             include_endpoints (bool): Whether to add a points at t = tspan[0] and
                 t = tspan[-1] to the data returned. This makes trapezoidal integration
                 less dependent on the time resolution. Default is False.
+            tspan_bg (iterable): Optional. A timespan defining when `item` is at its
+                baseline level. The average value of `item` in this interval will be
+                subtracted from the values returned.
         """
         vseries = self[item]
         tseries = vseries.tseries
@@ -499,15 +502,29 @@ class Measurement(Saveable):
                     v = np.append(v, v_end)
             mask = np.logical_and(tspan[0] <= t, t <= tspan[-1])
             t, v = t[mask], v[mask]
+        if tspan_bg:
+            t_bg, v_bg = self.grab(item, tspan=tspan_bg)
+            v = v - np.mean(v_bg)
         return t, v
 
-    def grab_for_t(self, item, t):
-        """Return a numpy array with the value of item interpolated to time t"""
+    def grab_for_t(self, item, t, tspan_bg=None):
+        """Return a numpy array with the value of item interpolated to time t
+
+        Args:
+            item (str): The name of the value to grab
+            t (np array): The time vector to grab the value for
+            tspan_bg (iterable): Optional. A timespan defining when `item` is at its
+                baseline level. The average value of `item` in this interval will be
+                subtracted from what is returned.
+        """
         vseries = self[item]
         tseries = vseries.tseries
         v_0 = vseries.data
         t_0 = tseries.data + tseries.tstamp - self.tstamp
         v = np.interp(t, t_0, v_0)
+        if tspan_bg:
+            t_bg, v_bg = self.grab(item, tspan=tspan_bg)
+            v = v - np.mean(v_bg)
         return v
 
     def integrate(self, item, tspan=None, ax=None):

--- a/src/ixdat/measurements.py
+++ b/src/ixdat/measurements.py
@@ -449,6 +449,17 @@ class Measurement(Saveable):
                 new_series_list.append(s)
         self._series_list = new_series_list
 
+    def correct_data(self, value_name, new_data):
+        """Replace the old data for ´value_name´ (str) with ´new_data` (np array)"""
+        old_vseries = self[value_name]
+        new_vseries = ValueSeries(
+            name=value_name,
+            unit_name=old_vseries.unit_name,
+            data=new_data,
+            tseries=old_vseries.tseries
+        )
+        self[value_name] = new_vseries
+
     def grab(self, item, tspan=None, include_endpoints=False):
         """Return a value vector with the corresponding time vector
 

--- a/src/ixdat/plotters/ecms_plotter.py
+++ b/src/ixdat/plotters/ecms_plotter.py
@@ -201,7 +201,7 @@ class ECMSPlotter(MPLPlotter):
 
         if not axes:
             axes = self.new_two_panel_axes(
-                n_bottom=2,
+                n_bottom=1,
                 n_top=(2 if (mass_lists or mol_lists) else 1),
                 emphasis=emphasis,
             )

--- a/src/ixdat/plotters/ms_plotter.py
+++ b/src/ixdat/plotters/ms_plotter.py
@@ -85,10 +85,16 @@ class MSPlotter(MPLPlotter):
         tspan_bg = specs_this_axis["tspan_bg"]
         unit = specs_this_axis["unit"]
         unit_factor = specs_this_axis["unit_factor"]
-        for v_name in v_list:
+        for v_or_v_name in v_list:
+            if isinstance(v_or_v_name, str):
+                v_name = v_or_v_name
+                color = STANDARD_COLORS.get(v_name, "k")
+            else:
+                v_name = v_or_v_name.name
+                color = v_or_v_name.color
             if quantified:
                 t, v = measurement.grab_flux(
-                    v_name,
+                    v_or_v_name,
                     tspan=tspan,
                     tspan_bg=tspan_bg,
                     removebackground=removebackground,
@@ -96,7 +102,7 @@ class MSPlotter(MPLPlotter):
                 )
             else:
                 t, v = measurement.grab_signal(
-                    v_name,
+                    v_or_v_name,
                     tspan=tspan,
                     t_bg=tspan_bg,
                     removebackground=removebackground,
@@ -107,7 +113,7 @@ class MSPlotter(MPLPlotter):
             ax.plot(
                 t,
                 v * unit_factor,
-                color=STANDARD_COLORS.get(v_name, "k"),
+                color=color,
                 label=v_name,
                 **kwargs,
             )

--- a/src/ixdat/plotters/value_plotter.py
+++ b/src/ixdat/plotters/value_plotter.py
@@ -15,7 +15,13 @@ class ValuePlotter(MPLPlotter):
         return self.plot_measurement(measurement=self.measurement, *args, **kwargs)
 
     def plot_measurement(
-        self, measurement, v_list=None, tspan=None, ax=None, legend=True, logscale=False
+        self,
+        measurement=None,
+        v_list=None,
+        tspan=None,
+        ax=None,
+        legend=True,
+        logscale=False,
     ):
         """Plot a measurement's values vs time
 
@@ -27,6 +33,7 @@ class ValuePlotter(MPLPlotter):
             legend (bool): Whether to include a legend. Defaults to True.
             logscale (bool): Whether to use a log-scaled y-axis. Defaults to False.
         """
+        measurement = measurement or self.measurement
         if not ax:
             ax = self.new_ax()
         v_list = v_list or measurement.value_names

--- a/src/ixdat/readers/__init__.py
+++ b/src/ixdat/readers/__init__.py
@@ -14,9 +14,11 @@ from .ixdat_csv import IxdatCSVReader
 from .biologic import BiologicMPTReader
 from .autolab import NovaASCIIReader
 from .ivium import IviumDatasetReader
+from .chi import CHInstrumentsTXTReader
 
 # mass spectrometers
 from .pfeiffer import PVMassSpecReader
+from .rgasoft import StanfordRGASoftReader
 from .cinfdata import CinfdataTXTReader
 
 # ec-ms
@@ -31,7 +33,9 @@ READER_CLASSES = {
     "biologic": BiologicMPTReader,
     "autolab": NovaASCIIReader,
     "ivium": IviumDatasetReader,
+    "chi": CHInstrumentsTXTReader,
     "pfeiffer": PVMassSpecReader,
+    "rgasoft": StanfordRGASoftReader,
     "cinfdata": CinfdataTXTReader,
     "zilien": ZilienTSVReader,
     "zilien_tmp": ZilienTMPReader,

--- a/src/ixdat/readers/chi.py
+++ b/src/ixdat/readers/chi.py
@@ -1,0 +1,25 @@
+"""A reader for text exports from the RGA Software of Stanford Instruments"""
+
+from EC_MS import Dataset
+from .ec_ms_pkl import measurement_from_ec_ms_dataset
+from ..techniques import ECMeasurement
+
+
+class CHInstrumentsTXTReader:
+    path_to_file = None
+
+    def read(self, path_to_file, cls=None):
+        """Read a .txt file exported by CH Instruments software.
+
+        TODO: Write a new reader that doesn't use the old EC_MS package
+
+        Args:
+            path_to_file (Path or str): The file to read
+            cls (Measurement subclass): The class to return. Defaults to ECMeasuremnt
+        """
+        self.path_to_file = path_to_file
+        cls = cls if (cls and not issubclass(ECMeasurement, cls)) else ECMeasurement
+        ec_ms_dataset = Dataset(path_to_file, data_type="CHI")
+        return measurement_from_ec_ms_dataset(
+            ec_ms_dataset.data, cls=cls, reader=self, technique="EC"
+        )

--- a/src/ixdat/readers/ec_ms_pkl.py
+++ b/src/ixdat/readers/ec_ms_pkl.py
@@ -37,7 +37,12 @@ class EC_MS_CONVERTER:
 
 
 def measurement_from_ec_ms_dataset(
-    ec_ms_dict, name=None, cls=ECMSMeasruement, reader=None, **kwargs,
+    ec_ms_dict,
+    name=None,
+    cls=ECMSMeasruement,
+    reader=None,
+    technique=None,
+    **kwargs,
 ):
     """Return an ixdat Measurement with the data from an EC_MS data dictionary.
 
@@ -49,7 +54,8 @@ def measurement_from_ec_ms_dataset(
         ec_ms_dict (dict): The EC_MS data dictionary
         name (str): Name of the measurement
         cls (Measurement class): The class to return a measurement of
-        reader (Reader object): typically what calls this funciton with its read() method
+        reader (Reader object): The class which read ec_ms_dataset from file
+        technique (str): The name of the technique
     """
 
     if "Ewe/V" in ec_ms_dict and "<Ewe>/V" in ec_ms_dict:
@@ -96,12 +102,17 @@ def measurement_from_ec_ms_dataset(
             print(f"Not including '{col}' due to mismatch size with {tseries}")
             continue
         cols_list.append(
-            ValueSeries(name=v_name, data=data, unit_name=unit_name, tseries=tseries,)
+            ValueSeries(
+                name=v_name,
+                data=data,
+                unit_name=unit_name,
+                tseries=tseries,
+            )
         )
 
     obj_as_dict = dict(
         name=name,
-        technique="EC_MS",
+        technique=technique or "EC_MS",
         series_list=cols_list,
         reader=reader,
         tstamp=ec_ms_dict["tstamp"],

--- a/src/ixdat/readers/rgasoft.py
+++ b/src/ixdat/readers/rgasoft.py
@@ -1,0 +1,37 @@
+"""A reader for text exports from the potentiostat software of CH Instruments"""
+
+from EC_MS import Dataset
+from .reading_tools import timestamp_string_to_tstamp
+from .ec_ms_pkl import measurement_from_ec_ms_dataset
+from ..techniques import MSMeasurement
+
+
+class StanfordRGASoftReader:
+    path_to_file = None
+
+    def read(self, path_to_file, cls=None):
+        """Read a .txt file exported by CH Instruments software.
+
+        TODO: Write a new reader that doesn't use the old EC_MS package
+
+        Args:
+            path_to_file (Path or str): The file to read
+            cls (Measurement subclass): The class to return. Defaults to ECMeasuremnt
+        """
+
+        # with open(path_to_file, "r") as f:
+        #     timestamp_string = f.readline().strip()
+        # tstamp = timestamp_string_to_tstamp(
+        #     timestamp_string,
+        #     form="%b %d, %Y  %I:%M:%S %p",  # like "Mar 05, 2020  09:50:34 AM"
+        # )   # ^ For later. EC_MS actually gets this right.
+
+        self.path_to_file = path_to_file
+        cls = cls if (cls and not issubclass(MSMeasurement, cls)) else MSMeasurement
+        ec_ms_dataset = Dataset(
+            path_to_file,
+            data_type="RGA",  # tstamp=tstamp
+        )
+        return measurement_from_ec_ms_dataset(
+            ec_ms_dataset.data, cls=cls, reader=self, technique="MS"
+        )

--- a/src/ixdat/techniques/cv.py
+++ b/src/ixdat/techniques/cv.py
@@ -193,6 +193,23 @@ class CyclicVoltammagram(ECMeasurement):
             )
         return timed_sweeps
 
+    def calc_capacitance(self, vspan):
+        """Return the capacitance in [F], calculated by the first sweeps through vspan
+
+        Args:
+            vspan (iterable): The potential range in [V] to use for capacitance
+        """
+        sweep_1 = self.select_sweep(vspan)
+        v_scan_1 = np.mean(sweep_1.grab("scan_rate")[1])  # [V/s]
+        I_1 = np.mean(sweep_1.grab("raw_current")[1])  # [mA] -> [A]
+
+        sweep_2 = self.select_sweep([vspan[-1], vspan[0]])
+        v_scan_2 = np.mean(sweep_2.grab("scan_rate")[1])  # [V/s]
+        I_2 = np.mean(sweep_2.grab("raw_current")[1]) * 1e-3  # [mA] -> [A]
+
+        cap = 1/2 * (I_1 / v_scan_1 + I_2 / v_scan_2)  # [A] / [V/s] = [C/V] = [F]
+        return cap
+
     def diff_with(self, other, v_list=None, cls=None, v_scan_res=0.001, res_points=10):
         """Return a CyclicVotammagramDiff of this CyclicVotammagram with another one
 

--- a/src/ixdat/techniques/ec.py
+++ b/src/ixdat/techniques/ec.py
@@ -217,7 +217,9 @@ class ECMeasurement(Measurement):
             ):
                 self.series_list.append(
                     ConstantValue(
-                        name=self.raw_current_names[0], unit_name="mA", value=0,
+                        name=self.raw_current_names[0],
+                        unit_name="mA",
+                        value=0,
                     )
                 )
                 self._populate_constants()  # So that OCP currents are included as 0.
@@ -232,7 +234,11 @@ class ECMeasurement(Measurement):
                 ]
             ):
                 self.series_list.append(
-                    ConstantValue(name=self.cycle_names[0], unit_name=None, value=0,)
+                    ConstantValue(
+                        name=self.cycle_names[0],
+                        unit_name=None,
+                        value=0,
+                    )
                 )
                 self._populate_constants()  # So that everything has a cycle number
 
@@ -427,16 +433,28 @@ class ECMeasurement(Measurement):
             self.correct_ohmic_drop(R_Ohm=R_Ohm)
 
     def calibrate_RE(self, RE_vs_RHE):
-        """Calibrate the reference electrode by providing `RE_vs_RHE` in [V]."""
+        """Calibrate the reference electrode by providing `RE_vs_RHE` in [V].
+
+        Return string: The name of the calibrated potential
+        """
         self.RE_vs_RHE = RE_vs_RHE
+        return self.V_str
 
     def normalize_current(self, A_el):
-        """Normalize current to electrod surface area by providing `A_el` in [cm^2]."""
+        """Normalize current to electrod surface area by providing `A_el` in [cm^2].
+
+        Return string: The name of the normalized current
+        """
         self.A_el = A_el
+        return self.J_str
 
     def correct_ohmic_drop(self, R_Ohm):
-        """Correct for ohmic drop by providing `R_Ohm` in [Ohm]."""
+        """Correct for ohmic drop by providing `R_Ohm` in [Ohm].
+
+        Return string: The name of the corrected potential
+        """
         self.R_Ohm = R_Ohm
+        return self.V_str
 
     @property
     def potential(self):
@@ -578,7 +596,10 @@ class ECMeasurement(Measurement):
                 changes = np.logical_or(changes, n_down < values)
         selector = np.cumsum(changes)
         selector_series = ValueSeries(
-            name=sel_str, unit_name="", data=selector, tseries=self.potential.tseries,
+            name=sel_str,
+            unit_name="",
+            data=selector,
+            tseries=self.potential.tseries,
         )
         self[self.sel_str] = selector_series  # TODO: Better cache'ing. This gets saved.
 

--- a/src/ixdat/techniques/ms.py
+++ b/src/ixdat/techniques/ms.py
@@ -23,7 +23,10 @@ class MSMeasurement(Measurement):
     """Class implementing raw MS functionality"""
 
     extra_column_attrs = {
-        "ms_meaurements": {"mass_aliases", "signal_bgs",},
+        "ms_meaurements": {
+            "mass_aliases",
+            "signal_bgs",
+        },
     }
 
     def __init__(
@@ -98,6 +101,7 @@ class MSMeasurement(Measurement):
             t_bg (list): Timespan that corresponds to the background signal.
                 If not given, no background is subtracted.
             removebackground (bool): Whether to remove a pre-set background if available
+                Defaults to False. (Note in grab_flux it defaults to True.)
             include_endpoints (bool): Whether to ensure tspan[0] and tspan[-1] are in t
         """
         time, value = self.grab(
@@ -138,7 +142,7 @@ class MSMeasurement(Measurement):
         mol,
         tspan=None,
         tspan_bg=None,
-        removebackground=False,
+        removebackground=True,
         include_endpoints=False,
     ):
         """Return the flux of mol (calibrated signal) in [mol/s]
@@ -149,6 +153,7 @@ class MSMeasurement(Measurement):
             tspan_bg (list): Timespan that corresponds to the background signal.
                 If not given, no background is subtracted.
             removebackground (bool): Whether to remove a pre-set background if available
+                Defaults to True.
         """
         if isinstance(mol, str):
             if not self.calibration or mol not in self.calibration:
@@ -173,7 +178,12 @@ class MSMeasurement(Measurement):
         return x, n_dot
 
     def grab_flux_for_t(
-        self, mol, t, tspan_bg=None, removebackground=False, include_endpoints=False,
+        self,
+        mol,
+        t,
+        tspan_bg=None,
+        removebackground=False,
+        include_endpoints=False,
     ):
         """Return the flux of mol (calibrated signal) in [mol/s] for a given time vec
 
@@ -197,16 +207,10 @@ class MSMeasurement(Measurement):
         """Return a ValueSeries with the calibrated flux of mol during tspan"""
         t, n_dot = self.grab_flux(mol, tspan=tspan)
         tseries = TimeSeries(
-            name="n_dot_" + mol + "-t",
-            unit_name="s",
-            data=t,
-            tstamp=self.tstamp
+            name="n_dot_" + mol + "-t", unit_name="s", data=t, tstamp=self.tstamp
         )
         vseries = ValueSeries(
-            name="n_dot_" + mol,
-            unit_name="mol/s",
-            data=n_dot,
-            tseries=tseries
+            name="n_dot_" + mol, unit_name="mol/s", data=n_dot, tseries=tseries
         )
         return vseries
 
@@ -275,7 +279,12 @@ class MSCalResult(Saveable):
     column_attrs = {"name", "mol", "mass", "cal_type", "F"}
 
     def __init__(
-        self, name=None, mol=None, mass=None, cal_type=None, F=None,
+        self,
+        name=None,
+        mol=None,
+        mass=None,
+        cal_type=None,
+        F=None,
     ):
         super().__init__()
         self.name = name or f"{mol} at {mass}"
@@ -399,7 +408,13 @@ class MSInlet:
         return n_dot
 
     def gas_flux_calibration(
-        self, measurement, mol, mass, tspan=None, tspan_bg=None, ax=None,
+        self,
+        measurement,
+        mol,
+        mass,
+        tspan=None,
+        tspan_bg=None,
+        ax=None,
     ):
         """
         Args:


### PR DESCRIPTION
This adds a few things to  ixdat's EC-MS analysis that proved missing or broken while preparing article repositories (https://github.com/ScottSoren/Huang2021, from which the branch gets its name) and issues #16, #17, #19, and #20:

- Molar fluxes for a calibrated molecule `mol` can be looked up using the name`"n_dot_{mol}"` (indexing for the `ValueSeries`, `grab()` for the  `t` and `n_dot` numpy arrays)
- Molar fluxes can be exported by giving a `mol_list` to the `export()` function. 
- `MSCalResults` can be dropped in for molecule names in `mol_list`s (like the `Molecule` objects of the old `EC_MS` package)
- New readers for RGA and CHI (will need to be replaced eventually - these use the old EC_MS package)
- If a background has been set by `set_bg()`, background is removed by default when calculating molar fluxes.
- The names of the newly calibrated series are returned by `calibrate_RE` and `normalize_current`

I could use eyes on the code. Specifically whether the additions are intuitive and well-documented. Once this is merged into [user_ready], I think it's time to distribute an ixdat v0.1.6