### PR TITLE
GitHub actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,49 @@
+# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: Continuous integration
+
+# Run the CI on any direct push to a branch on this repository or on pull request
+# branches
+on:
+  push:
+    branches:
+      - '**'
+  pull_request:
+    branches:
+      - 'main'
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+        if [ -f requirements-dev.txt ]; then pip install -r requirements-dev.txt; fi
+    - name: Set PYTHONPATH
+      run: |
+        echo "PYTHONPATH=src" >> $GITHUB_ENV
+    - name: Lint with flake8
+      run: |
+        # stop the build if there are Python syntax errors or undefined names
+        invoke lint
+    - name: Test with pytest
+      run: |
+        invoke test
+    - name: Check black formatting of code, tests and development scripts
+      run: |
+        invoke check-code-format
+

--- a/tasks.py
+++ b/tasks.py
@@ -11,6 +11,8 @@ from subprocess import check_call, CalledProcessError, check_output, DEVNULL
 
 THIS_DIR = Path(__file__).parent
 SOURCE_DIR = THIS_DIR / "src" / "ixdat"
+TESTS_DIR = THIS_DIR / "tests"
+DEV_SCRIPTS_DIR = THIS_DIR / "development_scripts"
 # Patterns to match for files of directories that should be deleted in the clean task
 CLEAN_PATTERNS = ("__pycache__", "*.pyc", "*.pyo", ".mypy_cache")
 
@@ -32,7 +34,8 @@ def flake8(context):
 
     """
     print("# flake8")
-    return context.run("flake8 src tests").return_code
+    with context.cd(THIS_DIR):
+        return context.run(f"flake8 {SOURCE_DIR} {TESTS_DIR}").return_code
 
 
 @task(aliases=["test", "tests"])
@@ -47,6 +50,19 @@ def pytest(context):
         return context.run("pytest tests").return_code
 
 
+@task(aliases=("check_black", "black_check", "bc",))
+def check_code_format(context):
+    """Check that the code, tests and development_scripts are black formatted
+
+    See docstring of :func:`flake8` for explanation of `context` argument
+
+    """
+    print("### Checking code style ...")
+    with context.cd(THIS_DIR):
+        result = context.run(f"black --check {SOURCE_DIR} {TESTS_DIR} {DEV_SCRIPTS_DIR}")
+    return result.return_code
+
+
 @task(aliases=["QA", "qa", "check"])
 def checks(context):
     """Run all QA checks
@@ -56,11 +72,18 @@ def checks(context):
     """
     combined_return_code = flake8(context)
     combined_return_code += pytest(context)
+    combined_return_code += check_code_format(context)
     if combined_return_code == 0:
         print()
         print(r"+----------+")
         print(r"| All good |")
         print(r"+----------+")
+
+
+@task(aliases=("black",))
+def format_code(context):
+    """Format all spitze and tools code with black"""
+    context.run(f"black {SOURCE_DIR} {TESTS_DIR} {DEV_SCRIPTS_DIR}")
 
 
 @task

--- a/tasks.py
+++ b/tasks.py
@@ -12,6 +12,8 @@ from subprocess import check_call, CalledProcessError, check_output, DEVNULL
 THIS_DIR = Path(__file__).parent
 SOURCE_DIR = THIS_DIR / "src" / "ixdat"
 TESTS_DIR = THIS_DIR / "tests"
+# NOTE The development_scripts folder below is only used in the
+# actions for black formatting, but not linting etc.
 DEV_SCRIPTS_DIR = THIS_DIR / "development_scripts"
 # Patterns to match for files of directories that should be deleted in the clean task
 CLEAN_PATTERNS = ("__pycache__", "*.pyc", "*.pyo", ".mypy_cache")


### PR DESCRIPTION
This PR aims to setup continuous integration (CI) for ixdat via [Github Actions[(https://docs.github.com/en/actions).

Github Actions is a framework for having certain actions done automatically on certain events. It is heavily used for CI, but it is by no means exclusive to that. It is e.g. possible to setup actions to e.g. make releases triggered by a tag, or to do certain things when PRs are opened, like having a bot comment if the CI fails or similar. But for now I setup just the CI. The CI checks the same items as `invoke checks` does, which now is:

- That the tests pass
- That code and tests passes flake8
- That code, tests and development scripts are black formatted

The checking of black formatted code was added in this PR along with another task for black formatting everything.