### PR TITLE
[RFC] Deprecation decorator

### DIFF
--- a/src/ixdat/exceptions.py
+++ b/src/ixdat/exceptions.py
@@ -31,3 +31,7 @@ class TechniqueError(Exception):
 
 class QuantificationError(Exception):
     """ixdat errors having to do with techniques and their limitations"""
+
+
+class DeprecationError(Exception):
+    """Error raised when a deprecated component has reached hard deprecation"""

--- a/src/ixdat/tools.py
+++ b/src/ixdat/tools.py
@@ -1,0 +1,222 @@
+"""This module contains general purpose tools"""
+import inspect
+import warnings
+from functools import wraps
+
+import numpy as np
+
+from ixdat.exceptions import DeprecationError
+
+warnings.simplefilter("default")
+
+
+def thing_is_close(thing_one, thing_two):
+    """Return whether two things are (nearly) equal, looking recursively if necessary"""
+    if type(thing_one) != type(thing_two):
+        return False
+
+    if isinstance(thing_one, list):
+        return list_is_close(thing_one, thing_two)
+    elif isinstance(thing_one, dict):
+        return dict_is_close(thing_one, thing_two)
+    else:
+        return value_is_close(thing_one, thing_two)
+
+
+def value_is_close(value_one, value_two):
+    """Return whether `value_one` and `value_two` are equal (or close for floats)"""
+    if isinstance(value_one, float) or isinstance(value_two, float):
+        return np.isclose(value_one, value_two)
+    elif isinstance(value_one, np.ndarray) and isinstance(value_two, np.ndarray):
+        return np.allclose(value_one, value_two)
+
+    return value_one == value_two
+
+
+def dict_is_close(dict_one, dict_two):
+    """Return True if the dicts are equal, except floats are allowed to just be close
+
+    Args:
+        dict_one (dict): The first dictionary to compare
+        dict_two (dict): The second dictionary to compare
+
+    .. warning::
+       This function is recursive (also together with :ref:func:`list_is_close` and
+       **will** result in an infinite loop if the values reference back to itself
+    """
+    if len(dict_one) != len(dict_two):
+        return False
+    if dict_one.keys() != dict_two.keys():
+        return False
+
+    for key, value_one in dict_one.items():
+        value_two = dict_two[key]
+        if not thing_is_close(value_one, value_two):
+            return False
+
+    return True
+
+
+def list_is_close(list_one, list_two):
+    """Return True if the lists are equal, except floats are allowed to just be close
+
+    Args:
+        list_one (list): The first list to compare
+        list_two (list): The second list to compare
+
+    .. warning::
+       This function is recursive (also together with :ref:func:`list_is_close` and
+       **will** result in an infinite loop if the values reference back to itself
+    """
+    if len(list_one) != len(list_two):
+        return False
+
+    for value_one, value_two in zip(list_one, list_two):
+        if type(value_one) != type(value_two):
+            return False
+        if not thing_is_close(value_one, value_two):
+            return False
+
+    return True
+
+
+def _construct_deprecation_message(
+    identity,
+    last_release_when_supported,
+    soft_deprecation_period,
+    hard_deprecation_period,
+    message,
+    kwarg_name,
+):
+    """Return a deprecation message, see :func:`deprecate` for details on the arguments
+
+    Args:
+        identity (str): The identity of the callable being deprecated e.g.
+            "fuction 'myfunction'"
+
+    All other arguments are as in :func:`deprecate`
+
+    """
+    property_part = f"property named '{kwarg_name}' in " if kwarg_name else ""
+    return (
+        f"The {property_part}{identity} is deprecated, its last supported version being "
+        f"{last_release_when_supported}.\n"
+        "This means that:\n"
+        "* It is soft deprecated (issuing warnings) in all releases for "
+        f"{soft_deprecation_period} after the last supported release\n"
+        "* It is hard deprecated (raising exceptions) in all releases for an additional "
+        f"{hard_deprecation_period} after that\n"
+        "* After the hard deprecation period ends, it will be removed\n\n"
+        "See instruction below on how to update your code to avoid this message:\n"
+        f"{message}"
+    )
+
+
+def deprecate(
+    last_release_when_supported,
+    soft_deprecation_period,
+    hard_deprecation_period,
+    message,
+    kwarg_name=None,
+    hard_deprecate=False,
+):
+    """Mark a function, method or class for deprecation
+
+    The deprecator supports soft and hard deprecation which will either issue warnings or
+    raise exceptions. The deprecation periods are calculated from the date of
+    `last_release_when_supported`.
+
+    Args:
+        last_release_when_supported (str): The name of the last version when the deprecated
+            functionality was fully supported e.g. "1.2.3"
+        soft_deprecation_period (str): The period after `last_release_when_supported` when
+            the functionality will be soft deprecated, meaning using warnings e.g. "3 months"
+        hard_deprecation_period (str): The period after `last_release_when_supported` +
+            `soft_deprecation_period` when the functionality will raise Exception, but still
+            be present. E.g. "1 month". After the period the functionality will be removed
+            entirely.
+        message (str): A message to the user instructing with instruction on how to upgrade
+            to avoid the deprecated functionality
+
+    Keyword Args:
+        kwarg_name (str): If given, is the name of the keyword argument which is deprecated.
+            If not given it is assumed that the entire callable is deprecated.
+        hard_deprecate (bool): Whether the functionality is now hard deprecated. Defaults to
+            False.
+
+    Examples:
+
+    Used to deprecate a class::
+     @deprecate("1.2.3", "1 month", "1 month", "Please use `MyNewClass` instead")
+     class MyClass:
+         ...
+
+    Used to deprecate a method or an argument in a method::
+        class MyClass:
+
+            @deprecate("1.2.3", "1 month", "1 month", "Please use `mynewmethod` instead")
+            def mymethod(self):
+                ...
+
+            @classmethod
+            @deprecate(
+                "1.2.3",
+                "1 month",
+                "1 month",
+                "Please use `kwargb` instead",
+                kwarg_name="kwarga"
+            )
+            def mymethod(cls, arg, kwarga=None, kwargb=None):
+                ...
+
+    Note: In the example above, when this decorator is applied to class or static methods,
+    it must be applied as the first decorator (closest to the def).
+
+    """
+
+    def decorator(callable_):
+        """Decorate a callable with"""
+        # Form an identity string for the object which is being decorated, which is used
+        # in the message to the user
+        if inspect.isclass(callable_):
+            identity = f"class '{callable_.__qualname__}'"
+        else:
+            if "." in callable_.__qualname__:
+                identity = f"method '{callable_.__qualname__}'"
+            else:
+                identity = f"function '{callable_.__qualname__}'"
+
+        compound_message = _construct_deprecation_message(
+            identity,
+            last_release_when_supported,
+            soft_deprecation_period,
+            hard_deprecation_period,
+            message,
+            kwarg_name,
+        )
+
+        # Get the argument signature of the callable
+        callable_signature = inspect.signature(callable_)
+
+        @wraps(callable_)
+        def inner_function(*args, **kwargs):
+            # Form bound arguments, so both args and kwargs gets mapped to their name
+            bound_arguments = {}
+            if kwarg_name:
+                bound_arguments = callable_signature.bind(*args, **kwargs).arguments
+
+            # If something deprecated is being used, issue the warning or exception
+            if kwarg_name is None or kwarg_name in bound_arguments:
+                if hard_deprecate:
+                    raise DeprecationError(compound_message)
+                else:
+                    warnings.warn(compound_message, DeprecationWarning, stacklevel=2)
+
+            # Calculate the return value of the original object and return
+            return_value = callable_(*args, **kwargs)
+
+            return return_value
+
+        return inner_function
+
+    return decorator

--- a/tests/unit/test_tools.py
+++ b/tests/unit/test_tools.py
@@ -1,0 +1,146 @@
+"""Tests for tools.py"""
+import pytest
+
+from ixdat.exceptions import DeprecationError
+from ixdat.tools import deprecate
+
+# Standard arguments for deprecate
+DEPRECATE_STANDARD_ARGS = {
+    "last_release_when_supported": "1.2.3",
+    "soft_deprecation_period": "3 months",
+    "hard_deprecation_period": "6 months",
+}
+
+
+class TestDeprecate:
+    """Test the `deprecate` decorator"""
+
+
+    @pytest.mark.parametrize(
+        "callable_name",
+        ["myfunction", "mymethod", "myclassmethod", "mystaticmethod", "MyClass"],
+    )
+    @pytest.mark.parametrize("decorate_kwarg", [None, "intkwarg"])
+    @pytest.mark.parametrize("hard_deprecate", [False, True])
+    def test_function_decorator(self, callable_name, hard_deprecate, decorate_kwarg):
+        """Test all permutations of the callable to decorate, decorate kwarg or not and hard
+        deprecate or not
+
+        Args:
+            callable_name (str): The name of the kind of callable to test
+            decorate_kwarg (bool): Whether to test deprecating a kwarg in the callable
+            hard_deprecate (bool): Whether to test hard deprecation
+
+        """
+        # First form the decorator
+        decorator = deprecate(
+            **DEPRECATE_STANDARD_ARGS,
+            message="Do SOMETHING ELSE now",
+            hard_deprecate=hard_deprecate,
+            kwarg_name=decorate_kwarg,
+        )
+        if "method" in callable_name or "MyClass" in callable_name:
+            # If we need a class, ee build it inside the test function to avoid decorating
+            # the methods more than once
+            class MyClass:
+                def __init__(self, intarg, intkwarg=2, one_more_kwarg=None):
+                    pass
+
+                @decorator
+                def mymethod(self, intarg, intkwarg=2, one_more_kwarg=None):
+                    return 47 + intarg + intkwarg
+
+                @classmethod
+                @decorator
+                def myclassmethod(cls, intarg, intkwarg=2, one_more_kwarg=None):
+                    return 47 + intarg + intkwarg
+
+                @staticmethod
+                @decorator
+                def mystaticmethod(intarg, intkwarg=2, one_more_kwarg=None):
+                    return 47 + intarg + intkwarg
+
+            # Get the appropriate callable from the class
+            if "classmethod" in callable_name:
+                decorated_callable = getattr(MyClass, callable_name)
+            elif callable_name == "MyClass":
+                decorated_callable = decorator(MyClass)
+            else:
+                my_obj = MyClass(1)
+                decorated_callable = getattr(my_obj, callable_name)
+        else:
+            # We just need a normal function
+            def myfunction(intarg, intkwarg=2, one_more_kwarg=None):
+                return 47 + intarg + intkwarg
+
+            decorated_callable = decorator(myfunction)
+
+        # If we are testing decorating a kwarg
+        if decorate_kwarg:
+            # Make sure nothing happens if we do not use the kwarg
+            with pytest.warns(None) as captured_warnings:
+                return_value = decorated_callable(3)
+            if decorated_callable.__name__ == "MyClass":
+                assert isinstance(return_value, MyClass)
+            else:
+                assert return_value == 52
+            assert len(captured_warnings) == 0
+
+            # In the case of hard deprecation, test that it raises an exception, otherwise it
+            # should raise a warning
+            if hard_deprecate:
+                with pytest.raises(DeprecationError) as exception:
+                    decorated_callable(3, intkwarg=3)
+                message = str(exception.value)
+            else:
+                with pytest.warns(DeprecationWarning) as captured_warnings:
+                    return_value = decorated_callable(3, intkwarg=3)
+                if decorated_callable.__name__ == "MyClass":
+                    assert isinstance(return_value, MyClass)
+                else:
+                    assert return_value == 53
+                warning = captured_warnings.pop()
+                message = str(warning.message)
+
+            # Make sure deprecation is triggered both when using the kwarg as a kwarg as a
+            # kwarg and when reaching it as a arg
+            if hard_deprecate:
+                with pytest.raises(DeprecationError) as exception:
+                    decorated_callable(3, 3)
+                message2 = str(exception.value)
+            else:
+                with pytest.warns(DeprecationWarning) as captured_warnings:
+                    return_value = decorated_callable(3, 3)
+                if decorated_callable.__name__ == "MyClass":
+                    assert isinstance(return_value, MyClass)
+                else:
+                    assert return_value == 53
+                warning = captured_warnings.pop()
+                message2 = str(warning.message)
+
+            # No-matter how we reached the deprecation, the message should be the same
+            assert message == message2
+
+        else:  # We are decorating a callable, not a kwarg within it
+            # In the case of hard deprecation, test that it raises an exception, otherwise it
+            # should raise a warning
+            if hard_deprecate:
+                with pytest.raises(DeprecationError) as exception:
+                    decorated_callable(3, 3)
+                message = str(exception.value)
+            else:
+                with pytest.warns(DeprecationWarning) as captured_warnings:
+                    return_value = decorated_callable(3, 3)
+                if decorated_callable.__name__ == "MyClass":
+                    assert isinstance(return_value, MyClass)
+                else:
+                    assert return_value == 53
+                warning = captured_warnings.pop()
+                message = str(warning.message)
+
+        # Make sure all the `deprecate` text inputs are in the exception or warning message
+        for snippet in list(DEPRECATE_STANDARD_ARGS.values()) + [
+            callable_name,
+            "SOMETHING ELSE",
+        ]:
+            assert snippet in message


### PR DESCRIPTION
This is a Request For Comments on the idea of introducing a decorators that would mark either a class, function methods **or** a specific kwarg within any of these callables as deprecated. After input I will make a more polished PR. What I need input on is this:

1. The implementation has both the notion of soft and hard deprecation, where the former issues a warning and the latter raises and exception. Personally, I think that is nice, but I need input on whether you think it is overkill
2. The periods where a feature is soft or hard deprecated in given as a time interval since last supported release. I.e "the feature is soft deprecated for all releases for 3 months after version '1.2.3' and hard deprecated an additional 3 months after that". Is this the way you prefer to work with these intervals? One might also list those intervals as a number of releases i.e. "the feature is soft deprecated 2 releases after version '1.2.3' and hard deprecated an additional 2 releases after that"
3. EDIT How clever do we want it to be? In principle we could of course give it a "last supported time stamp" and well defined time deltas and then we could calculate when it would move from soft deprecation to hard, as opposed to the suggested implementation when you will need to flip the `hard_deprecation` boolean by hand. I didn't do it because it is my view that it will not be worth the extra code complexity and because I don't want peoples code to all of a sudden hard deprecate with them having upgraded.

The feature is used like this:
```python
import sys
from time import sleep

from ixdat.tools import deprecate


@deprecate("1.2.3", "1 month", "1 month", "Please use `MyNewClass` instead")
class MyClass:
    pass

my_obj = MyClass()

# This is just a bit of trickery to make the warnings appear in order with the printed
# separator
sys.stderr.flush()
sleep(0.1)
print("\n\n===\n\n", flush=True)

class MyClass:

    @deprecate("1.2.3", "1 month", "1 month", "Please use `mynewmethod` instead")
    def mymethod(self):
        ...

    @classmethod
    @deprecate(
        "1.2.3",
        "1 month",
        "1 month",
        "Please use `kwargb` instead",
        kwarg_name="kwarga",
        hard_deprecate=True
    )
    def myothermethod(cls, arg, kwarga=None, kwargb=None):
        ...


my_obj = MyClass()
my_obj.mymethod()  # Will warn

sys.stderr.flush()
sleep(0.3)
print("\n\n===\n\n", flush=True)
sleep(0.3)


my_obj.myothermethod(1, kwarga=7)
```

which outputs something like this:
```python
/home/kenneth/venv/ixdat/ixdat/test.py:12: DeprecationWarning: The class 'MyClass' is deprecated, its last supported version being 1.2.3.
This means that:
* It is soft deprecated (issuing warnings) in all releases for 1 month after the last supported release
* It is hard deprecated (raising exceptions) in all releases for an additional 1 month after that
* After the hard deprecation period ends, it will be removed

See instruction below on how to update your code to avoid this message:
Please use `MyNewClass` instead
  my_obj = MyClass()


===


/home/kenneth/venv/ixdat/ixdat/test.py:40: DeprecationWarning: The method 'MyClass.mymethod' is deprecated, its last supported version being 1.2.3.
This means that:
* It is soft deprecated (issuing warnings) in all releases for 1 month after the last supported release
* It is hard deprecated (raising exceptions) in all releases for an additional 1 month after that
* After the hard deprecation period ends, it will be removed

See instruction below on how to update your code to avoid this message:
Please use `mynewmethod` instead
  my_obj.mymethod()  # Will warn


===


Traceback (most recent call last):
  File "/home/kenneth/venv/ixdat/ixdat/test.py", line 48, in <module>
    my_obj.myothermethod(1, kwarga=7)
  File "/home/kenneth/venv/ixdat/ixdat/src/ixdat/tools.py", line 211, in inner_function
    raise DeprecationError(compound_message)
ixdat.exceptions.DeprecationError: The property named 'kwarga' in method 'MyClass.myothermethod' is deprecated, its last supported version being 1.2.3.
This means that:
* It is soft deprecated (issuing warnings) in all releases for 1 month after the last supported release
* It is hard deprecated (raising exceptions) in all releases for an additional 1 month after that
* After the hard deprecation period ends, it will be removed

See instruction below on how to update your code to avoid this message:
Please use `kwargb` instead
```