### PR TITLE
start on proper database table definitions

### DIFF
--- a/src/ixdat/data_series.py
+++ b/src/ixdat/data_series.py
@@ -82,7 +82,11 @@ class TimeSeries(DataSeries):
     # ------ table defining class attributes -------- #
     table_name = "tseries"  # the tseries table will just contain id's and tstamps.
     parent_table_class = DataSeries  # The pk is DataSeries.id
-    columns = [Column("tstamp", float)]  # this gets "appended" to DataSeries.columns
+    columns = [
+        Column("data_series_id", int, "id", foreign_key=("data_series", "id")),
+        Column("tstamp", float)  # this gets "appended" to DataSeries.columns
+    ]
+    primary_key = "data_series_id"
 
     # ---- other class attributes --------- #
     series_type = "time_series"

--- a/src/ixdat/data_series.py
+++ b/src/ixdat/data_series.py
@@ -216,6 +216,7 @@ class ValueSeries(Field):
     Characterized by a reference to the corresponding time series. This reference is
     represented in relational databases as a row in an auxiliary linker table
     """
+
     # ------ table defining class attributes -------- #
     # Note, nothing needs be added to the database representation.
 
@@ -279,6 +280,7 @@ class ValueSeries(Field):
 
 class ConstantValue(ValueSeries):
     """This is a stand-in for a VSeries for when we know the value is constant"""
+
     # ------ table defining class attributes -------- #
     # Note, nothing needs be added to the database representation.
 

--- a/src/ixdat/data_series.py
+++ b/src/ixdat/data_series.py
@@ -10,6 +10,7 @@ import numpy as np
 from .db import Saveable
 from .units import Unit
 from .exceptions import AxisError, BuildError
+from .db import Column, OwnedObjectList
 
 
 class DataSeries(Saveable):
@@ -19,8 +20,14 @@ class DataSeries(Saveable):
     """
 
     table_name = "data_series"
-    column_attrs = {"name", "unit_name", "data", "series_type"}
-    series_type = "series"
+    columns = [
+        Column("id", int),
+        Column("name", str),
+        Column("unit_name", str),
+        Column("data", np.ndarray),
+        Column("series_type", str),  # faster than e.g. looking for the id in "tseries"
+    ]
+    series_type = "data_series"
 
     def __init__(self, name, unit_name, data):
         """initialize a data series with its name, unit, and data (id handled by parent)
@@ -69,8 +76,10 @@ class DataSeries(Saveable):
 class TimeSeries(DataSeries):
     """Class to store time data. These are characterized by having a tstamp"""
 
-    extra_column_attrs = {"tstamps": {"tstamp"}}
-    series_type = "tseries"
+    table_name = "tseries"  # the tseries table will just contain id's and tstamps.
+    parent_table_class = DataSeries  # The pk is DataSeries.id
+    columns = [Column("tstamp", float)]  # this gets "appended" to DataSeries.columns
+    series_type = "time_series"
 
     def __init__(self, name, unit_name, data, tstamp):
         """Initiate a TimeSeries with name, unit_name, data, and a tstamp (float)
@@ -98,8 +107,8 @@ class Field(DataSeries):
     DataSeries. This is represented in the extra linkers.
     """
 
-    extra_linkers = {"field_axes": ("data_series", "a_ids")}
-    child_attrs = ["axes_series"]
+    parent_table_class = DataSeries
+    owned_object_lists = [OwnedObjectList("axes_series", "data_series", "axes_series")]
     series_type = "field"
 
     def __init__(self, name, unit_name, data, a_ids=None, axes_series=None):
@@ -196,7 +205,8 @@ class ValueSeries(Field):
     represented in relational databases as a row in an auxiliary linker table
     """
 
-    series_type = "vseries"
+    # Note, nothing needs be added to the database representation.
+    series_type = "value_series"
 
     def __init__(
         self,
@@ -256,7 +266,7 @@ class ValueSeries(Field):
 class ConstantValue(ValueSeries):
     """This is a stand-in for a VSeries for when we know the value is constant"""
 
-    series_type = "constantvalue"
+    series_type = "constant_value"
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/src/ixdat/data_series.py
+++ b/src/ixdat/data_series.py
@@ -119,7 +119,15 @@ class Field(DataSeries):
 
     # ------ table defining class attributes -------- #
     parent_table_class = DataSeries
-    owned_object_lists = [OwnedObjectList("axes_series", "data_series", "axes_series")]
+    owned_object_lists = [
+        OwnedObjectList(
+            "axes_series",
+            "data_series",
+            "axes_series",
+            parent_object_id_column_name="field_series_id",
+            owned_object_id_column_name="axis_series_id",
+        ),
+    ]
     # explicitly coding that no new columns are added is necessary because otherwise
     # DataSeries' columns get duplicated in "full_column_list":
     columns = []

--- a/src/ixdat/data_series.py
+++ b/src/ixdat/data_series.py
@@ -84,7 +84,7 @@ class TimeSeries(DataSeries):
     parent_table_class = DataSeries  # The pk is DataSeries.id
     columns = [
         Column("data_series_id", int, "id", foreign_key=("data_series", "id")),
-        Column("tstamp", float)  # this gets "appended" to DataSeries.columns
+        Column("tstamp", float),  # this gets "appended" to DataSeries.columns
     ]
     primary_key = "data_series_id"
 

--- a/src/ixdat/data_series.py
+++ b/src/ixdat/data_series.py
@@ -19,6 +19,7 @@ class DataSeries(Saveable):
     These class's objects are saved and loaded as rows in the data_series table
     """
 
+    # ------ table defining class attributes -------- #
     table_name = "data_series"
     columns = [
         Column("id", int),
@@ -27,6 +28,8 @@ class DataSeries(Saveable):
         Column("data", np.ndarray),
         Column("series_type", str),  # faster than e.g. looking for the id in "tseries"
     ]
+
+    # ---- other class attributes --------- #
     series_type = "data_series"
 
     def __init__(self, name, unit_name, data):
@@ -76,9 +79,12 @@ class DataSeries(Saveable):
 class TimeSeries(DataSeries):
     """Class to store time data. These are characterized by having a tstamp"""
 
+    # ------ table defining class attributes -------- #
     table_name = "tseries"  # the tseries table will just contain id's and tstamps.
     parent_table_class = DataSeries  # The pk is DataSeries.id
     columns = [Column("tstamp", float)]  # this gets "appended" to DataSeries.columns
+
+    # ---- other class attributes --------- #
     series_type = "time_series"
 
     def __init__(self, name, unit_name, data, tstamp):
@@ -107,8 +113,14 @@ class Field(DataSeries):
     DataSeries. This is represented in the extra linkers.
     """
 
+    # ------ table defining class attributes -------- #
     parent_table_class = DataSeries
     owned_object_lists = [OwnedObjectList("axes_series", "data_series", "axes_series")]
+    # explicitly coding that no new columns are added is necessary because otherwise
+    # DataSeries' columns get duplicated in "full_column_list":
+    columns = []
+
+    # ---- other class attributes --------- #
     series_type = "field"
 
     def __init__(self, name, unit_name, data, a_ids=None, axes_series=None):
@@ -204,8 +216,10 @@ class ValueSeries(Field):
     Characterized by a reference to the corresponding time series. This reference is
     represented in relational databases as a row in an auxiliary linker table
     """
-
+    # ------ table defining class attributes -------- #
     # Note, nothing needs be added to the database representation.
+
+    # ---- other class attributes --------- #
     series_type = "value_series"
 
     def __init__(
@@ -265,7 +279,10 @@ class ValueSeries(Field):
 
 class ConstantValue(ValueSeries):
     """This is a stand-in for a VSeries for when we know the value is constant"""
+    # ------ table defining class attributes -------- #
+    # Note, nothing needs be added to the database representation.
 
+    # ---- other class attributes --------- #
     series_type = "constant_value"
 
     def __init__(self, *args, **kwargs):

--- a/src/ixdat/db.py
+++ b/src/ixdat/db.py
@@ -100,7 +100,13 @@ def get_database_name():
 class Column:
     """The metadata for an ixdat attribute corresponding to a database column"""
 
-    def __init__(self, name, ctype, attribute_name=None):
+    def __init__(
+            self,
+            name,
+            ctype,
+            attribute_name=None,
+            foreign_key=False,
+    ):
         """Initialize a database column representation.
 
         Args:
@@ -110,10 +116,14 @@ class Column:
                 int --> INTEGER, float --> REAL, str --> TEXT, dict --> BLOB
             attribute_name (str): The name of the attribute of the class, if different
                 from name.
+            foreign_key (tuple): Optional. If the column references a column of another
+                table, the foreign key should be specified as a tuple of
+                (table_name, column_name).
         """
         self.name = name
         self.ctype = ctype
         self.attribute_name = attribute_name or name
+        self.foriegn_key = foreign_key
 
     def __repr__(self):
         return f"Column(name={self.name}, ctype='{self.ctype}')"
@@ -258,7 +268,7 @@ class Saveable(metaclass=SaveableMetaClass):
     # overwritten
     owned_object_lists = []  # This can be overwritten in inheriting classes
     parent_table_class = None  # This can be overwritten in double-inheriting classes
-    principle_key = "id"  # This can be overwritten in inheriting classes
+    primary_key = "id"  # This can be overwritten in inheriting classes
 
     def __init__(self, backend=None, **self_as_dict):
         """Initialize a Saveable object from its dictionary serialization
@@ -319,7 +329,7 @@ class Saveable(metaclass=SaveableMetaClass):
 
     @property
     def id(self):
-        """The principle-key identifier. Set by backend or counted in memory."""
+        """The primary-key identifier. Set by backend or counted in memory."""
         if not self._id:
             if self.backend_type in ("none", "memory"):
                 self._id = self.backend.get_next_available_id(self.table_name, obj=self)

--- a/src/ixdat/db.py
+++ b/src/ixdat/db.py
@@ -152,6 +152,9 @@ class OwnedObjectList:
         self.owned_object_class = owned_object_table_name
         self.joining_table_name = joining_table_name
 
+    def __repr__(self):
+        return f"OwnedObjectList(list_name={self.list_name})"
+
 
 class Saveable:
     """Base class for table-representing classes implementing database functionality.
@@ -227,12 +230,22 @@ class Saveable:
         return f"{self.__class__.__name__}(id={self.id}, name='{self.name}')"
 
     @classmethod
-    def full_column_list(cls):
-        """If a class has a parent_table_class, the full column list is its"""
+    def full_columns(cls):
+        """A class's full columns list includes that of its parent table class"""
         if cls.parent_table_class:
-            return cls.parent_table_class.full_column_list() + cls.columns
+            return cls.parent_table_class.full_columns() + cls.columns
         else:
             return cls.columns
+
+    @classmethod
+    def full_owned_object_lists(cls):
+        """A class's full owned object lists includes those of its parent table class"""
+        if cls.parent_table_class:
+            return (
+                cls.parent_table_class.full_owned_object_lists() + cls.owned_object_lists
+            )
+        else:
+            return cls.owned_object_lists
 
     @property
     def id(self):

--- a/src/ixdat/db.py
+++ b/src/ixdat/db.py
@@ -244,7 +244,8 @@ class Saveable(metaclass=SaveableMetaClass):
 
     db = DB
     table_name = None  # This MUST be overwritten in inheriting classes
-    columns = [Column("id", int), ("name", str)]  # This should probably be overwritten
+    columns = [Column("id", int), Column("name", str)]  # This should probably be
+    # overwritten
     owned_object_lists = []  # This can be overwritten in inheriting classes
     parent_table_class = None  # This can be overwritten in double-inheriting classes
     principle_key = "id"  # This can be overwritten in inheriting classes

--- a/src/ixdat/db.py
+++ b/src/ixdat/db.py
@@ -101,11 +101,11 @@ class Column:
     """The metadata for an ixdat attribute corresponding to a database column"""
 
     def __init__(
-            self,
-            name,
-            ctype,
-            attribute_name=None,
-            foreign_key=False,
+        self,
+        name,
+        ctype,
+        attribute_name=None,
+        foreign_key=False,
     ):
         """Initialize a database column representation.
 
@@ -141,12 +141,12 @@ class Column:
 
 class OwnedObjectList:
     def __init__(
-            self,
-            list_name,
-            owned_object_table_name,
-            joining_table_name,
-            parent_object_id_column_name=None,
-            owned_object_id_column_name=None,
+        self,
+        list_name,
+        owned_object_table_name,
+        joining_table_name,
+        parent_object_id_column_name=None,
+        owned_object_id_column_name=None,
     ):
         """Initialize an OwnedObjectList, representing a many-to-many relationship
 
@@ -189,7 +189,7 @@ class OwnedObjectList:
 
         Args:
             list_name (str): The name of the attribute that is a list of owned objects
-            owned_object_table_name (Saveable class): The type of the objects in that list
+            owned_object_table_name (Saveable class): The type of the objects in the list
             joining_table_name (str): The name to be given to the table of relations
                between the two classes (by convention this is the two corresponding
                table names separated by an underscore).
@@ -275,7 +275,8 @@ class Saveable(metaclass=SaveableMetaClass):
         parent_table_class (Saveable class): The class corresponding to the parent table.
             If given, the primary key of the parent table is a foreign key of this table,
             and the columns and owned_object_lists that make up the dictionary
-            representations of objects of this class include those of the parent table class.
+            representations of objects of this class include those of the parent table
+            class.
         principle_key (str): The name of the column which is the principle key.
 
     Object attributes:

--- a/src/ixdat/measurements.py
+++ b/src/ixdat/measurements.py
@@ -12,7 +12,7 @@ classes will be defined in the corresponding module in ./techniques/
 from pathlib import Path
 import json
 import numpy as np
-from .db import Saveable, PlaceHolderObject, fill_object_list
+from .db import Saveable, PlaceHolderObject, fill_object_list, Column, OwnedObjectList
 from .data_series import (
     DataSeries,
     TimeSeries,
@@ -33,23 +33,24 @@ from .tools import deprecate
 class Measurement(Saveable):
     """The Measurement class"""
 
-    # ------ table description class attributes --------
+    # ------ table description class attributes -------- #
     table_name = "measurement"
-    column_attrs = {
-        "name",
-        "technique",
-        "metadata",
-        "aliases",
-        "sample_name",
-        "tstamp",
-    }
-    extra_linkers = {
-        "component_measurements": ("measurements", "m_ids"),
-        "measurement_calibrations": ("calibrations", "c_ids"),
-        "measurement_series": ("data_series", "s_ids"),
-    }
-    child_attrs = ["component_measurements", "calibration_list", "series_list"]
-    # TODO: child_attrs should be derivable from extra_linkers?
+    columns = [
+        Column("id", int),
+        Column("name", str),
+        Column("technique", str),
+        Column("metadatata", dict),
+        Column("aliases", dict),
+        Column("sample_name", str),
+        Column("tstamp", float),
+    ]
+    owned_object_lists = [
+        OwnedObjectList(
+            "component_measurements", "measurement", "component_measurements"
+        ),
+        OwnedObjectList("calibration_list", "calibration", "measurement_calibrations"),
+        OwnedObjectList("series_list", "data_series", "measurement_series"),
+    ]
 
     # ---- measurement class attributes, can be overwritten in inheriting classes ---- #
     control_technique_name = None
@@ -1292,12 +1293,13 @@ class Measurement(Saveable):
 class Calibration(Saveable):
     """Base class for calibrations."""
 
-    table_name = "calibration"
-    column_attrs = {
-        "name",
-        "technique",
-        "tstamp",
-    }
+    table_name = "calibrations"
+    columns = [
+        Column("id", int),
+        Column("name", str),
+        Column("technique", str),
+        Column("tstamp", float),
+    ]
 
     def __init__(self, *, name=None, technique=None, tstamp=None, measurement=None):
         """Initiate a Calibration

--- a/src/ixdat/measurements.py
+++ b/src/ixdat/measurements.py
@@ -34,7 +34,7 @@ class Measurement(Saveable):
     """The Measurement class"""
 
     # ------ table description class attributes -------- #
-    table_name = "measurement"
+    table_name = "measurements"
     columns = [
         Column("id", int),
         Column("name", str),
@@ -46,9 +46,9 @@ class Measurement(Saveable):
     ]
     owned_object_lists = [
         OwnedObjectList(
-            "component_measurements", "measurement", "component_measurements"
+            "component_measurements", "measurements", "component_measurements"
         ),
-        OwnedObjectList("calibration_list", "calibration", "measurement_calibrations"),
+        OwnedObjectList("calibration_list", "calibrations", "measurement_calibrations"),
         OwnedObjectList("series_list", "data_series", "measurement_series"),
     ]
 

--- a/src/ixdat/measurements.py
+++ b/src/ixdat/measurements.py
@@ -46,10 +46,19 @@ class Measurement(Saveable):
     ]
     owned_object_lists = [
         OwnedObjectList(
-            "component_measurements", "measurements", "component_measurements"
+            "component_measurements",  # owned object attribute name
+            "measurements",  # owned object table name
+            "component_measurements",  # linker table name
+            parent_object_id_column_name="combined_measurement_id",
+            owned_object_id_column_name="component_measurement_id",
         ),
         OwnedObjectList("calibration_list", "calibrations", "measurement_calibrations"),
-        OwnedObjectList("series_list", "data_series", "measurement_series"),
+        OwnedObjectList(
+            "series_list",
+            "data_series",
+            "measurement_series",
+            owned_object_id_column_name="data_series_id",  # avoid "data_serie_id" (sic)
+        ),
     ]
 
     # ---- measurement class attributes, can be overwritten in inheriting classes ---- #

--- a/src/ixdat/projects/lablogs.py
+++ b/src/ixdat/projects/lablogs.py
@@ -4,6 +4,8 @@ from ixdat.db import Saveable
 class LabLog(Saveable):
     """TODO: flush out this class"""
 
+    _SKIP_IN_TABLE_SCAN = True
+
     table_name = "lablog"
     column_attrs = {"name": "name"}
 

--- a/src/ixdat/projects/samples.py
+++ b/src/ixdat/projects/samples.py
@@ -6,6 +6,8 @@ from ixdat.db import Saveable
 class Sample(Saveable):
     """TODO: flush out this class"""
 
+    _SKIP_IN_TABLE_SCAN = True
+
     table_name = "sample"
     column_attrs = {"name": "name"}
 

--- a/src/ixdat/spectra.py
+++ b/src/ixdat/spectra.py
@@ -24,6 +24,8 @@ class Spectrum(Saveable):
     while spec.xseries and spec.yseries give the corresponding DataSeries.
     """
 
+    _SKIP_IN_TABLE_SCAN = True
+
     table_name = "spectrum"
     column_attrs = {
         "name",
@@ -270,6 +272,8 @@ class SpectrumSeries(Spectrum):
     spec is a spectrum series, spec.x is the x data with shape (N, ), spec.t is the
     time data with shape (M, ), and spec.y is the spectrum data with shape (M, N).
     """
+
+    _SKIP_IN_TABLE_SCAN = True
 
     def __init__(self, *args, **kwargs):
         """Initiate a spectrum series

--- a/src/ixdat/techniques/cv.py
+++ b/src/ixdat/techniques/cv.py
@@ -340,6 +340,8 @@ class CyclicVoltammogram(ECMeasurement):
 
 class CyclicVoltammagram(CyclicVoltammogram):
 
+    _SKIP_IN_TABLE_SCAN = True
+
     # FIXME: decorating the class itself doesn't work because the callable returned
     #   by the decorator does not have the class methods. But this works fine.
     @deprecate("0.1", "Use `CyclicVoltammogram` instead ('o' replaces 'a').", "0.3")

--- a/src/ixdat/techniques/ec.py
+++ b/src/ixdat/techniques/ec.py
@@ -92,7 +92,7 @@ class ECMeasurement(Measurement):
     parent_table_class = Measurement
     columns = [
         Column("measurement_id", int, "id", foreign_key=("measurements", "id")),
-        Column("ec_technique", str)
+        Column("ec_technique", str),
     ]
     owned_object_lists = []  # no additional owned objects
 

--- a/src/ixdat/techniques/ec.py
+++ b/src/ixdat/techniques/ec.py
@@ -90,6 +90,7 @@ class ECMeasurement(Measurement):
     # ------ table description class attributes -------- #
     parent_table_class = Measurement
     columns = [Column("ec_technique", str)]
+    owned_object_lists = []  # no additional owned objects
 
     # ---- other class attributes ---- #
     control_series_name = "raw_potential"

--- a/src/ixdat/techniques/ec.py
+++ b/src/ixdat/techniques/ec.py
@@ -88,6 +88,7 @@ class ECMeasurement(Measurement):
     """
 
     # ------ table description class attributes -------- #
+    table_name = "ec_measurements"
     parent_table_class = Measurement
     columns = [Column("ec_technique", str)]
     owned_object_lists = []  # no additional owned objects

--- a/src/ixdat/techniques/ec.py
+++ b/src/ixdat/techniques/ec.py
@@ -90,7 +90,10 @@ class ECMeasurement(Measurement):
     # ------ table description class attributes -------- #
     table_name = "ec_measurements"
     parent_table_class = Measurement
-    columns = [Column("ec_technique", str)]
+    columns = [
+        Column("measurement_id", int, "id", foreign_key=("measurements", "id")),
+        Column("ec_technique", str)
+    ]
     owned_object_lists = []  # no additional owned objects
 
     # ---- other class attributes ---- #
@@ -311,6 +314,7 @@ class ECCalibration(Calibration):
     table_name = "ec_calibrations"
     parent_table_class = Calibration
     columns = [
+        Column("calibration_id", int, "id", foreign_key=("calibrations", "id")),
         Column("RE_vs_RHE", float),
         Column("A_el", float),
         Column("R_Ohm", float),

--- a/src/ixdat/techniques/ec.py
+++ b/src/ixdat/techniques/ec.py
@@ -1,6 +1,7 @@
 """Module for representation and analysis of EC measurements"""
 
 from ..measurements import Measurement, Calibration
+from ..db import Column
 from ..data_series import ValueSeries
 from ..exporters.ec_exporter import ECExporter
 from ..plotters.ec_plotter import ECPlotter
@@ -86,11 +87,11 @@ class ECMeasurement(Measurement):
     such as `CyclicVoltammogram`.
     """
 
-    extra_column_attrs = {
-        "ec_meaurements": {
-            "ec_technique",
-        }
-    }
+    # ------ table description class attributes -------- #
+    parent_table_class = Measurement
+    columns = [Column("ec_technique", str)]
+
+    # ---- other class attributes ---- #
     control_series_name = "raw_potential"
     essential_series_names = ("t", "raw_potential", "raw_current")
     selection_series_names = ("file_number", "loop_number", "cycle number", "Ns")
@@ -305,8 +306,13 @@ class ECMeasurement(Measurement):
 class ECCalibration(Calibration):
     """An electrochemical calibration with RE_vs_RHE, A_el, and/or R_Ohm"""
 
-    extra_column_attrs = {"ec_calibration": {"RE_vs_RHE", "A_el", "R_Ohm"}}
-    # TODO: https://github.com/ixdat/ixdat/pull/11#discussion_r677552828
+    table_name = "ec_calibrations"
+    parent_table_class = Calibration
+    columns = [
+        Column("RE_vs_RHE", float),
+        Column("A_el", float),
+        Column("R_Ohm", float),
+    ]
 
     def __init__(
         self,

--- a/src/ixdat/techniques/ec_ms.py
+++ b/src/ixdat/techniques/ec_ms.py
@@ -1,6 +1,7 @@
 """Module for representation and analysis of EC-MS measurements"""
 import numpy as np
 from ..constants import FARADAY_CONSTANT
+from ..db import Column, OwnedObjectList
 from .ec import ECMeasurement, ECCalibration
 from .ms import MSMeasurement, MSCalResult, MSCalibration
 from .cv import CyclicVoltammogram
@@ -12,13 +13,14 @@ from ..plotters.ms_plotter import STANDARD_COLORS
 class ECMSMeasurement(ECMeasurement, MSMeasurement):
     """Class for raw EC-MS functionality. Parents: ECMeasurement and MSMeasurement"""
 
-    extra_column_attrs = {
-        "ecms_meaurements": {"ec_technique", "tspan_bg"},
-    }
-    # FIXME: It would be much more elegant if this carried over automatically from
-    #  *both* parents, by appending the table columns...
-    #  We'll see how the problem changes with the metaprogramming work.
+    #  ----- table describing attributes --------- #
+    #  The parent_table_class, inherited from ECMeasurement, is still Measurement
+    table_name = "ecms_measurements"
+    columns = [
+        Column("ec_technique", str),  # note that ec_measurements has the same column
+    ]
 
+    # ---- other class attributes -------- #
     default_plotter = ECMSPlotter
     default_exporter = ECMSExporter
 
@@ -185,12 +187,21 @@ class ECMSCyclicVoltammogram(CyclicVoltammogram, ECMSMeasurement):
 class ECMSCalibration(ECCalibration, MSCalibration):
     """Class for calibrations useful for ECMSMeasurements"""
 
-    extra_column_attrs = {
-        "ecms_calibrations": {"date", "setup", "RE_vs_RHE", "A_el", "L"}
-    }
-    # FIXME: The above should be covered by the parent classes. Needs metaprogramming!
-    # NOTE: technique, name, and tstamp in column_attrs are inherited from Calibration
-    # NOTE: ms_results_ids in extra_linkers is inherited from MSCalibration.
+    table_name = "ecms_calibrations"
+    parent_table_class = ECCalibration
+    columns = [
+        # Column("RE_vs_RHE", float),  # already there from ECCalibration!
+        # Column("A_el", float),  # already there from ECCalibration!
+        # Column("R_Ohm", float)  # already there from ECCalibration!
+        Column("tspan_bg", tuple),  # same column is in MSCalibration...
+        Column("L", float),  # the working distance, special to ECMSCalibration.
+    ]
+    owned_object_lists = [
+        # Define a table with info on which ms_cal_results go with which calibration:
+        OwnedObjectList("ms_cal_results", "ms_cal_results", "calibration_ms_cal_results")
+    ]
+    # ^ This will be replaced with `owned_object_list = MSCalibration.owned_object_list`
+
     # NOTE: signal_bgs is left out
 
     def __init__(

--- a/src/ixdat/techniques/ec_ms.py
+++ b/src/ixdat/techniques/ec_ms.py
@@ -14,7 +14,7 @@ class ECMSMeasurement(ECMeasurement, MSMeasurement):
     """Class for raw EC-MS functionality. Parents: ECMeasurement and MSMeasurement"""
 
     #  ----- table describing attributes --------- #
-    parent_table_class = ECMeasurement
+    parent_table_class = (ECMeasurement, MSMeasurement)
     table_name = "ecms_measurements"
     columns = []  # no additional columns.
     owned_object_lists = []  # no additional owned objects
@@ -187,7 +187,7 @@ class ECMSCalibration(ECCalibration, MSCalibration):
     """Class for calibrations useful for ECMSMeasurements"""
 
     table_name = "ecms_calibrations"
-    parent_table_class = MSCalibration
+    parent_table_class = (ECCalibration, MSCalibration)
     # simpler to use MSCalibration as parent_table_class instead of ECCalibration to use
     #    its MSCalibration's owned_object_lists
     columns = [

--- a/src/ixdat/techniques/ec_ms.py
+++ b/src/ixdat/techniques/ec_ms.py
@@ -14,11 +14,10 @@ class ECMSMeasurement(ECMeasurement, MSMeasurement):
     """Class for raw EC-MS functionality. Parents: ECMeasurement and MSMeasurement"""
 
     #  ----- table describing attributes --------- #
-    #  The parent_table_class, inherited from ECMeasurement, is still Measurement
+    parent_table_class = ECMeasurement
     table_name = "ecms_measurements"
-    columns = [
-        Column("ec_technique", str),  # note that ec_measurements has the same column
-    ]
+    columns = []  # no additional columns.
+    owned_object_lists = []  # no additional owned objects
 
     # ---- other class attributes -------- #
     default_plotter = ECMSPlotter
@@ -188,21 +187,17 @@ class ECMSCalibration(ECCalibration, MSCalibration):
     """Class for calibrations useful for ECMSMeasurements"""
 
     table_name = "ecms_calibrations"
-    parent_table_class = ECCalibration
+    parent_table_class = MSCalibration
+    # simpler to use MSCalibration as parent_table_class instead of ECCalibration to use
+    #    its MSCalibration's owned_object_lists
     columns = [
-        # Column("RE_vs_RHE", float),  # already there from ECCalibration!
-        # Column("A_el", float),  # already there from ECCalibration!
-        # Column("R_Ohm", float)  # already there from ECCalibration!
-        Column("tspan_bg", tuple),  # same column is in MSCalibration...
+        Column("RE_vs_RHE", float),  # same column is in ECCalibration.
+        Column("A_el", float),  # same column is in ECCalibration.
+        Column("R_Ohm", float),  # same column is in ECCalibration.
+        # Column("signal_bgs", dict),  # already there from MSCalibration.
         Column("L", float),  # the working distance, special to ECMSCalibration.
     ]
-    owned_object_lists = [
-        # Define a table with info on which ms_cal_results go with which calibration:
-        OwnedObjectList("ms_cal_results", "ms_cal_results", "calibration_ms_cal_results")
-    ]
-    # ^ This will be replaced with `owned_object_list = MSCalibration.owned_object_list`
-
-    # NOTE: signal_bgs is left out
+    owned_object_lists = []  # no new owned objects, just the one from MSMeasurement
 
     def __init__(
         self,

--- a/src/ixdat/techniques/ec_ms.py
+++ b/src/ixdat/techniques/ec_ms.py
@@ -13,10 +13,12 @@ from ..plotters.ms_plotter import STANDARD_COLORS
 class ECMSMeasurement(ECMeasurement, MSMeasurement):
     """Class for raw EC-MS functionality. Parents: ECMeasurement and MSMeasurement"""
 
-    #  ----- table describing attributes --------- #
+    #  ----- table-describing class attributes --------- #
     parent_table_class = (ECMeasurement, MSMeasurement)
     table_name = "ecms_measurements"
-    columns = []  # no additional columns.
+    columns = [
+        Column("measurement_id", int, "id", foreign_key=("measurements", "id")),
+    ]
     owned_object_lists = []  # no additional owned objects
 
     # ---- other class attributes -------- #
@@ -188,13 +190,9 @@ class ECMSCalibration(ECCalibration, MSCalibration):
 
     table_name = "ecms_calibrations"
     parent_table_class = (ECCalibration, MSCalibration)
-    # simpler to use MSCalibration as parent_table_class instead of ECCalibration to use
-    #    its MSCalibration's owned_object_lists
     columns = [
-        Column("RE_vs_RHE", float),  # same column is in ECCalibration.
-        Column("A_el", float),  # same column is in ECCalibration.
-        Column("R_Ohm", float),  # same column is in ECCalibration.
-        # Column("signal_bgs", dict),  # already there from MSCalibration.
+        # All the columns from ECCalibration and MSCalibration are inherited
+        Column("calibration_id", int, "id", foreign_key=("calibrations", "id")),
         Column("L", float),  # the working distance, special to ECMSCalibration.
     ]
     owned_object_lists = []  # no new owned objects, just the one from MSMeasurement

--- a/src/ixdat/techniques/ec_ms.py
+++ b/src/ixdat/techniques/ec_ms.py
@@ -1,7 +1,7 @@
 """Module for representation and analysis of EC-MS measurements"""
 import numpy as np
 from ..constants import FARADAY_CONSTANT
-from ..db import Column, OwnedObjectList
+from ..db import Column
 from .ec import ECMeasurement, ECCalibration
 from .ms import MSMeasurement, MSCalResult, MSCalibration
 from .cv import CyclicVoltammogram

--- a/src/ixdat/techniques/ms.py
+++ b/src/ixdat/techniques/ms.py
@@ -28,7 +28,9 @@ class MSMeasurement(Measurement):
 
     parent_table_class = Measurement
     table_name = "ms_measurements"
-    columns = []
+    columns = [
+        Column("measurement_id", int, "id", foreign_key=("measurements", "id")),
+    ]
     owned_object_lists = []
 
     default_plotter = MSPlotter
@@ -308,7 +310,10 @@ class MSCalibration(Calibration):
 
     table_name = "ms_calibrations"
     parent_table_class = Calibration
-    columns = [Column("signal_bgs", dict)]
+    columns = [
+        Column("calibration_id", int, "id", foreign_key=("calibrations", "id")),
+        Column("signal_bgs", dict)
+    ]
     owned_object_lists = [
         OwnedObjectList("ms_cal_results", "ms_cal_results", "calibration_ms_cal_results")
     ]

--- a/src/ixdat/techniques/ms.py
+++ b/src/ixdat/techniques/ms.py
@@ -306,6 +306,7 @@ class MSCalResult(Saveable):
 class MSCalibration(Calibration):
     """Class for mass spec calibrations. TODO: replace with powerful external package"""
 
+    table_name = "ms_calibrations"
     parent_table_class = Calibration
     columns = [Column("signal_bgs", dict)]
     owned_object_lists = [

--- a/src/ixdat/techniques/ms.py
+++ b/src/ixdat/techniques/ms.py
@@ -312,7 +312,7 @@ class MSCalibration(Calibration):
     parent_table_class = Calibration
     columns = [
         Column("calibration_id", int, "id", foreign_key=("calibrations", "id")),
-        Column("signal_bgs", dict)
+        Column("signal_bgs", dict),
     ]
     owned_object_lists = [
         OwnedObjectList("ms_cal_results", "ms_cal_results", "calibration_ms_cal_results")
@@ -699,4 +699,5 @@ class MSSpectrum(Spectrum):
     TODO: Methods for co-plotting ref spectra from a database
     """
 
+    _SKIP_IN_TABLE_SCAN = True
     pass

--- a/src/ixdat/techniques/ms.py
+++ b/src/ixdat/techniques/ms.py
@@ -19,14 +19,18 @@ from ..constants import (
     MOLAR_MASSES,
 )
 from ..data_series import ValueSeries
-from ..db import Saveable
+from ..db import Saveable, Column, OwnedObjectList
 from ..tools import deprecate
 
 
 class MSMeasurement(Measurement):
     """Class implementing raw MS functionality"""
 
-    extra_column_attrs = {"ms_measurement": ("tspan_bg",)}
+    parent_table_class = Measurement
+    table_name = "ms_measurements"
+    columns = []
+    owned_object_lists = []
+
     default_plotter = MSPlotter
 
     def __init__(self, name, **kwargs):
@@ -264,7 +268,14 @@ class MSCalResult(Saveable):
     """
 
     table_name = "ms_cal_results"
-    column_attrs = {"name", "mol", "mass", "cal_type", "F"}
+    columns = [
+        Column("id", int),
+        Column("name", str),
+        Column("mol", str),
+        Column("mass", str),
+        Column("cal_type", str),
+        Column("F", float),
+    ]
 
     def __init__(
         self,
@@ -295,11 +306,10 @@ class MSCalResult(Saveable):
 class MSCalibration(Calibration):
     """Class for mass spec calibrations. TODO: replace with powerful external package"""
 
-    extra_linkers = {"ms_calibration_results": ("ms_cal_results", "ms_cal_result_ids")}
-    # FIXME: signal_bgs are not saved at present. Should they be a separate table
-    #   of Saveable objects like ms_cal_results or should they be a single json value?
-    child_attrs = [
-        "ms_cal_results",
+    parent_table_class = Calibration
+    columns = [Column("signal_bgs", dict)]
+    owned_object_lists = [
+        OwnedObjectList("ms_cal_results", "ms_cal_results", "calibration_ms_cal_results")
     ]
 
     def __init__(

--- a/tools/generate_db_schema.py
+++ b/tools/generate_db_schema.py
@@ -1,0 +1,219 @@
+from collections import defaultdict
+from pprint import pprint, pformat
+
+import numpy as np
+import pyperclip
+
+from ixdat import db
+from ixdat.db import Saveable
+
+
+def collect_db_classes(*, verbose=False):
+    """Return all DB table defining classes
+
+    Args:
+        verbose (bool): The to print information out about the collected information
+
+    Returns:
+        list(cls), set((str, OwnedObjectList)): Returns data for the primary tables
+        and linker tables. The primary tables is returned as a list of the classes
+        that define them and the linker tables as a tuple of
+        (class_that_owns_the_owned_object_list, owned_object_list).
+
+    """
+    # Collect classes that map to the same DB table
+    table_to_class_mapping = defaultdict(list)
+    for cls in db.ALL_SAVABLE_CLASSES:
+        table_to_class_mapping[cls.table_name].append(cls)
+
+    primary_table_classes = _extract_primary_classes(
+        table_to_class_mapping, verbose=verbose
+    )
+    linker_tables = _extract_linker_tables(primary_table_classes, verbose=verbose)
+    return primary_table_classes, linker_tables
+
+
+def _extract_primary_classes(table_to_class_mapping, *, verbose=False):
+    """Return the set of primary classes from all Saveable classes, formed from the
+    `table_name -> [class]` mapping in `table_to_class_mapping`
+
+    """
+    # Collect the table that actually defines the table, which is the highest class in
+    # terms of inheritance (super) of the list of class that all map to the same table
+    primary_table_classes = set()
+    for table_name, classes in table_to_class_mapping.items():
+        top_class = None
+        for cls in classes:
+            if not top_class:
+                top_class = cls
+            else:
+                if cls in top_class.__mro__:
+                    top_class = cls
+        primary_table_classes.add(top_class)
+
+        if verbose:
+            print("")
+            print(f"Table --- {top_class.table_name} ---")
+            print(
+                f"Defined by {top_class.__name__}(Parent table class: "
+                f""
+                # top_class.parent_table_class may be None
+                f"{getattr(top_class.parent_table_class, '__name__', None)})"
+            )
+
+            columns_lines = pformat(top_class.columns).split("\n")
+            print(f"Columns: {columns_lines[0]}")
+            for line in columns_lines[1:]:
+                print("        ", line)
+            if len(classes) > 1:
+                print("Derived, non-table inducing, sub-classes:")
+                for cls in classes:
+                    if cls is top_class:
+                        continue
+                    print("  ", cls.__name__)
+
+    # Sort the primary tables by their distance to Saveable (in terms of inheritance),
+    # and then by name, to make sure that tables that are higher on the inheritance
+    # chain are generated first
+    sorted_primary_table_classes = sorted(
+        primary_table_classes,
+        key=lambda cls_: (cls_.__mro__.index(Saveable), cls_.__name__),
+    )
+
+    return sorted_primary_table_classes
+
+
+def _extract_linker_tables(primary_table_classes, *, verbose=False):
+    """Return the linker tables defined in the set of `primary_table_classes`
+    as a set of (source_class, OwnedObjectList) pairs
+
+    """
+    linker_tables = set()  # Of (OwningClass, OwnedObjectList)
+    for cls in primary_table_classes:
+        for owned_object_list in cls.owned_object_lists:
+            linker_tables.add((cls, owned_object_list))
+
+    if verbose:
+        print("\nLinker tables:")
+        for source_class, owned_object_list in linker_tables:
+            print(f"{source_class.__name__: <20} --->", owned_object_list)
+
+    return linker_tables
+
+
+# Type translation for BDML
+_type_translation = {
+    int: "INTEGER",
+    str: "TEXT",
+    float: "REAL",
+    np.ndarray: "BLOB",
+    dict: "JSON",
+}
+_id_type = _type_translation[int]
+
+
+def generate_dbdiagramio_DBML(primary_table_classes, linker_tables):
+    """Generate DB schema source code for dbdiagram.io"""
+    schema, table_name_to_id_column_name = _generate_DBML_for_primary_tables(
+        primary_table_classes
+    )
+
+    schema += _generate_DBML_for_linker_tables(
+        linker_tables, primary_table_classes, table_name_to_id_column_name
+    )
+
+    return schema
+
+
+def _generate_DBML_for_primary_tables(primary_table_classes):
+    """Return DBML for primary tables and table_name -> id_column_name mapping"""
+    schema = ""
+    # Generate schema for primary classes
+    table_name_to_id_column_name = {}
+    for cls in primary_table_classes:
+        if "ecms" in cls.table_name:  # Broken, so skip for now
+            continue
+
+        schema += f"table {cls.table_name}{{\n"
+        # If the class has a `parent_table_class`, then it is an expansion of a parent
+        # class and the id from the parent class is re-used
+        if cls.parent_table_class:
+            id_column_name = f"{cls.parent_table_class.table_name.rstrip('s')}_id"
+            table_name_to_id_column_name[cls.table_name] = id_column_name
+            schema += (
+                f"  {id_column_name} {_id_type} "
+                f"[pk, ref: - {cls.parent_table_class.table_name}.id]\n"
+            )
+        else:
+            table_name_to_id_column_name[cls.table_name] = "id"
+
+        for column in cls.columns:
+            schema += f"  {column.name} {_type_translation[column.ctype]}"
+            if column.name == "id":
+                schema += " [pk, increment]\n"
+            else:
+                schema += "\n"
+        schema += "}\n\n"
+
+    return schema, table_name_to_id_column_name
+
+
+def _generate_DBML_for_linker_tables(
+    linker_tables, primary_table_classes, table_name_to_id_column_name
+):
+    """Return DBML for `linker_tables`, using also the set of `primary_table_classes` and
+    the table_name -> id_column_name mapping
+
+    """
+    schema = ""
+    # Generate schema for linker tables
+    table_name_to_primary_class = {cls.table_name: cls for cls in primary_table_classes}
+    for parent_class, owned_object_list in linker_tables:
+        # Broken, so skip for now
+        if "component" in owned_object_list.joining_table_name:
+            continue
+
+        # Owner foreign key
+        schema += f"table {owned_object_list.joining_table_name}{{\n"
+
+        def link(cls_):
+            """Return column DBML for link class"""
+            # Determin the name of the column the foreign key points to
+            foreign_key_column_name = table_name_to_id_column_name[cls_.table_name]
+            if foreign_key_column_name == "id":
+                column_name = cls_.table_name.rstrip("s") + "_id"
+            else:
+                column_name = foreign_key_column_name
+
+            # Generate link text on the form:
+            #   calibration_id INTEGER [pk, ref: > ms_calibrations.calibration_id]
+            link_text = (
+                f"  {column_name} {_id_type} [pk, ref: > "
+                f"{cls_.table_name}.{foreign_key_column_name}]\n"
+            )
+            return link_text
+
+        # Generate columns for the two foreign keys in a linker class e.g:
+        #   calibration_id INTEGER [pk, ref: > ms_calibrations.calibration_id]
+        #   ms_cal_result_id INTEGER [pk, ref: > ms_cal_results.id]
+        owned_cls = table_name_to_primary_class[owned_object_list.owned_object_class]
+        for cls in (parent_class, owned_cls):
+            schema += link(cls)
+        schema += "}\n\n"
+
+    return schema
+
+
+def main():
+    """Generate all DB defining table information, convert to DBML and print and copy
+    to clipboard
+
+    """
+    primary_table_classes, linker_tables = collect_db_classes(verbose=False)
+    schema = generate_dbdiagramio_DBML(primary_table_classes, linker_tables)
+    pyperclip.copy(schema)
+    print(schema)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/generate_db_schema.py
+++ b/tools/generate_db_schema.py
@@ -140,8 +140,8 @@ def _generate_DBML_for_primary_tables(primary_table_classes):
             dbml_column_specs = []
             if column.name == cls.primary_key:
                 dbml_column_specs.append("pk")
-            if column.foriegn_key:
-                fk_table, fk_column = column.foriegn_key
+            if column.foreign_key:
+                fk_table, fk_column = column.foreign_key
                 dbml_column_specs.append(f"ref: - {fk_table}.{fk_column}")
 
             if dbml_column_specs:
@@ -201,4 +201,12 @@ def main():
 
 
 if __name__ == "__main__":
+
+    from ixdat.techniques.ec_ms import ECMSCalibration
+
+    cols = ECMSCalibration.get_full_columns()
+    print(cols)
+    owned = ECMSCalibration.get_full_owned_object_lists()
+    print(owned)
+
     main()

--- a/tools/generate_db_schema.py
+++ b/tools/generate_db_schema.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from pprint import pprint, pformat
+from pprint import pformat
 
 import numpy as np
 import pyperclip
@@ -121,9 +121,7 @@ _id_type = _type_translation[int]
 
 def generate_dbdiagramio_DBML(primary_table_classes, linker_tables):
     """Generate DB schema source code for dbdiagram.io"""
-    schema = _generate_DBML_for_primary_tables(
-        primary_table_classes
-    )
+    schema = _generate_DBML_for_primary_tables(primary_table_classes)
 
     schema += _generate_DBML_for_linker_tables(linker_tables)
 
@@ -134,7 +132,6 @@ def _generate_DBML_for_primary_tables(primary_table_classes):
     """Return DBML for primary tables and table_name -> id_column_name mapping"""
     schema = ""
     # Generate schema for primary classes
-    table_name_to_id_column_name = {}
     for cls in primary_table_classes:
         schema += f"table {cls.table_name}{{\n"
 
@@ -155,9 +152,7 @@ def _generate_DBML_for_primary_tables(primary_table_classes):
     return schema
 
 
-def _generate_DBML_for_linker_tables(
-    linker_tables
-):
+def _generate_DBML_for_linker_tables(linker_tables):
     """Return DBML for `linker_tables`, using also the set of `primary_table_classes` and
     the table_name -> id_column_name mapping
 

--- a/tools/generate_db_schema.py
+++ b/tools/generate_db_schema.py
@@ -173,7 +173,7 @@ def _generate_DBML_for_linker_tables(linker_tables):
             owned_object_list.parent_object_id_column_name
             or parent_table_name.rstrip("s") + "_id"
         )
-        parent_link = parent_id_column_name + " int [ref:> " + parent_table_name + ".id]"
+        parent_link = f"  {parent_id_column_name} int [ref:> {parent_table_name}.id]"
 
         # foreign key to the owned object table
         owned_table_name = owned_object_list.owned_object_table_name
@@ -181,10 +181,22 @@ def _generate_DBML_for_linker_tables(linker_tables):
             owned_object_list.owned_object_id_column_name
             or owned_table_name.rstrip("s") + "_id"
         )
-        owned_link = owned_id_column_name + " int [ref:> " + owned_table_name + ".id]"
+        owned_link = f"  {owned_id_column_name} int [ref:> {owned_table_name}.id]"
+
+        # order column
+        order_line = "  order int"
+
+        # primary key column
+        pk_lines = [
+            "  indexes {",
+            f"    ({parent_id_column_name}, {owned_id_column_name}) [pk]",
+            "  }",
+        ]
 
         # put it together:
-        schema += "\n".join([parent_link, owned_link, "}"]) + "\n\n"
+        schema += (
+            "\n".join([parent_link, owned_link, order_line] + pk_lines + ["}"]) + "\n\n"
+        )
 
     return schema
 

--- a/tools/generate_db_schema.py
+++ b/tools/generate_db_schema.py
@@ -3,110 +3,7 @@ from pprint import pformat
 
 import numpy as np
 import pyperclip
-
-from ixdat import db
-from ixdat.db import Saveable
-
-
-def collect_db_classes(*, verbose=False):
-    """Return all DB table defining classes
-
-    Args:
-        verbose (bool): The to print information out about the collected information
-
-    Returns:
-        list(cls), set((str, OwnedObjectList)): Returns data for the primary tables
-        and linker tables. The primary tables is returned as a list of the classes
-        that define them and the linker tables as a tuple of
-        (class_that_owns_the_owned_object_list, owned_object_list).
-
-    """
-    # Collect classes that map to the same DB table
-    table_to_class_mapping = defaultdict(list)
-    for cls in db.ALL_SAVABLE_CLASSES:
-        table_to_class_mapping[cls.table_name].append(cls)
-
-    primary_table_classes = _extract_primary_classes(
-        table_to_class_mapping, verbose=verbose
-    )
-    linker_tables = _extract_linker_tables(table_to_class_mapping, verbose=verbose)
-    return primary_table_classes, linker_tables
-
-
-def _extract_primary_classes(table_to_class_mapping, *, verbose=False):
-    """Return the set of primary classes from all Saveable classes, formed from the
-    `table_name -> [class]` mapping in `table_to_class_mapping`
-
-    """
-    # Collect the table that actually defines the table, which is the highest class in
-    # terms of inheritance (super) of the list of class that all map to the same table
-    primary_table_classes = set()
-    for table_name, classes in table_to_class_mapping.items():
-        top_class = None
-        for cls in classes:
-            if not top_class:
-                top_class = cls
-            else:
-                if cls in top_class.__mro__:
-                    top_class = cls
-        primary_table_classes.add(top_class)
-
-        if verbose:
-            print("")
-            print(f"Table --- {top_class.table_name} ---")
-            print(
-                f"Defined by {top_class.__name__}(Parent table class: "
-                f""
-                # top_class.parent_table_class may be None
-                f"{getattr(top_class.parent_table_class, '__name__', None)})"
-            )
-
-            columns_lines = pformat(top_class.columns).split("\n")
-            print(f"Columns: {columns_lines[0]}")
-            for line in columns_lines[1:]:
-                print("        ", line)
-            if len(classes) > 1:
-                print("Derived, non-table inducing, sub-classes:")
-                for cls in classes:
-                    if cls is top_class:
-                        continue
-                    print("  ", cls.__name__)
-
-    # Sort the primary tables by their distance to Saveable (in terms of inheritance),
-    # and then by name, to make sure that tables that are higher on the inheritance
-    # chain are generated first
-    sorted_primary_table_classes = sorted(
-        primary_table_classes,
-        key=lambda cls_: (cls_.__mro__.index(Saveable), cls_.__name__),
-    )
-
-    return sorted_primary_table_classes
-
-
-def _extract_linker_tables(table_to_class_mapping, *, verbose=False):
-    """Return the linker tables defined in the set of `primary_table_classes`
-    as a set of (source_class, OwnedObjectList) pairs
-
-    """
-    linker_tables = set()  # Of (OwningClass, OwnedObjectList)
-    for table_name, classes in table_to_class_mapping.items():
-        top_cls = classes[0]
-        # FIXME: see if this can't be simpler
-        while top_cls.parent_table_class:
-            top_cls = top_cls.parent_table_class
-            if isinstance(top_cls, tuple):
-                top_cls = top_cls[0]
-        for cls in classes:
-            for owned_object_list in cls.owned_object_lists:
-                linker_tables.add((top_cls, owned_object_list))
-
-    if verbose:
-        print("\nLinker tables:")
-        for source_class, owned_object_list in linker_tables:
-            print(f"{source_class.__name__: <20} --->", owned_object_list)
-
-    return linker_tables
-
+from ixdat.db import TABLE_CLASSES, LINKERS
 
 # Type translation for BDML
 _type_translation = {
@@ -206,8 +103,9 @@ def main():
     to clipboard
 
     """
-    primary_table_classes, linker_tables = collect_db_classes(verbose=False)
-    schema = generate_dbdiagramio_DBML(primary_table_classes, linker_tables)
+    schema = generate_dbdiagramio_DBML(
+        primary_table_classes=TABLE_CLASSES, linker_tables=LINKERS
+    )
     pyperclip.copy(schema)
     print(schema)
 


### PR DESCRIPTION
Hi @KennethNielsen , 
This is a start of proper table dfinitions. I've tried to explain the logic in comments. See if it makes sense!

This much, for example, works:
```
>>>from ixdat.techniques import ECMSMeasurement
>>> ECMSMeasurement.full_colums()
[Column(name=id, ctype='<class 'int'>'),
 Column(name=name, ctype='<class 'str'>'),
 Column(name=technique, ctype='<class 'str'>'),
 Column(name=metadatata, ctype='<class 'dict'>'),
 Column(name=aliases, ctype='<class 'dict'>'),
 Column(name=sample_name, ctype='<class 'str'>'),
 Column(name=tstamp, ctype='<class 'float'>'),
 Column(name=ec_technique, ctype='<class 'str'>')]
```
Where the first 6 are "inherited" form `Measurement` and the last one is "inherited" from `ECMeasurement`. 

I've redone the table definition class attributes in data_series.py, measurements.py, techniques/ec.py, techniques/ms.py, and techniques/ecms.py. 
This is the dbdiagram of the database that one can hopefully derive from if: https://dbdiagram.io/d/601bedcb80d742080a392b99, image attached.
![image](https://user-images.githubusercontent.com/28803592/169081920-df190a2a-5435-46db-a7d3-33e37f78ef39.png)
I've tried to use the SQLite type names there. Note that in ixdat classes, columns are typed according to their python type, and it is up to the backend to figure out how to translate between available types.

Things left to do after this PR:
- get `Saveable.as_dict()` to build the full dictionary represenation (using `full_columns()` and `full_owned_object_lists()`) and ensure all the owned objects are represented and in memory
- fix up the relationships between `Saveable`, `Backend`, and `DB` 
- get `DirectoryBackend` working with the new column tables
- debug, debug, debug
- write an SQLite backend.

Questions for review of this request-for-comment PR:
- Is all the needed information there?
- Does the "inheritance" regime make sense, i.e. can it be translated to a database which is in sa?
- What happens with multiple inheritance? The trickiest thing in this PR was `ECMSCalibration` which inherits from `ECCalibration` and `MSCalibration`. However, its `id` is a foreign key that can only refer to *one* of ec_calibrations.id and ms_calibrations.id (even though both of those are foreign keys refering to calibrations.id). Ideally we'd have the same id appear in all thee tables ec_calibrations, ms_calibrations, and ecms_calibrations, and ecms_calibrations would only need the two columns id and L (working distance, the only attribute in an ECMSCalibration which isn't in an MSCalibration or ECCalibration). However, if the table-defining class attributes are also to be used to build the dictionary representations of objects, then everything needs to be there.

Looking forward to your comments on this!