### PR TITLE
Add Github Action to ansure there is changelog entry in NEXT_CHANGES.rst

### DIFF
--- a/.github/workflows/changelog_checker.yml
+++ b/.github/workflows/changelog_checker.yml
@@ -1,0 +1,19 @@
+name: "Pull Request Workflow"
+on:
+  pull_request:
+    # The specific activity types are listed here to include "labeled" and "unlabeled"
+    # (which are not included by default for the "pull_request" trigger).
+    # This is needed to allow skipping enforcement of the changelog in PRs with specific labels,
+    # as defined in the (optional) "skipLabels" property.
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
+
+jobs:
+  # Enforces the update of a changelog file on every pull request
+  changelog:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: dangoslen/changelog-enforcer@b2a627f5ad95e3610e22143df08656fc1a8ad130
+      with:
+        changeLogPath: 'NEXT_CHANGES.rst'
+        skipLabels: "skip-changelog"
+        missingUpdateErrorMessage: "Please add a changelog entry to NEXT_CHANGES.rst"

--- a/.github/workflows/changelog_checker.yml
+++ b/.github/workflows/changelog_checker.yml
@@ -1,4 +1,4 @@
-name: "Pull Request Workflow"
+name: "Changelog checker"
 on:
   pull_request:
     # The specific activity types are listed here to include "labeled" and "unlabeled"


### PR DESCRIPTION
This PR adds a Github Action that checks whether a PR contains changes to NEXT_CHANGES.rst. If it doesn't, it qualifies as a failed PR check, preventing the PR from begin merged. The check can be disabled for individual PR's if it is evaluated to be necessary by adding the label "skip-changelog" (which will need to be added to the label collection).