### PR TITLE
Multiple point gas flux calibration

### DIFF
--- a/NEXT_CHANGES.rst
+++ b/NEXT_CHANGES.rst
@@ -14,6 +14,14 @@ links to relevant Issues, Discussions, and PR's on github with the following for
 
 API changes
 -----------
+techniques
+^^^^^^^^^^^
+- Improved docstring for ``ECMSMeasurement.ecms_calibration_curve()`` to include the new additions from previous release.
+- Added MSInlet``gas_flux_calibration_curve`` to enable multiple point calibration using calculated gas flux 
+either with different concentrations in carrier gas or at different inlet pressures. Note, concentration needs to be given in ppm, as the flux calculation uses various constants from the carrier gas molecule instead of a mixture, which will lead to significant inaccuracy for high concentrations.
 
 Debugging
 ---------
+techniques
+^^^^^^^^^^^
+- ``_get_tspan_list`` in ``ECMSMeasurement`` now defaults ``t_steady_pulse`` to ``None`` instead of ``0``, which simplifies explanation in docstring and makes it more clear what it does (i.e. if now a pulse time of 0 is given it will actually use 0s instead of the entire pulse)

--- a/src/ixdat/techniques/ec_ms.py
+++ b/src/ixdat/techniques/ec_ms.py
@@ -116,15 +116,15 @@ class ECMSMeasurement(ECMeasurement, MSMeasurement):
         mass,
         n_el,
         tspan_list=None,
-        selector_list=None,
         selector_name=None,
-        t_steady_pulse=0,
+        selector_list=None,
+        t_steady_pulse=None,
         tspan_bg=None,
         ax="new",
         axes_measurement=None,
         return_ax=False,
     ):
-        """Fit mol's sensitivity at mass based on steady periods of EC production
+        """Fit mol's sensitivity at mass based on steady periods of EC production.
 
         Args:
             mol (str): Name of the molecule to calibrate
@@ -132,6 +132,13 @@ class ECMSMeasurement(ECMeasurement, MSMeasurement):
             n_el (str): Number of electrons passed per molecule produced (remember the
                 sign! e.g. +4 for O2 by OER and -2 for H2 by HER)
             tspan_list (list of tspan): The timespans of steady electrolysis
+            selector_name (str): Name of selector which identifies the periods
+                of steady electrolysis for automatic selection of timespans of steady
+                electrolysis. E.g. "selector" or "Ns" for biologic EC data
+            selector_list (list): List of values for selector_name for automatic
+                selection of timespans of steady electrolysis
+            t_steady_pulse (float): Length of steady electrolysis for each segment
+                given by selector_list. Defaults to None = entire length of segment
             tspan_bg (tspan): The time to use as a background
             ax (Axis): The axis on which to plot the ms_calibration curve result.
                 Defaults to a new axis.
@@ -188,7 +195,7 @@ class ECMSMeasurement(ECMeasurement, MSMeasurement):
         self,
         selector_list,
         selector_name=None,
-        t_steady_pulse=0,
+        t_steady_pulse=None,
     ):
         """
         Generate a t_span list from input of selectors.
@@ -201,13 +208,15 @@ class ECMSMeasurement(ECMeasurement, MSMeasurement):
                                 selector_name cannot contain a space character due to
                                 limitations of self.select_values().
             t_steady_pulse (float): length of steady state pulse period to integrate
-                                    (will choose the last x seconds)
+                                    (will choose the last x seconds of the period).
+                                    Defaults to None: uses entire steady state pulse
 
         Returns tspan_list(list of tspan)
         """
         t_idx = -1
-        if t_steady_pulse == 0:
+        if t_steady_pulse is None:
             t_idx = 0
+            t_steady_pulse = 0
 
         tspan_list = [
             [

--- a/src/ixdat/techniques/ec_ms.py
+++ b/src/ixdat/techniques/ec_ms.py
@@ -102,11 +102,7 @@ class ECMSMeasurement(ECMeasurement, MSMeasurement):
         n = Q / (n_el * FARADAY_CONSTANT)
         F = Y / n
         cal = MSCalResult(
-            name=f"{mol}@{mass}",
-            mol=mol,
-            mass=mass,
-            cal_type="ecms_calibration",
-            F=F,
+            name=f"{mol}@{mass}", mol=mol, mass=mass, cal_type="ecms_calibration", F=F,
         )
         return cal
 
@@ -192,10 +188,7 @@ class ECMSMeasurement(ECMeasurement, MSMeasurement):
         return cal
 
     def _get_tspan_list(
-        self,
-        selector_list,
-        selector_name=None,
-        t_steady_pulse=None,
+        self, selector_list, selector_name=None, t_steady_pulse=None,
     ):
         """
         Generate a t_span list from input of selectors.
@@ -214,10 +207,9 @@ class ECMSMeasurement(ECMeasurement, MSMeasurement):
         Returns tspan_list(list of tspan)
         """
         t_idx = -1
-        if t_steady_pulse is None:
+        if not t_steady_pulse:
             t_idx = 0
             t_steady_pulse = 0
-
         tspan_list = [
             [
                 self.select_values(**{selector_name: selector_value}).grab("t")[0][t_idx]
@@ -271,10 +263,7 @@ class ECMSCalibration(ECCalibration, MSCalibration):
             L (float): The working distance in [m]
         """
         ECCalibration.__init__(
-            self,
-            A_el=A_el,
-            RE_vs_RHE=RE_vs_RHE,
-            R_Ohm=R_Ohm,
+            self, A_el=A_el, RE_vs_RHE=RE_vs_RHE, R_Ohm=R_Ohm,
         )
         MSCalibration.__init__(
             self,

--- a/src/ixdat/techniques/ec_ms.py
+++ b/src/ixdat/techniques/ec_ms.py
@@ -102,7 +102,11 @@ class ECMSMeasurement(ECMeasurement, MSMeasurement):
         n = Q / (n_el * FARADAY_CONSTANT)
         F = Y / n
         cal = MSCalResult(
-            name=f"{mol}@{mass}", mol=mol, mass=mass, cal_type="ecms_calibration", F=F,
+            name=f"{mol}@{mass}",
+            mol=mol,
+            mass=mass,
+            cal_type="ecms_calibration",
+            F=F,
         )
         return cal
 
@@ -188,7 +192,10 @@ class ECMSMeasurement(ECMeasurement, MSMeasurement):
         return cal
 
     def _get_tspan_list(
-        self, selector_list, selector_name=None, t_steady_pulse=None,
+        self,
+        selector_list,
+        selector_name=None,
+        t_steady_pulse=None,
     ):
         """
         Generate a t_span list from input of selectors.
@@ -263,7 +270,10 @@ class ECMSCalibration(ECCalibration, MSCalibration):
             L (float): The working distance in [m]
         """
         ECCalibration.__init__(
-            self, A_el=A_el, RE_vs_RHE=RE_vs_RHE, R_Ohm=R_Ohm,
+            self,
+            A_el=A_el,
+            RE_vs_RHE=RE_vs_RHE,
+            R_Ohm=R_Ohm,
         )
         MSCalibration.__init__(
             self,

--- a/src/ixdat/techniques/ec_ms.py
+++ b/src/ixdat/techniques/ec_ms.py
@@ -217,9 +217,6 @@ class ECMSMeasurement(ECMeasurement, MSMeasurement):
             ]
             for selector_value in selector_list
         ]
-
-        print("Choose a selector_name that is present in your data.")
-
         print("Following tspans were selected for calibration: " + str(tspan_list))
         return tspan_list
 

--- a/src/ixdat/techniques/ms.py
+++ b/src/ixdat/techniques/ms.py
@@ -691,7 +691,7 @@ class MSInlet:
         t_steady_pulse=0,
         tspan_bg=None,
         ax="new",
-        # axes_measurement=None, #TODO: add this
+        axes_measurement=None,
         return_ax=False,
     ):
         """Fit mol's sensitivity at mass based on steady periods with different
@@ -724,6 +724,8 @@ class MSInlet:
             tspan_bg (tspan): The time to use as a background
             ax (Axis): The axis on which to plot the ms_calibration curve result.
                 Defaults to a new axis.
+            axes_measurement (list of Axes): The EC-MS plot axes to highlight the
+                ms_calibration on. Defaults to None. These axes are not returned.
             return_ax (bool): Whether to return the axis on which the calibration is
                 plotted together with the MSCalResult. Defaults to False.
 
@@ -742,7 +744,7 @@ class MSInlet:
             mol_conc_ppm_list = mol_conc_ppm
         if p_list is None:
             p_list = [None for x in tspan_list]
-        if not len(mol_conc_ppm) == len(p_list) == len(tspan_list):
+        if not len(mol_conc_ppm_list) == len(p_list) == len(tspan_list):
             raise QuantificationError("Length of input lists for concentrations"
                                       " and tspan or pressures and tspan is not equal")
         S_list = []
@@ -750,10 +752,10 @@ class MSInlet:
         for tspan, mol_conc_ppm, pressure in zip(tspan_list, mol_conc_ppm_list,
                                                  p_list):
             t, S = measurement.grab_signal(mass, tspan=tspan, tspan_bg=tspan_bg)
-            if ax:
-                ax.plot(t, S, color=STANDARD_COLORS[mass], linewidth=5)
+            if axes_measurement:
+                axes_measurement.plot(t, S, color=STANDARD_COLORS[mass], linewidth=5)
             if carrier_mol:
-                if mol_conc_ppm:
+                if mol_conc_ppm is not None:
                     cal_type = "carrier_gas_flux_calibration_curve"
                 else:
                     raise QuantificationError(

--- a/src/ixdat/techniques/ms.py
+++ b/src/ixdat/techniques/ms.py
@@ -180,7 +180,12 @@ class MSMeasurement(Measurement):
         "0.1", "Use `remove_background` instead.", "0.3", kwarg_name="removebackground"
     )
     def grab_flux_for_t(
-        self, mol, t, tspan_bg=None, remove_background=False, removebackground=None,
+        self,
+        mol,
+        t,
+        tspan_bg=None,
+        remove_background=False,
+        removebackground=None,
     ):
         """Return the flux of mol (calibrated signal) in [mol/s] for a given time vec
 
@@ -195,7 +200,9 @@ class MSMeasurement(Measurement):
         if removebackground is not None:
             remove_background = removebackground
         t_0, y_0 = self.grab_flux(
-            mol, tspan_bg=tspan_bg, remove_background=remove_background,
+            mol,
+            tspan_bg=tspan_bg,
+            remove_background=remove_background,
         )
         y = np.interp(t, t_0, y_0)
         return y
@@ -260,7 +267,12 @@ class MSCalResult(Saveable):
     column_attrs = {"name", "mol", "mass", "cal_type", "F"}
 
     def __init__(
-        self, name=None, mol=None, mass=None, cal_type=None, F=None,
+        self,
+        name=None,
+        mol=None,
+        mass=None,
+        cal_type=None,
+        F=None,
     ):
         super().__init__()
         self.name = name or f"{mol}@{mass}"
@@ -576,7 +588,7 @@ class MSInlet:
         p_1 = p
         lambda_ = d  # defining the transitional pressure
         # ...from setting mean free path equal to capillary d
-        p_t = BOLTZMAN_CONSTANT * T / (2 ** 0.5 * pi * s ** 2 * lambda_)
+        p_t = BOLTZMAN_CONSTANT * T / (2**0.5 * pi * s**2 * lambda_)
         p_2 = 0
         p_m = (p_1 + p_t) / 2  # average pressure in the transitional flow region
         v_m = (8 * BOLTZMAN_CONSTANT * T / (pi * m)) ** 0.5
@@ -615,7 +627,7 @@ class MSInlet:
     ):
         """
         Fit mol's sensitivity at mass based on period with steady gas composition.
-        
+
         Args:
             measurement (MSMeasurement): The measurement with the calibration data
             mol (str): The name of the molecule to calibrate
@@ -652,12 +664,16 @@ class MSInlet:
             )
         else:
             cal_type = "gas_flux_calibration"
-            mol_conc_ppm = 10 ** 6
+            mol_conc_ppm = 10**6
             carrier_mol = mol
-        n_dot = self.calc_n_dot_0(gas=carrier_mol) * mol_conc_ppm / 10 ** 6
+        n_dot = self.calc_n_dot_0(gas=carrier_mol) * mol_conc_ppm / 10**6
         F = np.mean(S) / n_dot
         return MSCalResult(
-            name=f"{mol}@{mass}", mol=mol, mass=mass, cal_type=cal_type, F=F,
+            name=f"{mol}@{mass}",
+            mol=mol,
+            mass=mass,
+            cal_type=cal_type,
+            F=F,
         )
 
     def gas_flux_calibration_curve(
@@ -757,10 +773,10 @@ class MSInlet:
             t, S = measurement.grab_signal(mass, tspan=tspan, tspan_bg=tspan_bg)
             if axes_measurement:
                 axes_measurement.plot(t, S, color=STANDARD_COLORS[mass], linewidth=5)
-                mol_conc_ppm = 10 ** 6
+                mol_conc_ppm = 10**6
                 carrier_mol = mol
             n_dot = (
-                self.calc_n_dot_0(gas=carrier_mol, p=pressure) * mol_conc_ppm / 10 ** 6
+                self.calc_n_dot_0(gas=carrier_mol, p=pressure) * mol_conc_ppm / 10**6
             )
             S_list.append(np.mean(S))
             n_dot_list.append(n_dot)
@@ -779,7 +795,11 @@ class MSInlet:
             S_fit = n_dot_fit * pfit[0] + pfit[1]
             ax.plot(n_dot_fit * 1e9, S_fit * 1e9, "--", color=color)
         cal = MSCalResult(
-            name=f"{mol}@{mass}", mol=mol, mass=mass, cal_type=cal_type, F=F,
+            name=f"{mol}@{mass}",
+            mol=mol,
+            mass=mass,
+            cal_type=cal_type,
+            F=F,
         )
         if return_ax:
             return cal, ax

--- a/src/ixdat/techniques/ms.py
+++ b/src/ixdat/techniques/ms.py
@@ -687,7 +687,7 @@ class MSInlet:
         selector_name=None,
         carrier_mol=None,
         mol_conc_ppm=None,
-        p_list=None,
+        p_inlet=None,
         t_steady_pulse=0,
         tspan_bg=None,
         ax="new",
@@ -716,9 +716,10 @@ class MSInlet:
                 the carrier gas in ppm. Defaults to None. Accepts float (for pressure
                 calibration) or list for concentration calibration. If list needs
                 to be same length as tspan_list or selector_list.
-            p_list(list): Pressure at the inlet (Pa). Overwrites the pressure
-                inherent to self. Needs to be same length as tspan_list or
-                selector_list.
+            p_inlet (float, list): Pressure at the inlet (Pa). Overwrites the pressure
+                inherent to self (i.e. the MSInlet object). Accepts float (for conc.
+                calibration) or list for pressure calibration. If list, then
+                needs to be same length as tspan_list or selector_list.
             t_steady_pulse (float): Length of steady electrolysis for each segment
                 given by selector_list. Defaults to None = entire length of segment
             tspan_bg (tspan): The time to use as a background
@@ -742,8 +743,8 @@ class MSInlet:
             mol_conc_ppm_list = [mol_conc_ppm for x in tspan_list]
         else:
             mol_conc_ppm_list = mol_conc_ppm
-        if p_list is None:
-            p_list = [None for x in tspan_list]
+        if type(p_inlet) is not list:
+            p_list = [p_inlet for x in tspan_list]
         if not len(mol_conc_ppm_list) == len(p_list) == len(tspan_list):
             raise QuantificationError("Length of input lists for concentrations"
                                       " and tspan or pressures and tspan is not equal")

--- a/src/ixdat/techniques/ms.py
+++ b/src/ixdat/techniques/ms.py
@@ -746,12 +746,13 @@ class MSInlet:
         if type(p_inlet) is not list:
             p_list = [p_inlet for x in tspan_list]
         if not len(mol_conc_ppm_list) == len(p_list) == len(tspan_list):
-            raise QuantificationError("Length of input lists for concentrations"
-                                      " and tspan or pressures and tspan is not equal")
+            raise QuantificationError(
+                "Length of input lists for concentrations"
+                " and tspan or pressures and tspan is not equal"
+            )
         S_list = []
         n_dot_list = []
-        for tspan, mol_conc_ppm, pressure in zip(tspan_list, mol_conc_ppm_list,
-                                                 p_list):
+        for tspan, mol_conc_ppm, pressure in zip(tspan_list, mol_conc_ppm_list, p_list):
             t, S = measurement.grab_signal(mass, tspan=tspan, tspan_bg=tspan_bg)
             if axes_measurement:
                 axes_measurement.plot(t, S, color=STANDARD_COLORS[mass], linewidth=5)
@@ -772,7 +773,9 @@ class MSInlet:
                 cal_type = "gas_flux_calibration_curve"
                 mol_conc_ppm = 10**6
                 carrier_mol = mol
-            n_dot = self.calc_n_dot_0(gas=carrier_mol, p=pressure) * mol_conc_ppm / 10**6
+            n_dot = (
+                self.calc_n_dot_0(gas=carrier_mol, p=pressure) * mol_conc_ppm / 10**6
+            )
             S_list.append(np.mean(S))
             n_dot_list.append(n_dot)
         n_dot_vec = np.array(n_dot_list)

--- a/tasks.py
+++ b/tasks.py
@@ -78,13 +78,7 @@ def pytest(context):
         return context.run("pytest tests").return_code
 
 
-@task(
-    aliases=(
-        "check_black",
-        "black_check",
-        "bc",
-    )
-)
+@task(aliases=("check_black", "black_check", "bc",))
 def check_code_format(context):
     """Check that the code, tests and development_scripts are black formatted
 
@@ -144,7 +138,6 @@ def tox(context, single=False):
         )
     else:
         environments_to_run = filter_tox_environments_linux(environments, single=single)
-
     context.run("tox -p auto -e " + ",".join(environments_to_run))
 
 
@@ -165,13 +158,11 @@ def filter_tox_environments_linux(environments, single=False):
             else:
                 # The environments look like: py36
                 command = "python{}.{}".format(*environment[2:4])
-
             # Check that the executable exists
             try:
                 check_call([command, "--version"], stdout=DEVNULL)
             except (CalledProcessError, FileNotFoundError):
                 continue
-
             # Certain version of Ubuntu may have a old "reduced"
             # Python version, with an "m" suffix. It is insufficient
             # for tox so check that it isn't there.
@@ -180,13 +171,10 @@ def filter_tox_environments_linux(environments, single=False):
                 continue
             except (CalledProcessError, FileNotFoundError):
                 pass
-
             if found_at_least_one_python and single:
                 continue
-
             environments_to_run.append(environment)
             found_at_least_one_python = True
-
         else:
             environments_to_run.append(environment)
     return environments_to_run
@@ -213,7 +201,6 @@ def filter_tox_environments_windows(environments, single=False):
             version_numbers = version_string.replace("Python ", "").split(".")
             version = "".join(version_numbers[:2])
             python_versions.append("py" + version)
-
     environments_to_run = []
     found_at_least_one_python = False
     for environment in environments:
@@ -221,12 +208,10 @@ def filter_tox_environments_windows(environments, single=False):
             if environment in python_versions:
                 if found_at_least_one_python and single:
                     continue
-
                 environments_to_run.append(environment)
                 found_at_least_one_python = True
         else:
             environments_to_run.append(environment)
-
     return environments_to_run
 
 
@@ -276,6 +261,7 @@ def dependencies(context):
     """
     # See https://stackoverflow.com/a/1883251/11640721 for virtual env detection trick
     conda_environment = os.environ.get("CONDA_PREFIX")
+    # conda_environment is None if not using Anaconda python
     if conda_environment is None and sys.prefix == sys.base_prefix:
         raise RuntimeError(
             "Current python does not seem to be in a virtual environment, which is the "

--- a/tasks.py
+++ b/tasks.py
@@ -25,6 +25,7 @@ Read more about invoke here: https://www.pyinvoke.org/
 
 """
 
+import os
 import sys
 import configparser
 import platform
@@ -274,7 +275,8 @@ def dependencies(context):
     See docstring of :func:`flake8` for explanation of `context` argument
     """
     # See https://stackoverflow.com/a/1883251/11640721 for virtual env detection trick
-    if sys.prefix == sys.base_prefix:
+    conda_environment = os.environ.get("CONDA_PREFIX")
+    if conda_environment is None and sys.prefix == sys.base_prefix:
         raise RuntimeError(
             "Current python does not seem to be in a virtual environment, which is the "
             "recommended way to install dependencies for development. Please "


### PR DESCRIPTION
Small edits in `ecms_calibration_curve` documentation.
Major part is an extension of `MSInlet.gas_flux_calibration()` called  `MSInlet.gas_flux_calibration_curve()` to enable multiple point calibration with either different gas concentrations or pressures as described in issue #80  I decided to just make one method with both options, but it might make more sense to separate them? let me know what you think. 

Also, I know, it's still not passing the tests, because I haven't managed to include black in my workflow (I got lost somewhere in the description in the developer doc) - will ask Kenneth to help me, but wanted to put this here already.