### PR TITLE
Debug after big merge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -122,7 +122,7 @@ for academic publications:
 Join us
 -------
 
-`ixdat`` is free and open source software and we welcome input and new collaborators. Please help us improve!
+``ixdat`` is free and open source software and we welcome input and new collaborators. Please help us improve!
 
-Contact us (sbscott@ic.ac.uk) or just
+Contact us (https://github.com/ixdat/ixdat/discussions or sbscott@ic.ac.uk) or just
 `get started developing <https://ixdat.readthedocs.io/en/latest/developing.html>`_.

--- a/README.rst
+++ b/README.rst
@@ -122,7 +122,7 @@ for academic publications:
 Join us
 -------
 
-``ixdat`` is free and open source software and we welcome input and new collaborators. Please help us improve!
+``ixdat`` is free and open source software and we welcome input and new collaborators. Please help us improve ``ixdat``!
 
 Contact us (https://github.com/ixdat/ixdat/discussions or sbscott@ic.ac.uk) or just
 `get started developing <https://ixdat.readthedocs.io/en/latest/developing.html>`_.

--- a/development_scripts/reader_testers/test_ixdat_csv_reader.py
+++ b/development_scripts/reader_testers/test_ixdat_csv_reader.py
@@ -15,7 +15,7 @@ else:
     meas = Measurement.read(
         "../../test_data/biologic/Pt_poly_cv_CUT.mpt", reader="biologic"
     )
-    meas.calibrate_RE(0.715)
+    meas.calibrate_RE(0.01)
 
     meas.correct_ohmic_drop(R_Ohm=100)
 

--- a/development_scripts/reader_testers/test_zilien_spectrum_reader.py
+++ b/development_scripts/reader_testers/test_zilien_spectrum_reader.py
@@ -18,4 +18,5 @@ spec.plot(color="k")
 s_id = spec.save()
 
 loaded = Spectrum.get(s_id)
-loaded.plot(color="g")
+ax = loaded.plot(color="g")
+ax.set_yscale("log")

--- a/docs/source/tutorials.rst
+++ b/docs/source/tutorials.rst
@@ -15,9 +15,15 @@ This repository is a bit of a mess at the moment, apologies, but the tutorials t
 not bad, if we may say so ourselves. More are needed. Right now there are two,
 both based on electrochemistry data:
 
-Loading, selecting, calibrating, and exporting data
+Electrochemistry Tutorial 1: Reading and using data
 ***************************************************
-Location: `loading_appending_and_saving/export_demo_data_as_csv.ipynb <https://github.com/ixdat/tutorials/blob/main/loading_appending_and_saving/export_demo_data_as_csv.ipynb>`_
+
+Loading, selecting, calibrating, and exporting data, with a set of electrochemistry
+files from a long complex measurement, taken with Biologic's EC-Lab, as an example.
+
+Location (ixdat v0.2+): `electrochemistry/01_reading_and_using_data.ipynb <https://github.com/ixdat/tutorials/blob/ixdat_v0p2/electrochemistry/01_reading_and_using_data.ipynb>`_
+
+Location (ixdat v0.1.x): `loading_appending_and_saving/export_demo_data_as_csv.ipynb <https://github.com/ixdat/tutorials/blob/main/loading_appending_and_saving/export_demo_data_as_csv.ipynb>`_
 
 This tutorial shows with electrochemistry data how to load, append, and export data.
 It shows, among other things, the **appending + operator** and how to use the **backend** (save() and get()).
@@ -25,12 +31,14 @@ It shows, among other things, the **appending + operator** and how to use the **
 It requires the data files `here <https://www.dropbox.com/sh/ag3pq7vqwuapd0o/AAB2Vqs6ZLZuFuMGp2ZeeWisa?dl=0>`_.
 
 
-Comparing cycles of a cyclic voltammagram
-*****************************************
+Electrochemistry Tutorial 2: Comparing cycles of a CV
+*****************************************************
 
-Location: `simple_ec_analysis/difference_between_two_cvs.ipynb <https://github.com/ixdat/tutorials/blob/main/simple_ec_analysis/difference_between_two_cvs.ipynb>`_
+Location (ixdat v0.2+): `electrochemistry/02_comparing_cycles.ipynb <https://github.com/ixdat/tutorials/blob/ixdat_v0p2/electrochemistry/02_comparing_cycles.ipynb>`_
 
-This tutorial, together with the previous one, shows the ``ixdat``'s API for electrochemistry data.
+Location (ixdat v0.1.x): `simple_ec_analysis/difference_between_two_cvs.ipynb <https://github.com/ixdat/tutorials/blob/main/simple_ec_analysis/difference_between_two_cvs.ipynb>`_
+
+This tutorial, together with the previous one, shows ``ixdat``'s API for electrochemistry data.
 It demonstrates, with CO stripping as an example, the following features:
 
 - Selecting cyclic voltammatry cycles
@@ -49,7 +57,8 @@ Spectroelectrochemistry
 
 Location:`spectroelectrochemistry/ <https://github.com/ixdat/tutorials/blob/main/spectroelectrochemistry/>`_
 
-This tutorial demonstrates importing, plotting, and exporting spectroelectrochemistry (S-EC) data
+This tutorial demonstrates importing, plotting, and exporting in-operando UV-Vis data
+as an example of spectroelectrochemistry (S-EC).
 It shows delta optical density calculation and both calculation and plotting of the full 2-D data field and
 cross sections (i.e. spectra and wavelength-vs-time).
 

--- a/src/ixdat/exporters/sec_exporter.py
+++ b/src/ixdat/exporters/sec_exporter.py
@@ -35,7 +35,7 @@ class SECExporter(CSVExporter):
     def default_export_columns(self):
         """The default v_list for SECExporter is that from EC and tracked wavelengths"""
         v_list = (
-            ECExporter(measurement=self.measurement).default_v_list
+            ECExporter(measurement=self.measurement).default_export_columns
             + self.measurement.tracked_wavelengths
         )
         return v_list

--- a/src/ixdat/exporters/spectrum_exporter.py
+++ b/src/ixdat/exporters/spectrum_exporter.py
@@ -35,9 +35,13 @@ class SpectrumExporter:
             line = f"{attr} = {getattr(spectrum, attr)}\n"
             header_lines.append(line)
 
-        N_header_lines = len(header_lines) + 3
-        header_lines.append(f"N_header_lines = {N_header_lines}\n")
         header_lines.append("\n")
+
+        # Insert a line, after the first two lines, saying how long the header is.
+        N_header_lines = len(header_lines) + 2
+        # The `+ 2` is for the header length line and the column header line.
+        header_length_line = f"N_header_lines = {N_header_lines}\n"
+        header_lines = header_lines[:2] + [header_length_line] + header_lines[2:]
 
         with open(path_to_file, "w") as f:
             f.writelines(header_lines)
@@ -92,9 +96,6 @@ class SpectrumSeriesExporter:
             line = f"{attr} = {getattr(spectrum_series, attr)}\n"
             header_lines.append(line)
 
-        N_header_lines = len(header_lines) + 3
-        header_lines.append(f"N_header_lines = {N_header_lines}\n")
-
         header_lines.append(
             f"values are y='{field.name}' with units [{field.unit_name}]\n"
         )
@@ -123,6 +124,12 @@ class SpectrumSeriesExporter:
             )
 
         header_lines.append("\n")
+
+        # Insert a line, after the first two lines, saying how long the header is.
+        N_header_lines = len(header_lines) + 2
+        # The `+ 2` is for the header length line and the column header line.
+        header_length_line = f"N_header_lines = {N_header_lines}\n"
+        header_lines = header_lines[:2] + [header_length_line] + header_lines[2:]
 
         with open(path_to_file, "w") as f:
             f.writelines(header_lines)

--- a/src/ixdat/measurements.py
+++ b/src/ixdat/measurements.py
@@ -373,6 +373,7 @@ class Measurement(Saveable):
 
     @property
     def tstamp(self):
+        """Float: The unix epoch time used by the measurement as t=0"""
         return self._tstamp
 
     @tstamp.setter

--- a/src/ixdat/measurements.py
+++ b/src/ixdat/measurements.py
@@ -134,7 +134,7 @@ class Measurement(Saveable):
         self._calibration_list = fill_object_list(
             calibration_list, c_ids, cls=Calibration
         )
-        self.tstamp = tstamp
+        self._tstamp = tstamp
 
         self._cached_series = {}
         self._aliases = aliases or {}
@@ -276,7 +276,7 @@ class Measurement(Saveable):
 
     @classmethod
     def from_component_measurements(
-        cls, component_measurements, keep_originals=True, sort=True, **kwargs
+        cls, component_measurements, keep_originals=True, sorted=True, **kwargs
     ):
         """Return a measurement with the data contained in the component measurements
 
@@ -288,7 +288,7 @@ class Measurement(Saveable):
             component_measurements (list of Measurement)
             keep_originals: Whether to keep a list of component_measurements referenced.
                 This may result in redundant numpy arrays in RAM.
-            sort (bool): Whether to sort the series according to time
+            sorted (bool): Whether to sort the series according to time
             kwargs: key-word arguments are added to the dictionary for cls.from_dict()
 
         Returns cls: the combined measurement.
@@ -327,7 +327,7 @@ class Measurement(Saveable):
         sort_indeces = {}
         for name, s_as_dict in series_as_dicts.items():
             if "tstamp" in s_as_dict:
-                if sort:
+                if sorted:
                     sort_indeces[name] = np.argsort(s_as_dict["data"])
                     s_as_dict["data"] = s_as_dict["data"][sort_indeces[name]]
                 tseries_dict[name] = TimeSeries.from_dict(s_as_dict)
@@ -341,7 +341,7 @@ class Measurement(Saveable):
                 if s_as_dict["data"].shape == tseries.shape:
                     # Then we assume that the time and value data have lined up
                     # successfully! :D
-                    if sort:
+                    if sorted:
                         s_as_dict["data"] = s_as_dict["data"][
                             sort_indeces[tseries.name]
                         ]
@@ -363,13 +363,24 @@ class Measurement(Saveable):
                             for s in m.series_list
                             if s.name == name
                         ],
-                        sort=sort,
+                        sorted=sorted,
                     )
                 series_list.append(vseries)
 
-        # Finally, add this series to the dictionary representation and return the object
+        # Finally, add the series to the dictionary representation and return the object
         obj_as_dict["series_list"] = series_list
         return cls.from_dict(obj_as_dict)
+
+    @property
+    def tstamp(self):
+        return self._tstamp
+
+    @tstamp.setter
+    def tstamp(self, tstamp):
+        # Resetting the tstamp needs to clear the cache, so series are returned wrt the
+        # new timestamp.
+        self.clear_cache()
+        self._tstamp = tstamp
 
     @property
     def metadata_json_string(self):

--- a/src/ixdat/plotters/ecms_plotter.py
+++ b/src/ixdat/plotters/ecms_plotter.py
@@ -130,7 +130,7 @@ class ECMSPlotter(MPLPlotter):
                 axes=[axes[0], axes[2]] if (mass_lists or mol_lists) else axes[0],
                 tspan=tspan,
                 tspan_bg=tspan_bg,
-                removebackground=remove_background,
+                remove_background=remove_background,
                 mass_list=mass_list,
                 mass_lists=mass_lists,
                 mol_list=mol_list,

--- a/src/ixdat/plotters/ms_plotter.py
+++ b/src/ixdat/plotters/ms_plotter.py
@@ -23,7 +23,7 @@ class MSPlotter(MPLPlotter):
         mol_lists=None,
         tspan=None,
         tspan_bg=None,
-        removebackground=None,
+        remove_background=None,
         unit=None,
         logplot=True,
         legend=True,
@@ -60,7 +60,7 @@ class MSPlotter(MPLPlotter):
                 If `mass_lists` are given rather than a single `mass_list`, `tspan_bg`
                 must also be two timespans - one for each axis. Default is `None` for no
                 background subtraction.
-            removebackground (bool): Whether otherwise to subtract pre-determined
+            remove_background (bool): Whether otherwise to subtract pre-determined
                 background signals if available. Defaults to (not logplot)
             unit (str): defaults to "A" or "mol/s"
             logplot (bool): Whether to plot the MS data on a log scale (default True)
@@ -68,8 +68,8 @@ class MSPlotter(MPLPlotter):
             kwargs: extra key-word args are passed on to matplotlib's plot()
         """
         measurement = measurement or self.measurement
-        if removebackground is None:
-            removebackground = not logplot
+        if remove_background is None:
+            remove_background = not logplot
 
         # Figure out, based on the inputs, whether or not to plot calibrated results
         # (`quantified`), specifications for the axis to plot on now (`specs_this_axis`)
@@ -102,7 +102,7 @@ class MSPlotter(MPLPlotter):
                     v_or_v_name,
                     tspan=tspan,
                     tspan_bg=tspan_bg,
-                    removebackground=removebackground,
+                    remove_background=remove_background,
                     include_endpoints=False,
                 )
             else:
@@ -110,7 +110,7 @@ class MSPlotter(MPLPlotter):
                     v_or_v_name,
                     tspan=tspan,
                     tspan_bg=tspan_bg,
-                    removebackground=removebackground,
+                    remove_background=remove_background,
                     include_endpoints=False,
                 )
             if logplot:
@@ -234,7 +234,7 @@ class MSPlotter(MPLPlotter):
                     v_name,
                     tspan=tspan,
                     tspan_bg=tspan_bg,
-                    removebackground=removebackground,
+                    remove_background=removebackground,
                     include_endpoints=False,
                 )
             else:
@@ -443,10 +443,10 @@ STANDARD_COLORS = {
     "CO2": "brown",
     "CH4": "r",
     "C2H4": "g",
-    "O2_M32": "k",
-    "O2_M34": "r",
-    "O2_M36": "g",
-    "CO2_M44": "brown",
-    "CO2_M46": "purple",
-    "CO2_M48": "darkslategray",
+    "O2@M32": "k",
+    "O2@M34": "r",
+    "O2@M36": "g",
+    "CO2@M44": "brown",
+    "CO2@M46": "purple",
+    "CO2@M48": "darkslategray",
 }

--- a/src/ixdat/plotters/sec_plotter.py
+++ b/src/ixdat/plotters/sec_plotter.py
@@ -60,6 +60,13 @@ class SECPlotter(MPLPlotter):
                 FIXME: colorbar at present mis-alignes axes
             kwargs: Additional key-word arguments are passed on to
                 ECPlotter.plot_measurement().
+
+        Returns:
+            list of Axes: axes=[spectra, potential, None, current]
+                axes[0] is the top axis with the heat map of the spectra
+                axes[1] is the bottom left axis with electrochemical potential
+                axes[2] is None (this is where a top right axis would go)
+                axes[3] is the bottom right axis with electrode current
         """
         measurement = measurement or self.measurement
 
@@ -71,7 +78,7 @@ class SECPlotter(MPLPlotter):
             )
         self.ec_plotter.plot_measurement(
             measurement=measurement,
-            axes=[axes[1], axes[2]],
+            axes=[axes[1], axes[3]],
             tspan=tspan,
             **kwargs,
         )
@@ -247,7 +254,7 @@ class SECPlotter(MPLPlotter):
         axes[0].set_ylabel(r"$\Delta$O.D.")
 
         self.ec_plotter.plot_measurement(
-            measurement=measurement, axes=axes[1:], tspan=tspan, **kwargs
+            measurement=measurement, axes=[axes[1], axes[3]], tspan=tspan, **kwargs
         )
 
     def plot_wavelengths_vs_potential(

--- a/src/ixdat/readers/zilien.py
+++ b/src/ixdat/readers/zilien.py
@@ -156,20 +156,18 @@ class ZilienSpectrumReader:
                     tstamp_match = re.search(FLOAT_MATCH, line)
                     tstamp = float(tstamp_match.group())
         xseries = DataSeries(data=x, name=x_name, unit_name="m/z")
-        tseries = TimeSeries(
-            data=np.array([0]), name="spectrum time / [s]", unit_name="s", tstamp=tstamp
-        )
         field = Field(
-            data=np.array([y]),
+            data=np.array(y),
             name=y_name,
             unit_name="A",
-            axes_series=[xseries, tseries],
+            axes_series=[xseries, ],
         )
         obj_as_dict = {
             "name": path_to_spectrum.name,
             "technique": "MS",
             "field": field,
             "reader": self,
+            "tstamp": tstamp,
         }
         obj_as_dict.update(kwargs)
         return cls.from_dict(obj_as_dict)

--- a/src/ixdat/spectra.py
+++ b/src/ixdat/spectra.py
@@ -16,10 +16,8 @@ class Spectrum(Saveable):
     wavelength OR angle OR mass-to-charge ratio). Even though in reality it takes time
     to require a spectrum, a spectrum is considered to represent one instance in time.
 
-    In ixdat, the data of a spectrum is organized into a Field, where the y-data is
-    considered to span a space defined by the x-data and the timestamp. If the x-data
-    has shape (N, ), then the y-data has shape (N, 1) to span the x-axis and the
-    single-point t axis.
+    In ixdat, the data of a spectrum is organized into a 1-Dimensional Field, where the
+    y-data is considered to span a space defined by the x-data.
 
     The Spectrum class makes the data in this field intuitively available. If spec
     is a spectrum, spec.x and spec.y give access to the x and y data, respectively,
@@ -217,7 +215,7 @@ class Spectrum(Saveable):
     @property
     def y(self):
         """The y data is the one-dimensional data attribute of the field"""
-        return self.field.data[0]
+        return self.field.data
 
     @property
     def y_name(self):

--- a/src/ixdat/techniques/deconvolution.py
+++ b/src/ixdat/techniques/deconvolution.py
@@ -10,6 +10,9 @@ from numpy.fft import fft, ifft, ifftshift, fftfreq  # noqa
 import numpy as np
 
 # FIXME: too much abbreviation in this module.
+# TODO: Implement the PR review here: https://github.com/ixdat/ixdat/pull/4
+#  Perhaps best to merge [master] into [deconvolution], improve the module on the
+#  latter branch, and then reopen the PR.
 
 
 class DecoMeasurement(ECMSMeasurement):

--- a/src/ixdat/techniques/ec_ms.py
+++ b/src/ixdat/techniques/ec_ms.py
@@ -102,7 +102,7 @@ class ECMSMeasurement(ECMeasurement, MSMeasurement):
         n = Q / (n_el * FARADAY_CONSTANT)
         F = Y / n
         cal = MSCalResult(
-            name=f"{mol}_{mass}", mol=mol, mass=mass, cal_type="ecms_calibration", F=F,
+            name=f"{mol}@{mass}", mol=mol, mass=mass, cal_type="ecms_calibration", F=F,
         )
         return cal
 
@@ -140,7 +140,7 @@ class ECMSMeasurement(ECMeasurement, MSMeasurement):
         for tspan in tspan_list:
             Y = self.integrate_signal(mass, tspan=tspan, tspan_bg=tspan_bg, ax=axis_ms)
             # FIXME: plotting current by giving integrate() an axis doesn't work great.
-            Q = self.integrate("raw current / [mA]", tspan=tspan, axis=axis_current)
+            Q = self.integrate("raw current / [mA]", tspan=tspan, ax=axis_current)
             Q *= 1e-3  # mC --> [C]
             n = Q / (n_el * FARADAY_CONSTANT)
             Y_list.append(Y)
@@ -160,7 +160,7 @@ class ECMSMeasurement(ECMeasurement, MSMeasurement):
             Y_fit = n_fit * pfit[0] + pfit[1]
             ax.plot(n_fit * 1e9, Y_fit * 1e9, "--", color=color)
         cal = MSCalResult(
-            name=f"{mol}_{mass}",
+            name=f"{mol}@{mass}",
             mol=mol,
             mass=mass,
             cal_type="ecms_calibration_curve",
@@ -212,9 +212,10 @@ class ECMSCalibration(ECCalibration, MSCalibration):
             A_el (float): the geometric electrode area in [cm^2]
             L (float): the working distance in [m]
         """
-        ECCalibration.__init__(self, name=name, A_el=A_el, RE_vs_RHE=RE_vs_RHE)
+        ECCalibration.__init__(self, A_el=A_el, RE_vs_RHE=RE_vs_RHE,)
         MSCalibration.__init__(
             self,
+            name=name,
             date=date,
             tstamp=tstamp,
             setup=setup,


### PR DESCRIPTION
Hi Kenneth, here is a small follow-up to our big merge (#30) resulting from going through the [tutorials and article repositories](https://github.com/ixdat/ixdat/blob/debug_after_big_merge/docs/source/tutorials.rst) and the reader_testers. This also resulted in a number of changes to tutorials and article repositories, which was done in each case on an **ixdat_v0p2** branch. 

Things of note in this PR

- convention established of using the string `"mol@mass"` for calibration names, or aliases for molecules of a specific isotope. Previously "_" had been used instead of "@" but it turns out this convuses `MSCalibration` which splits on arguments like `"n_dot_H2"` on `"_"` to find the molecule name. 
- A Spectrum contains a 1-D field defined only on the scanning variable, with a tstamp separate in the object. (Previously it was a 2-D shape=(N, 1) field defined on the scanning variable and a one-point time variable)
- `Measurement.tspan` is now a managed attribute, so that the measurement can clear the cache in its setter to ensure that data series come out of the measurement with the measurement's new t=0 point.

After this, there will be another small PR with recent contributions from Anna and Krabbe. They need to be merged in from the user_ready branch.

And then we're ready to "launch" ixdat v0.2.0 with everything based on this master version :) 