### PR TITLE
Pin dev dependencies, extra invoke task and black style fixes

### DIFF
--- a/TOOLS.rst
+++ b/TOOLS.rst
@@ -23,12 +23,19 @@ The following is a list of "tool and commands runners":
 Install instructions
 ====================
 
-Install all development tools by executing::
+To setup a development environment (virtual environment or anaconda
+environment) the first time, run the following 2 commands within the
+active development environment::
 
-  pip install -r requirements-dev.txt
+  python -m pip install invoke
+  invoke depencencies 
 
-while being at the git archive root in your virtual environment or
-anaconda environment.
+After the initial setup above, the development environment can at any
+time be kept up to date with changes to tooling by re-running the
+command::
+
+  invoke dependencies
+
 
 Tool and command runners in more detail
 =======================================
@@ -138,6 +145,10 @@ For settings and arguments for tools the following rules apply:
   building the package) If the tools support configuration in the
   shared configuration file ``setup.cfg``, then it belong there
   always!
+* **pyproject.toml**) This file is another common configuration file
+  much like setup.cfg, which is used by black. Unfortunately, black
+  and flake8 (which has settings in setup.cfg) do not share a single
+  shared settings file
 * **tox.ini** and **tasks.py**) If the tools only support
   configuration on the command line, then it goes into the
   configuration files of the tool runners, ``tox.ini`` for tox and
@@ -320,6 +331,15 @@ To see a list of all tasks::
 To run a specific task, say linting, run::
 
  $ invoke lint
+
+To run all (quality assurance) checks, run::
+
+ $ invoke checks
+
+To update the development environment with correct version of tools
+and settings, run::
+
+ $ invoke dependencies
 
 To run a command with an **invoke specific** argument do::
 

--- a/development_scripts/reader_testers/test_cinfdata_reader.py
+++ b/development_scripts/reader_testers/test_cinfdata_reader.py
@@ -38,8 +38,14 @@ ecms_meas.set_bg(tspan_bg=[0, 10])
 cv = ecms_meas.as_cv()
 cv.redefine_cycle(start_potential=0.39, redox=False)
 
-axes_cv = cv[2].plot(mass_list=["M2", "M44"], logplot=False, )
+axes_cv = cv[2].plot(
+    mass_list=["M2", "M44"],
+    logplot=False,
+)
 axes_cv = cv[1].plot(
-    mass_list=["M2", "M44"], linestyle="--", axes=axes_cv, logplot=False,
+    mass_list=["M2", "M44"],
+    linestyle="--",
+    axes=axes_cv,
+    logplot=False,
 )
 axes_cv[0].get_figure().savefig("Trimarco2018_ixdat.png")

--- a/development_scripts/reader_testers/test_ixdat_csv_reader.py
+++ b/development_scripts/reader_testers/test_ixdat_csv_reader.py
@@ -28,4 +28,3 @@ else:
     meas_loaded = Measurement.read("test.csv", reader="ixdat")
 
     meas_loaded.plot()
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.black]
+line-length = 89

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,6 @@
 black==22.1.0
-pytest==7.1.0
+pytest==7.1.0;python_version>'3.6'
+pytest==7.0.1;python_version=='3.6'
 Sphinx
 sphinx-rtd-theme
 sphinx_automodapi

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,11 +1,11 @@
-black
-pytest
+black==22.1.0
+pytest==7.1.0
 Sphinx
 sphinx-rtd-theme
 sphinx_automodapi
 EC_MS
-flake8
+flake8==4.0.1
 twine
-setuputils
+setuputils3
 tox
 invoke

--- a/src/ixdat/constants.py
+++ b/src/ixdat/constants.py
@@ -41,7 +41,7 @@ MOLECULAR_DIAMETERS = {
     "Ar": 3.58e-10,
     "He": 2.15e-10,
     "CO": 3.76e-10,
-    "CO2": 3.34 - 10,
+    "CO2": 3.34e-10,
     "H2": 2.71e-10,
 }  # in [m]
 MOLAR_MASSES = {

--- a/src/ixdat/db.py
+++ b/src/ixdat/db.py
@@ -432,9 +432,7 @@ class PlaceHolderObject:
         if not backend:  #
             backend = DB.backend
         if not backend or backend == "none" or backend is database_backends["none"]:
-            raise DataBaseError(
-                f"Can't make a PlaceHolderObject with backend={backend}"
-            )
+            raise DataBaseError(f"Can't make a PlaceHolderObject with backend={backend}")
         self.backend = backend
 
     def get_object(self):

--- a/src/ixdat/measurements.py
+++ b/src/ixdat/measurements.py
@@ -238,9 +238,7 @@ class Measurement(Saveable):
         return measurement
 
     @classmethod
-    def read_set(
-        cls, path_to_file_start, reader, suffix=None, file_list=None, **kwargs
-    ):
+    def read_set(cls, path_to_file_start, reader, suffix=None, file_list=None, **kwargs):
         """Read and append a set of files.
 
         Args:
@@ -342,9 +340,7 @@ class Measurement(Saveable):
                     # Then we assume that the time and value data have lined up
                     # successfully! :D
                     if sorted:
-                        s_as_dict["data"] = s_as_dict["data"][
-                            sort_indeces[tseries.name]
-                        ]
+                        s_as_dict["data"] = s_as_dict["data"][sort_indeces[tseries.name]]
                     vseries = ValueSeries(
                         name=name,
                         data=s_as_dict["data"],
@@ -479,9 +475,7 @@ class Measurement(Saveable):
     @property
     def value_series(self):
         """List of the VSeries in the measurement's DataSeries"""
-        return [
-            series for series in self.series_list if isinstance(series, ValueSeries)
-        ]
+        return [series for series in self.series_list if isinstance(series, ValueSeries)]
 
     @property
     def time_series(self):

--- a/src/ixdat/readers/biologic.py
+++ b/src/ixdat/readers/biologic.py
@@ -274,7 +274,7 @@ BIOLOGIC_TIMESTAMP_FORMS = (
     "%m/%d/%Y %H:%M:%S",  # like 07/29/2020 10:31:03
     "%m-%d-%Y %H:%M:%S.%f",  # (anticipated)
     "%m/%d/%Y %H:%M:%S.%f",  # like 04/27/2021 11:35:39.227 (EC-Lab v11.34)
-    "%m/%d/%Y %H.%M.%S",   # like 01/31/2022 11.19.17
+    "%m/%d/%Y %H.%M.%S",  # like 01/31/2022 11.19.17
 )
 
 # This tuple contains variable names encountered in .mpt files. The tuple can be used by

--- a/src/ixdat/readers/ec_ms_pkl.py
+++ b/src/ixdat/readers/ec_ms_pkl.py
@@ -72,9 +72,7 @@ def measurement_from_ec_ms_dataset(
 
     for col in cols_str:
         if col.endswith("-x"):
-            cols_list.append(
-                TimeSeries(col, "s", ec_ms_dict[col], ec_ms_dict["tstamp"])
-            )
+            cols_list.append(TimeSeries(col, "s", ec_ms_dict[col], ec_ms_dict["tstamp"]))
 
     if "time/s" in ec_ms_dict:
         cols_list.append(
@@ -117,7 +115,7 @@ def measurement_from_ec_ms_dataset(
         series_list=cols_list,
         reader=reader,
         tstamp=ec_ms_dict["tstamp"],
-        aliases=aliases
+        aliases=aliases,
     )
     obj_as_dict.update(kwargs)
 

--- a/src/ixdat/readers/ixdat_csv.py
+++ b/src/ixdat/readers/ixdat_csv.py
@@ -195,9 +195,7 @@ class IxdatCSVReader:
         if technique_match:
             self.technique = technique_match.group(1)
             if self.technique in TECHNIQUE_CLASSES:
-                if issubclass(
-                    TECHNIQUE_CLASSES[self.technique], self.measurement_class
-                ):
+                if issubclass(TECHNIQUE_CLASSES[self.technique], self.measurement_class):
                     self.measurement_class = TECHNIQUE_CLASSES[self.technique]
             return
         timecol_match = re.search(regular_expressions["timecol"], line)

--- a/src/ixdat/readers/msrh_sec.py
+++ b/src/ixdat/readers/msrh_sec.py
@@ -65,9 +65,7 @@ class MsrhSECReader:
         # If they didn't provide a tstamp, we have to prompt for it.
         tstamp = tstamp or prompt_for_tstamp(path_to_file)
         # Ready to define the measurement's TimeSeries:
-        tseries = TimeSeries(
-            "time from scan rate", unit_name="s", data=t, tstamp=tstamp
-        )
+        tseries = TimeSeries("time from scan rate", unit_name="s", data=t, tstamp=tstamp)
 
         # The wavelength comes from the reference spectrum file.
         wl = ref_df["wavelength"].to_numpy()

--- a/src/ixdat/readers/reading_tools.py
+++ b/src/ixdat/readers/reading_tools.py
@@ -28,7 +28,7 @@ def timestamp_string_to_tstamp(
             the standard timestamp form.
     """
     if form:
-        forms = (form, )
+        forms = (form,)
     for form in forms:
         try:
             return time.mktime(time.strptime(timestamp_string, form))

--- a/src/ixdat/readers/zilien.py
+++ b/src/ixdat/readers/zilien.py
@@ -23,6 +23,7 @@ ZILIEN_LEGACY_ALIASES = {
 #    unflattering example presently in the docs.
 #    https://github.com/ixdat/ixdat/pull/30/files#r810087496
 
+
 class ZilienTSVReader:
     """Class for reading files saved by Spectro Inlets' Zilien software"""
 
@@ -79,9 +80,7 @@ class ZilienTMPReader:
         cls = cls or ECMSMeasurement
         name = self.path_to_tmp_dir.parent.name
         timestamp_string = name[:19]  # the zilien timestamp is the first 19 chars
-        tstamp = timestamp_string_to_tstamp(
-            timestamp_string, form=ZILIEN_TIMESTAMP_FORM
-        )
+        tstamp = timestamp_string_to_tstamp(timestamp_string, form=ZILIEN_TIMESTAMP_FORM)
         series_list = []
         for tmp_file in self.path_to_tmp_dir.iterdir():
             series_list += series_list_from_tmp(tmp_file)
@@ -160,7 +159,9 @@ class ZilienSpectrumReader:
             data=np.array(y),
             name=y_name,
             unit_name="A",
-            axes_series=[xseries, ],
+            axes_series=[
+                xseries,
+            ],
         )
         obj_as_dict = {
             "name": path_to_spectrum.name,

--- a/src/ixdat/spectra.py
+++ b/src/ixdat/spectra.py
@@ -293,8 +293,10 @@ class SpectrumSeries(Spectrum):
     @property
     def yseries(self):
         # Should this return an average or would that be counterintuitive?
-        raise BuildError(f"{self} has no single y-series. Index it to get a Spectrum "
-                         "or see `y_average`")
+        raise BuildError(
+            f"{self} has no single y-series. Index it to get a Spectrum "
+            "or see `y_average`"
+        )
 
     @property
     def tseries(self):

--- a/src/ixdat/techniques/analysis_tools.py
+++ b/src/ixdat/techniques/analysis_tools.py
@@ -189,7 +189,7 @@ def calc_t_using_scan_rate(v, dvdt):
     def error(t_tot):
         t = np.linspace(0, t_tot[0], v.size)
         dvdt_calc = np.abs(calc_sharp_v_scan(t, v))
-        error = np.sum(dvdt_calc ** 2 - dvdt ** 2)
+        error = np.sum(dvdt_calc**2 - dvdt**2)
         return error
 
     t_total_guess = (max(v) - min(v)) / dvdt

--- a/src/ixdat/techniques/deconvolution.py
+++ b/src/ixdat/techniques/deconvolution.py
@@ -213,7 +213,7 @@ class Kernel:
             volflow_cap = self.params["volflow_cap"]
             henry_vola = self.params["henry_vola"]
 
-            tdiff = t_kernel * diff_const / (work_dist ** 2)
+            tdiff = t_kernel * diff_const / (work_dist**2)
 
             def fs(s):
                 # See Krempl et al, 2021. Equation 6.
@@ -221,7 +221,7 @@ class Kernel:
                 return 1 / (
                     sqrt(s) * sinh(sqrt(s))
                     + (vol_gas * henry_vola / 0.196e-4 / work_dist)
-                    * (s + volflow_cap / vol_gas * work_dist ** 2 / diff_const)
+                    * (s + volflow_cap / vol_gas * work_dist**2 / diff_const)
                     * cosh(sqrt(s))
                 )
 

--- a/src/ixdat/techniques/ec_ms.py
+++ b/src/ixdat/techniques/ec_ms.py
@@ -102,7 +102,11 @@ class ECMSMeasurement(ECMeasurement, MSMeasurement):
         n = Q / (n_el * FARADAY_CONSTANT)
         F = Y / n
         cal = MSCalResult(
-            name=f"{mol}@{mass}", mol=mol, mass=mass, cal_type="ecms_calibration", F=F,
+            name=f"{mol}@{mass}",
+            mol=mol,
+            mass=mass,
+            cal_type="ecms_calibration",
+            F=F,
         )
         return cal
 
@@ -174,8 +178,7 @@ class ECMSMeasurement(ECMeasurement, MSMeasurement):
 
 
 class ECMSCyclicVoltammogram(CyclicVoltammogram, ECMSMeasurement):
-    """Class for raw EC-MS functionality. Parents: CyclicVoltammogram, ECMSMeasurement
-    """
+    """Class for raw EC-MS functionality. Parents: CyclicVoltammogram, ECMSMeasurement"""
 
 
 class ECMSCalibration(ECCalibration, MSCalibration):
@@ -212,7 +215,11 @@ class ECMSCalibration(ECCalibration, MSCalibration):
             A_el (float): the geometric electrode area in [cm^2]
             L (float): the working distance in [m]
         """
-        ECCalibration.__init__(self, A_el=A_el, RE_vs_RHE=RE_vs_RHE,)
+        ECCalibration.__init__(
+            self,
+            A_el=A_el,
+            RE_vs_RHE=RE_vs_RHE,
+        )
         MSCalibration.__init__(
             self,
             name=name,

--- a/src/ixdat/techniques/ms.py
+++ b/src/ixdat/techniques/ms.py
@@ -201,9 +201,7 @@ class MSMeasurement(Measurement):
         """
         t, S = self.grab_signal(mass, tspan=tspan, include_endpoints=True)
         if tspan_bg:
-            t_bg, S_bg_0 = self.grab_signal(
-                mass, tspan=tspan_bg, include_endpoints=True
-            )
+            t_bg, S_bg_0 = self.grab_signal(mass, tspan=tspan_bg, include_endpoints=True)
             S_bg = np.mean(S_bg_0) * np.ones(t.shape)
         else:
             S_bg = np.zeros(t.shape)
@@ -470,9 +468,7 @@ class MSInlet:
         self.T = T
         self.gas = gas  # TODO: Gas mixture class. This must be a pure gas now.
 
-    def calc_n_dot_0(
-        self, gas=None, w_cap=None, h_cap=None, l_cap=None, T=None, p=None
-    ):
+    def calc_n_dot_0(self, gas=None, w_cap=None, h_cap=None, l_cap=None, T=None, p=None):
         """Calculate the total molecular flux through the capillary in [s^-1]
 
         Uses Equation 4.10 of Trimarco, 2017. "Real-time detection of sub-monolayer
@@ -512,7 +508,7 @@ class MSInlet:
         p_1 = p
         lambda_ = d  # defining the transitional pressure
         # ...from setting mean free path equal to capillary d
-        p_t = BOLTZMAN_CONSTANT * T / (2 ** 0.5 * pi * s ** 2 * lambda_)
+        p_t = BOLTZMAN_CONSTANT * T / (2**0.5 * pi * s**2 * lambda_)
         p_2 = 0
         p_m = (p_1 + p_t) / 2  # average pressure in the transitional flow region
         v_m = (8 * BOLTZMAN_CONSTANT * T / (pi * m)) ** 0.5

--- a/tasks.py
+++ b/tasks.py
@@ -1,4 +1,29 @@
-"""Definition of invoke tasks"""
+"""Definition of invoke tasks
+
+All functions in this file that is decorated with the `@task` decorator,
+constitutes an invoke task, which can be execute from the command line by
+calling invoke with the name of the task, which is the same as the name of the
+function (or using one of the aliasses possible listed in the @task decorator).
+E.g. to install all normal dependencies and development dependencies run::
+
+    invoke dependencies
+
+or::
+
+    invoke deps
+
+To see a full list of the available tasks and a brief summary of what they do,
+call::
+
+    invoke --list
+
+To get the full description of a task, call invoke --help on it::
+
+    invoke --help deps
+
+Read more about invoke here: https://www.pyinvoke.org/
+
+"""
 
 import sys
 import configparser
@@ -208,8 +233,13 @@ def clean(context, dryrun=False):
 
 
 @task(aliases=["deps"])
-def dependencies(context, user=False):
-    """Install development and normal dependencies
+def dependencies(context):
+    """Install all dedencendies required for development
+
+    This corresponds to:
+     * Upgrade pip
+     * Install/upgrade all normal dependencies
+     * Install/upgrade all development dependencies
 
     See docstring of :func:`flake8` for explanation of `context` argument
     """
@@ -220,7 +250,8 @@ def dependencies(context, user=False):
             "recommended way to install dependencies for development. Please "
             "consider using an virtual environment for development."
         )
-    command = "python -m pip install --upgrade -r"
     context.run("python -m pip install --upgrade pip")
+    command = "python -m pip install --upgrade -r"
     context.run(command + " requirements.txt")
     context.run(command + " requirements-dev.txt")
+

--- a/tests/functional/test_backends.py
+++ b/tests/functional/test_backends.py
@@ -22,9 +22,7 @@ class TestBackends:
         reloaded_ec_measurement = Measurement.get(id_)
         assert ec_measurement == reloaded_ec_measurement
 
-    def test_round_trip_of_composed(
-        self, composed_measurement, fresh_directory_backend
-    ):
+    def test_round_trip_of_composed(self, composed_measurement, fresh_directory_backend):
         """Test a load/save round trip of a composed measurement"""
         id_ = composed_measurement.save()
         loaded = Measurement.get(id_)

--- a/tests/functional/test_measurements.py
+++ b/tests/functional/test_measurements.py
@@ -37,18 +37,14 @@ class TestBiologicEC:
         # Check that the ms_calibration survived all that:
         assert cvs_1_plus_2.RE_vs_RHE == ec_measurement.RE_vs_RHE
         # Check that the main time variable, that of potential, wasn't corrupted:
-        assert len(cvs_1_plus_2.grab("potential")[0]) == len(
-            cvs_1_plus_2["time/s"].data
-        )
+        assert len(cvs_1_plus_2.grab("potential")[0]) == len(cvs_1_plus_2["time/s"].data)
         # Check that the selector is still available and works with the main time var:
         assert len(cvs_1_plus_2.selector.data) == len(cvs_1_plus_2.t)
 
     def test_calibration_over_save_load(self, composed_measurement):
         """Test save and load functionality"""
         # Now let's try calibrating just the loaded one:
-        composed_measurement_copy = Measurement.from_dict(
-            composed_measurement.as_dict()
-        )
+        composed_measurement_copy = Measurement.from_dict(composed_measurement.as_dict())
 
         RE_vs_RHE = 1
         A_el = 2


### PR DESCRIPTION
I'm planning on some more improvements around tooling. This is step one. The PR contains a couple of small items:

1. I added a new `dependencies` task (alias dep) to upgrade pip, install dependencies and dev dependencies
2. I pinned the version of the dev tools that we use for checks, because it is annoying to fight over differences in this sort or tooling i.e. some code might raise a flake8 warning on one machine and not on another for the same PR due to a version bump on one of the. It is just easier to pin them and upgrade every once in a while.
3. I added a `pyproject.toml` to be able to configure `black` which will now adhere to the BDFL determined one-true line length or 89 chars
4. I updated all files with black fixes as per the new pinned version of black