### PR TITLE
change removebackground to remove_background to avoid TypeError in pl…

### DIFF
--- a/src/ixdat/plotters/ms_plotter.py
+++ b/src/ixdat/plotters/ms_plotter.py
@@ -242,7 +242,7 @@ class MSPlotter(MPLPlotter):
                     v_name,
                     tspan=tspan,
                     tspan_bg=tspan_bg,
-                    removebackground=removebackground,
+                    remove_background=removebackground,
                     include_endpoints=False,
                 )
             if logplot:


### PR DESCRIPTION
TypeError when running ms_plotter.plot_vs()  

apparently plot_vs uses "removebackground" and grab_flux uses "remove_background".

I guess it is to preserve backwards compatibility not to change the name of the input in plot_vs and in ecms_plotter line 217 

I cannot find other places where removebackground is used instead of remove_background.
[https://github.com/ixdat/ixdat/search?q=removebackground](url)