### PR TITLE
regular expression in "unit":" / [(.+)]" searched for '('  '.'  '+'   ')'.

### DIFF
--- a/src/ixdat/readers/ixdat_csv.py
+++ b/src/ixdat/readers/ixdat_csv.py
@@ -18,7 +18,7 @@ regular_expressions = {
     "backend_name": r"backend_name = (\w+)",
     "id": r"id = ([0-9]+)",
     "timecol": r"timecol '(.+)' for: (?:'(.+)')$",
-    "unit": r"/ [(.+)]",
+    "unit": r"/ \[(.+)\]",
     "aux_file": r"'(.*)' in file: '(.*)'",
 }
 


### PR DESCRIPTION
I Changed to / \[(.+)\] to search for '/ [' and make a group of what ever comes after. Not sure if '\]' is nessecary for the expression to work but I kept it for consistency

If this was meant to search for "/ (" and not make a group, then just discard this pull request and sorry. 
