### PR TITLE
fix export bug

### DIFF
--- a/NEXT_CHANGES.rst
+++ b/NEXT_CHANGES.rst
@@ -11,3 +11,38 @@ links to relevant Issues, Discussions, and PR's on github with the following for
 `Issue #XX <https://github.com/ixdat/ixdat/issues/XX>`_
 
 `PR #XX <https://github.com/ixdat/ixdat/pulls/XX>`_
+
+
+Debugging for 0.2.1
+-------------------
+
+Will add the following when we finish debugging (will be 0.2.1 then). But some will go
+in the 0.2.0 section of CHANGES.rst as indicated:
+
+API changes
+...........
+
+techniques
+^^^^^^^^^^
+- Lookups instead of properties (as of 0.2.0)
+
+  - ``my_ec_meas["raw_potential"]`` replaces ``ECMeasurement.raw_potential``
+  - ``my_ec_meas["raw_currents"]`` replaces ``ECMeasurement.raw_potential``
+  - ``my_cv["scan_rate"]`` replaces ``CyclicVoltammogram.scan_rate``
+
+  The old properties are deprecated.
+
+- ``ECMSCyclicVoltammogram.diff_with()`` raises a ``NotImplementedError`` rather than
+  an obscure error message. (as of 0.2.1)
+
+- ``ECMSPlotter.plot_vs_potential`` can accept ``color`` as a keyword argument. This
+  colors both the U-J curve in the lower panel and all the signals in the top panel,
+  so best to use with together with a ``mass_list`` or ``mol_list`` of length 1. (as of 0.2.1)
+
+
+Debugging
+.........
+
+- ``ECMSExporter`` works as of 0.2.1 (it had been broken in 0.2.0).
+
+  This solves `Issue #56 <https://github.com/ixdat/ixdat/issues/56>`_

--- a/development_scripts/append_ec_files.py
+++ b/development_scripts/append_ec_files.py
@@ -47,7 +47,7 @@ combined_meas.tstamp += t_start
 combined_meas.plot(tspan=tspan)
 
 cut_meas = combined_meas.cut(tspan=tspan)
-cut_meas.plot(j_name="selector")
+cut_meas.plot(J_name="selector")
 
 select_meas = cut_meas.select_values(selector=range(4, 8))
 select_meas.correct_ohmic_drop(R_Ohm=200)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-black==22.1.0
+black==22.3.0
 pytest==7.1.0;python_version>'3.6'
 pytest==7.0.1;python_version=='3.6'
 Sphinx

--- a/src/ixdat/exporters/ec_exporter.py
+++ b/src/ixdat/exporters/ec_exporter.py
@@ -8,17 +8,23 @@ class ECExporter(CSVExporter):
     def default_export_columns(self):
         """The default v_list for ECExporter is V_str, J_str, and sel_str"""
         return [
-            # self.measurement.t_name,
+            # self.measurement.t_name,  # gets included automatically.
             self.measurement.U_name,
             self.measurement.J_name,
             self.measurement.selector_name,
         ]
 
     @property
-    def aliases(self):
-        return {
-            "t": (self.measurement.t_name,),
-            "raw_potential": (self.measurement.U_name,),
-            "raw_current": (self.measurement.J_name,),
-            "selector": (self.measurement.selector_name,),
-        }
+    def aliases(self):  # TODO: Figure out if this can be deleted.
+        """Ensure that the essential series are accessible as aliases."""
+        aliases = self.measurement.aliases.copy()
+        for name, prop_name in [
+            ("t", "t_name"),
+            ("raw_potential", "E_name"),
+            ("raw_current", "I_name"),
+            ("selector", "selector_name"),
+        ]:
+            name_in_measurement = getattr(self.measurement, prop_name)
+            if name not in aliases and name_in_measurement != name:
+                aliases[name] = (name_in_measurement,)
+        return aliases

--- a/src/ixdat/exporters/ecms_exporter.py
+++ b/src/ixdat/exporters/ecms_exporter.py
@@ -1,15 +1,14 @@
-from .csv_exporter import CSVExporter
 from .ec_exporter import ECExporter
 
 
-class ECMSExporter(CSVExporter):
+class ECMSExporter(ECExporter):
     """A CSVExporter that by default exports potential, current, selector, and all MID"""
 
     @property
     def default_export_columns(self):
         """The default v_list for ECExporter is V_str, J_str, and sel_str"""
         v_list = (
-            ECExporter(measurement=self.measurement).default_v_list
+            ECExporter(measurement=self.measurement).default_export_columns
             + self.measurement.mass_list
         )
 
@@ -26,9 +25,9 @@ class ECMSExporter(CSVExporter):
     ):
         if not v_list:
             if mass_list:
-                v_list = ECExporter(measurement=self.measurement).default_v_list
+                v_list = ECExporter(measurement=self.measurement).default_export_columns
             else:
-                v_list = self.default_v_list
+                v_list = self.default_export_columns
         if mass_list:
             v_list += mass_list
         if mol_list:

--- a/src/ixdat/plotters/ec_plotter.py
+++ b/src/ixdat/plotters/ec_plotter.py
@@ -71,11 +71,8 @@ class ECPlotter(MPLPlotter):
         U_color = U_color or V_color
 
         # apply defaults.
-        U_name = U_name or measurement.potential.name
-        J_name = J_name or measurement.current.name
-        # FIXME: We need a better solution for V_str and J_str that involves the
-        #   Calibration and is generalizable. see:
-        #   https://github.com/ixdat/ixdat/pull/11#discussion_r679290123
+        U_name = U_name or measurement.U_name
+        J_name = J_name or measurement.J_name
         U_color = U_color or "k"
         J_color = J_color or "r"
 
@@ -138,14 +135,8 @@ class ECPlotter(MPLPlotter):
         """
 
         measurement = measurement or self.measurement
-        U_name = U_name or (
-            measurement.U_name
-            if measurement.RE_vs_RHE is not None
-            else measurement.E_name
-        )
-        J_name = J_name or (
-            measurement.J_name if measurement.A_el is not None else measurement.I_name
-        )
+        U_name = U_name or measurement.U_name
+        J_name = J_name or measurement.J_name
         t_v, v = measurement.grab(U_name, tspan=tspan)
         t_j, j = measurement.grab(J_name, tspan=tspan)
 

--- a/src/ixdat/plotters/ms_plotter.py
+++ b/src/ixdat/plotters/ms_plotter.py
@@ -165,7 +165,7 @@ class MSPlotter(MPLPlotter):
         unit=None,
         logplot=True,
         legend=True,
-        **kwargs,
+        **plot_kwargs,
     ):
         """Plot m/z signal (MID) data against a specified variable and return the axis.
 
@@ -203,7 +203,7 @@ class MSPlotter(MPLPlotter):
                 background signals if available
             logplot (bool): Whether to plot the MS data on a log scale (default True)
             legend (bool): Whether to use a legend for the MS data (default True)
-            kwargs: key-word args are passed on to matplotlib's plot()
+            plot_kwargs: additional key-word args are passed on to matplotlib's plot()
         """
         measurement = measurement or self.measurement
         if remove_background is None:
@@ -248,12 +248,14 @@ class MSPlotter(MPLPlotter):
             if logplot:
                 v[v < MIN_SIGNAL] = MIN_SIGNAL
             x_mass = np.interp(t_v, t, x)
+            plot_kwargs_this_mass = plot_kwargs.copy()
+            if "color" not in plot_kwargs:
+                plot_kwargs_this_mass["color"] = STANDARD_COLORS.get(v_name, "k")
             ax.plot(
                 x_mass,
                 v * unit_factor,
-                color=STANDARD_COLORS.get(v_name, "k"),
                 label=v_name,
-                **kwargs,
+                **plot_kwargs_this_mass,
             )
         ax.set_ylabel(f"signal / [{unit}]")
         ax.set_xlabel(x_name)
@@ -269,7 +271,7 @@ class MSPlotter(MPLPlotter):
                 tspan_bg=specs_next_axis["tspan_bg"],
                 logplot=logplot,
                 legend=legend,
-                **kwargs,
+                **plot_kwargs,
             )
             axes = [ax, specs_next_axis["ax"]]
         else:

--- a/src/ixdat/techniques/cv.py
+++ b/src/ixdat/techniques/cv.py
@@ -239,7 +239,7 @@ class CyclicVoltammogram(ECMeasurement):
             res_points (int):  see :meth:`get_timed_sweeps`
         """
 
-        if self.__class__ is not CyclicVoltammogram:
+        if not type(self) is CyclicVoltammogram:
             raise NotImplementedError(
                 "CyclicVoltammogram.diff_with() is not implemented for "
                 f"cyclic voltammograms of type {type(self)}"

--- a/src/ixdat/techniques/cv.py
+++ b/src/ixdat/techniques/cv.py
@@ -170,6 +170,11 @@ class CyclicVoltammogram(ECMeasurement):
         )
         return scan_rate_series
 
+    @property
+    @deprecate("0.1", "Use a look-up, i.e. `ec_meas['scan_rate']`, instead.", "0.3")
+    def scan_rate(self):
+        return self["scan_rate"]
+
     def get_timed_sweeps(self, v_scan_res=5e-4, res_points=10):
         """Return list of [(tspan, type)] for all the potential sweeps in self.
 
@@ -233,6 +238,12 @@ class CyclicVoltammogram(ECMeasurement):
             v_scan_res (float): see :meth:`get_timed_sweeps`
             res_points (int):  see :meth:`get_timed_sweeps`
         """
+
+        if self.__class__ is not CyclicVoltammogram:
+            raise NotImplementedError(
+                "CyclicVoltammogram.diff_with() is not implemented for "
+                f"cyclic voltammograms of type {type(self)}"
+            )
 
         vseries = self.potential
         tseries = vseries.tseries

--- a/src/ixdat/techniques/ec.py
+++ b/src/ixdat/techniques/ec.py
@@ -152,15 +152,11 @@ class ECMeasurement(Measurement):
 
     @property
     def U_name(self):
-        if self.RE_vs_RHE is not None:
-            return EC_FANCY_NAMES["potential"]
-        return self.E_name
+        return self.potential.name
 
     @property
     def J_name(self):
-        if self.A_el is not None:
-            return EC_FANCY_NAMES["current"]
-        return self.I_name
+        return self.current.name
 
     @property
     @deprecate("0.1", "Use `E_name` instead.", "0.3")
@@ -186,7 +182,6 @@ class ECMeasurement(Measurement):
     def aliases(self):
         """A dictionary with the names of other data series a given name can refer to"""
         a = super().aliases.copy()
-        a.update({value: [key] for (key, value) in EC_FANCY_NAMES.items()})
         return a
 
     @property
@@ -372,7 +367,7 @@ class ECCalibration(Calibration):
             U = raw_potential.data
             if self.RE_vs_RHE:
                 U = U + self.RE_vs_RHE
-                name = measurement.U_name or EC_FANCY_NAMES["potential"]
+                name = EC_FANCY_NAMES["potential"]
             if self.R_Ohm:
                 I_mA = measurement.grab_for_t("raw_current", t=raw_potential.t)
                 U = U - self.R_Ohm * I_mA * 1e-3  # [V] = [Ohm*mA*(A/mA)]
@@ -390,7 +385,7 @@ class ECCalibration(Calibration):
             J = raw_current.data
             if self.A_el:
                 J = J / self.A_el
-                name = measurement.J_name or EC_FANCY_NAMES["current"]
+                name = EC_FANCY_NAMES["current"]
             return ValueSeries(
                 name=name,
                 unit_name=raw_current.unit_name,

--- a/src/ixdat/techniques/ec.py
+++ b/src/ixdat/techniques/ec.py
@@ -269,12 +269,12 @@ class ECMeasurement(Measurement):
         return self["current"]
 
     @property
-    @deprecate("0.1", "Use a look-up, i.e. `ec_meas['raw_potential'], instead.", "0.3")
+    @deprecate("0.1", "Use a look-up, i.e. `ec_meas['raw_potential']`, instead.", "0.3")
     def raw_potential(self):
         return self["raw_potential"]
 
     @property
-    @deprecate("0.1", "Use a look-up, i.e. `ec_meas['raw_current'], instead.", "0.3")
+    @deprecate("0.1", "Use a look-up, i.e. `ec_meas['raw_current']`, instead.", "0.3")
     def raw_current(self):
         return self["raw_current"]
 


### PR DESCRIPTION
This PR does the following:

- fixes `ECMSExporter`, which was broken by The Big Merge (#30)
- Has `ECMSCyclicVoltammogram.diff_with()` raise a `NotImplementedError`
- adds a deprecated `ECMSMeasurement.scan_rate` property so scripts that used this property in v0.1.x don't break 
- adds these and a few missing things to NEXT_CHANGES.rst

I think when done with the round of debugging started here, we should distribute an ixdat v0.2.1.