### PR TITLE
Bump black version to avoid broken click dependency

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-black==22.1.0
+black==22.3.0
 pytest==7.1.0;python_version>'3.6'
 pytest==7.0.1;python_version=='3.6'
 Sphinx


### PR DESCRIPTION
As per the explanation here: https://github.com/psf/black/issues/2964 there is an issue in black 22.1.0 with regards to one of its dependencies click. This PR fixes that by bumping the black dependency version to 22.3.0.

It has the tested that the version bump does not result in any format changes, so it is a trivial change.