### PR TITLE
Deprecation decorators

### DIFF
--- a/src/ixdat/exceptions.py
+++ b/src/ixdat/exceptions.py
@@ -31,3 +31,7 @@ class TechniqueError(Exception):
 
 class QuantificationError(Exception):
     """ixdat errors having to do with techniques and their limitations"""
+
+
+class DeprecationError(Exception):
+    """Error raised when a deprecated component has reached hard deprecation"""

--- a/src/ixdat/tools.py
+++ b/src/ixdat/tools.py
@@ -99,7 +99,7 @@ def _construct_deprecation_message(
     All other arguments are as in :func:`deprecate`
 
     """
-    property_part = f"property named '{kwarg_name}' in " if kwarg_name else ""
+    property_part = f"argument named '{kwarg_name}' in " if kwarg_name else ""
     message = (
         f"The {property_part}{identity} is deprecated, its last supported version being "
         f"{last_supported_release}:\n"

--- a/src/ixdat/tools.py
+++ b/src/ixdat/tools.py
@@ -135,7 +135,7 @@ def deprecate(
     remove_release=None,
     kwarg_name=None,
 ):
-    """Mark a function, method or class for deprecation
+    """Mark a function, method, programmed property or class for deprecation
 
     The deprecator supports soft and hard deprecation, which will either issue warnings
     or raise exceptions, as well as providing information about an update path and the
@@ -182,9 +182,25 @@ def deprecate(
             def mymethod(cls, arg, kwarga=None, kwargb=None):
                 ...
 
+    Used to decorate a property::
+        class MyClass:
+            def __init__(self):
+                self._internal = 8
+
+            @property
+            @deprecate("1.2.3", "Please use `new_external` instead")
+            def external(self):
+                return self._internal
+
+            @external.setter
+            @deprecate("1.2.3", "Please use `new_external` instead")
+            def external(self, value):
+                self._internal = value
+
     .. note::
-       In the example above, when this decorator is applied to a class method or
-       static method, it must be applied as the first decorator (closest to the def).
+       In the examples above, when this decorator is applied to a class method, static
+       method or programmed property, it must be applied as the first decorator (closest
+       to the def).
 
     """
 
@@ -226,6 +242,10 @@ def deprecate(
                 ) >= version.parse(hard_deprecation_release):
                     raise DeprecationError(compound_message)
                 else:
+                    # The stacklevel argument here is used to make the warning reference
+                    # the line at which the decorated callable was called, as the place
+                    # where the warning is raised, instead of here in `innner_function`,
+                    # which would be useless
                     warnings.warn(compound_message, DeprecationWarning, stacklevel=2)
 
             # Calculate the return value of the original object and return

--- a/tests/unit/test_tools.py
+++ b/tests/unit/test_tools.py
@@ -1,0 +1,200 @@
+"""Tests for tools.py"""
+
+from unittest.mock import patch
+
+import pytest
+from packaging import version
+
+from ixdat.exceptions import DeprecationError
+from ixdat.tools import deprecate
+
+# Standard arguments for deprecate
+DEPRECATE_STANDARD_ARGS = {
+    "last_supported_release": "1.2.3",
+    "update_message": "Do SOMETHING ELSE now.",
+}
+
+
+def generate_function_and_classes(decorator, *args):
+    """Generate decorated function and classes"""
+
+    class MyClass:
+        def __init__(self, intarg, intkwarg=2, one_more_kwarg=None):
+            pass
+
+        @decorator
+        def mymethod(self, intarg, intkwarg=2, one_more_kwarg=None):
+            return 47 + intarg + intkwarg
+
+        @classmethod
+        @decorator
+        def myclassmethod(cls, intarg, intkwarg=2, one_more_kwarg=None):
+            return 47 + intarg + intkwarg
+
+        @staticmethod
+        @decorator
+        def mystaticmethod(intarg, intkwarg=2, one_more_kwarg=None):
+            return 47 + intarg + intkwarg
+
+    DecoratedMyClass = decorator(MyClass)
+
+    @decorator
+    def myfunction(intarg, intkwarg=2, one_more_kwarg=None):
+        return 47 + intarg + intkwarg
+
+    return MyClass, DecoratedMyClass, myfunction
+
+
+class TestDeprecate:
+    """Test the `deprecate` decorator"""
+
+    @pytest.mark.parametrize("decorate_kwarg", [None, "intkwarg"])
+    @pytest.mark.parametrize("current_release", ["1.3.0", "1.9.0"])
+    @pytest.mark.parametrize("remove_release", ["2.0.0", None])
+    @pytest.mark.parametrize("hard_deprecate_release", ["1.4.0", None])
+    @pytest.mark.parametrize(
+        "callable_name",
+        ["myfunction", "mymethod", "myclassmethod", "mystaticmethod", "MyClass"],
+    )
+    def test_function_decorator(
+        self,
+        callable_name,
+        hard_deprecate_release,
+        remove_release,
+        current_release,
+        decorate_kwarg,
+    ):
+        """Test all permutations of the callable to decorate, decorate kwarg or not and hard
+        deprecate or not
+
+        Args:
+            callable_name (str): The name of the kind of callable to test
+            decorate_kwarg (bool): Whether to test deprecating a kwarg in the callable
+            hard_deprecate (bool): Whether to test hard deprecation
+
+        """
+        # First form the decorator
+        decorator = deprecate(
+            **DEPRECATE_STANDARD_ARGS,
+            hard_deprecation_release=hard_deprecate_release,
+            remove_release=remove_release,
+            kwarg_name=decorate_kwarg,
+        )
+
+        # Then get the class and functions we may need
+        MyClass, DecoratedMyClass, myfunction = generate_function_and_classes(decorator)
+
+        # Extract or set the appropriate callable, according to what we are testing
+        if callable_name == "myclassmethod":
+            decorated_callable = getattr(MyClass, callable_name)
+        elif callable_name == "MyClass":
+            decorated_callable = DecoratedMyClass
+        elif callable_name == "myfunction":
+            decorated_callable = myfunction
+        else:
+            my_obj = MyClass(1)
+            decorated_callable = getattr(my_obj, callable_name)
+
+        # Determine whether we are in hard deprecation
+        hard_deprecate = hard_deprecate_release is not None and version.parse(
+            current_release
+        ) >= version.parse(hard_deprecate_release)
+
+        # Patch out the imported version of __version__ with test value
+        with patch("ixdat.tools.__version__", current_release):
+            # If we are testing deprecating a kwarg
+            if decorate_kwarg:
+                message = self._test_decorate_kwarg(
+                    decorated_callable, MyClass, hard_deprecate
+                )
+            else:
+                message = self._test_decorate_callable(
+                    decorated_callable, MyClass, hard_deprecate
+                )
+
+        # Make sure all the `deprecate` text inputs are in the exception or warning
+        # messages
+        required_text_snippets = list(DEPRECATE_STANDARD_ARGS.values()) + [
+            callable_name,
+            "SOMETHING ELSE",
+        ]
+
+        if hard_deprecate_release is not None:
+            required_text_snippets.append(hard_deprecate_release)
+        else:
+            required_text_snippets.append(
+                "soft deprecated, issuing warnings, for the foreseeable future"
+            )
+
+        if remove_release:
+            required_text_snippets.append(remove_release)
+
+        for required_text_snippet in required_text_snippets:
+            assert required_text_snippet in message
+
+    def _test_decorate_kwarg(self, decorated_callable, MyClass, hard_deprecate):
+        """Test deprecation of kwarg"""
+        # Make sure nothing happens if we do not use the kwarg
+        with pytest.warns(None) as captured_warnings:
+            return_value = decorated_callable(3)
+        if decorated_callable.__name__ == "MyClass":
+            assert isinstance(return_value, MyClass)
+        else:
+            assert return_value == 52
+        assert len(captured_warnings) == 0
+
+        # In the case of hard deprecation, test that it raises an exception, otherwise it
+        # should raise a warning
+        if hard_deprecate:
+            with pytest.raises(DeprecationError) as exception:
+                decorated_callable(3, intkwarg=3)
+            message = str(exception.value)
+        else:
+            with pytest.warns(DeprecationWarning) as captured_warnings:
+                return_value = decorated_callable(3, intkwarg=3)
+            if decorated_callable.__name__ == "MyClass":
+                assert isinstance(return_value, MyClass)
+            else:
+                assert return_value == 53
+            warning = captured_warnings.pop()
+            message = str(warning.message)
+
+        # Make sure deprecation is triggered both when using the kwarg as a kwarg and
+        # when reaching it as an arg
+        if hard_deprecate:
+            with pytest.raises(DeprecationError) as exception:
+                decorated_callable(3, 3)
+            message2 = str(exception.value)
+        else:
+            with pytest.warns(DeprecationWarning) as captured_warnings:
+                return_value = decorated_callable(3, 3)
+            if decorated_callable.__name__ == "MyClass":
+                assert isinstance(return_value, MyClass)
+            else:
+                assert return_value == 53
+            warning = captured_warnings.pop()
+            message2 = str(warning.message)
+
+        # No-matter how we reached the deprecation, the message should be the same
+        assert message == message2
+        return message
+
+    def _test_decorate_callable(self, decorated_callable, MyClass, hard_deprecate):
+        """Test ordinary deprecation of callable"""
+        # In the case of hard deprecation, test that it raises an exception, otherwise it
+        # should raise a warning
+        if hard_deprecate:
+            with pytest.raises(DeprecationError) as exception:
+                decorated_callable(3, 3)
+            message = str(exception.value)
+        else:
+            with pytest.warns(DeprecationWarning) as captured_warnings:
+                return_value = decorated_callable(3, 3)
+            if decorated_callable.__name__ == "MyClass":
+                assert isinstance(return_value, MyClass)
+            else:
+                assert return_value == 53
+            warning = captured_warnings.pop()
+            message = str(warning.message)
+
+        return message


### PR DESCRIPTION
After the discussion in #34 I now consider the deprecation decorator functionality ready for review. As an outcome of the discussion the interface has changed to use specific version, instead of time intervals, to mark hard deprecation and deletion. The interface now is:
```python
def deprecate(
    last_supported_release,
    update_message,
    hard_deprecation_release=None,
    remove_release=None,
    kwarg_name=None,
):
```

which means that when applying the decorator to a class, method or function, the functionality is immediately considered soft deprecated, which means that it will issue warnings. If desired, it is possible to additionally provide `hard_deprecation_release` and `remove_release` to forewarn of when the functionality will become hard deprecated (raising exceptions) and finally be deleted. The two options compose in the warning and exception message, so while it is a little odd, it is possible to set a remove release and no hard deprecation release. But importantly, as requested, it is possible to leave both out to have the feature be soft deprecated indefinitely.

One note on this though. During the [discussion](https://github.com/ixdat/ixdat/pull/34#issuecomment-1065324297) @ScottSoren mentioned this option of indefinitely soft deprecating something. I would actually suggest to reverse this thinking, at least in the way we suggest to deprecate. I would suggest a relative short soft deprecation and a potentially long hard deprecation. The thinking behind this is that both the warning and the exception will contain instructions on how to fix the offending code, but only the exception will force you to.

Examples of use:
```python
@deprecate("0.1.6", "please use `newfunc` instead")
def func(a, b, c=None, d=None, e=None, f=None):
    return "called"

# OUTOUT
#/home/kenneth/venv/ixdat/ixdat/test.py:11: DeprecationWarning: The function 'func' is deprecated, its last supported version being 0.1.6:
#* It will continue to be soft deprecated, issuing warnings, for the foreseeable future
#
#See instructions below on how to update your code to avoid this message:
#please use `newfunc` instead

@deprecate("0.1.6", "please use `newfunc` instead", hard_deprecation_release="0.2.1")
def func(a, b, c=None, d=None, e=None, f=None):
    return "called"


func(1, 2, f=10)

# OUTPUT
#/home/kenneth/venv/ixdat/ixdat/test.py:12: DeprecationWarning: The function 'func' is deprecated, its last supported version being 0.1.6:
#* It will become hard deprecated, raising exceptions rather than issuing warnings, from version 0.2.1
#
#See instructions below on how to update your code to avoid this message:
#please use `newfunc` instead
#  func(1, 2, f=10)


@deprecate(
    "0.1.6",
    "please use `newfunc` instead",
    hard_deprecation_release="0.2.1",
    remove_release="1.0.0",
)
def func(a, b, c=None, d=None, e=None, f=None):
    return "called"


func(1, 2, f=10)

# OUTOUT
#/home/kenneth/venv/ixdat/ixdat/test.py:17: DeprecationWarning: The function 'func' is deprecated, its last supported version being 0.1.6:
#* It will become hard deprecated, raising exceptions rather than issuing warnings, from version 0.2.1
#* It is planned for complete removal in version 1.0.0
#
#See instructions below on how to update your code to avoid this message:
#please use `newfunc` instead
#  func(1, 2, f=10)


@deprecate("0.1.6", "please use `newfunc` instead", kwarg_name="f")
def func(a, b, c=None, d=None, e=None, f=None):
    return "called"


func(1, 2, f=10)

# OUTOUT
#/home/kenneth/venv/ixdat/ixdat/test.py:12: DeprecationWarning: The argument named 'f' in function 'func' is deprecated, its last supported version being 0.1.6:
#* It will continue to be soft deprecated, issuing warnings, for the foreseeable future
#
#See instructions below on how to update your code to avoid this message:
#please use `newfunc` instead
#  func(1, 2, f=10)


@deprecate("0.1.6", "please use `MyNewClass` instead")
class MyClass:
    ...


MyClass()

# OUTPUT
#/home/kenneth/venv/ixdat/ixdat/test.py:12: DeprecationWarning: The class 'MyClass' is deprecated, its last supported version being 0.1.6:
#* It will continue to be soft deprecated, issuing warnings, for the foreseeable future
#
#See instructions below on how to update your code to avoid this message:
#please use `MyNewClass` instead
#  MyClass()
```

The decorator is also completely tested (all permutations of arguments), which might seem a little like overkill for a development function, but it also serves as an example for pytest functionality like parametrization and patching.

Another discussion that cropped up somewhere (with @ScottSoren) is the (maybe anti)-pattern of having a `tools.py` module. I'm certainly open for input like this. One definition that I have seen is that `tools.py` is for user facing random stuff and `utils.py` is for developer facing random stuff. If we were to follow that, this should certainly go in `utils` instead.

Let me know what you think.