### PR TITLE
Def calc l cap effective

### DIFF
--- a/src/ixdat/techniques/ms.py
+++ b/src/ixdat/techniques/ms.py
@@ -346,7 +346,8 @@ class MSInlet:
     def calc_l_cap_eff(
         self, gas=None, n_dot=None, w_cap=None, h_cap=None,  T=None, p=None
         ):
-        """Calculate the effective length of the capillary in [m] 
+        """Calculate gas specific effective length of the capillary in [m]
+            and add {gas:value} to l_cap_eff (dict)
 
         Uses Equation 4.10 of Daniel's Thesis.
 
@@ -358,7 +359,7 @@ class MSInlet:
             T (float): Temperature [K], if to be updated
             p (float): pressure [Pa], if to be updated
         Returns:
-            float: the total molecular flux in [s^-1] through the capillary
+            float: gas specific effective length in [m]
         """
 
         if w_cap is None:
@@ -415,9 +416,13 @@ class MSInlet:
     def update_l_cap(self):
         """ Update self.l_cap from average of values in dict l_cap_eff
 
-        """
-        self.l_cap = np.mean(list(self.l_cap_eff.values()))
+        Returns:
+            float: averaged effective capilllary length in [m]
 
+        """
+        if self.l_cap_eff:
+            self.l_cap = np.mean(list(self.l_cap_eff.values()))
+        return self.l_cap
 
     def calc_n_dot_0(
         self, gas=None, w_cap=None, h_cap=None, l_cap=None, T=None, p=None):

--- a/src/ixdat/techniques/ms.py
+++ b/src/ixdat/techniques/ms.py
@@ -365,15 +365,22 @@ class MSInlet:
 
         return l_cap_gas_specific_eff
 
-    def update_l_cap(self):
+    def update_l_cap(self, gases=[]):
         """ Update self.l_cap from average of values in dict l_cap_eff
 
+        Args:
+            gases (list): list of gases to average l_cap, default all
         Returns:
             float: averaged effective capilllary length in [m]
-
         """
-        if self.l_cap_eff:
+        if self.l_cap_eff and not gases:
             self.l_cap = np.mean(list(self.l_cap_eff.values()))
+        elif self.l_cap_eff and gases:
+            _l_cap = 0
+            for gas in gases:
+                _l_cap += self.l_cap_eff[gas]
+            self.l_cap = _l_cap / len(gases)
+
         return self.l_cap
 
 

--- a/src/ixdat/techniques/ms.py
+++ b/src/ixdat/techniques/ms.py
@@ -412,7 +412,6 @@ class MSInlet:
         if p is None:
             p = self.p
 
-
         pi = np.pi
         eta = DYNAMIC_VISCOSITIES[gas]  # dynamic viscosity in [Pa*s]
         s = MOLECULAR_DIAMETERS[gas]  # molecule diameter in [m]


### PR DESCRIPTION
I have added a function to calculate the effective length of a capillary given a known n_dot per pure gas.

The value is returned and put in a dict {gas:l_cap_gas_eff} such that the mean of the values can be used to calculated an averaged effective length. 

A function to update self.l_cap (float) given l_cap_eff (dict) is not empty. 

Maybe this should be directly in calc_l_cap_eff(), but I didnt want to automatically update the value self.l_cap. 