### PR TITLE
siq integration

### DIFF
--- a/NEXT_CHANGES.rst
+++ b/NEXT_CHANGES.rst
@@ -28,10 +28,18 @@ techniques
     Mentioned in `Issue #94 <https://github.com/ixdat/ixdat/issues/94`_
 
 - ``ECMSMeasurement.ecms_calibration_curve()`` has the additional option of 
-passing a J_name to be used for highlighting the integrated current passed to
-``axes_measurement``. This does not affect the calculation of sensitivity factors, 
-only plotting.
+  passing a J_name to be used for highlighting the integrated current passed to
+  ``axes_measurement``. This does not affect the calculation of sensitivity factors,
+  only plotting.
     Resolves `Issue #118 <https://github.com/ixdat/ixdat/issues/118`_
+
+- Native MS calibration methods are moved from ``MSInlet`` to ``MSMeasurement``.
+  Meanwhile, those using ``spectro_inlets_quantification`` are prefixed with ``siq_``,
+  e.g. use ``ms_meas.gas_flux_calibration(...)`` for native ixdat MS calibration and
+  ``ms_meas.siq_gas_flux_calibration(...)`` to use the more powerful siq equivalents.
+  Resolves `Issue #122 <https://github.com/ixdat/ixdat/issues/122>`_
+
+- ``spectro_inlets_quantification`` is consistently abbreviated ``siq``.
 
 
 Debugging

--- a/development_scripts/siq_integration_demo.py
+++ b/development_scripts/siq_integration_demo.py
@@ -28,5 +28,9 @@ print(native_cal)  # An ixdat MSCalResult object
 # ---- Spectro Inlets calibration ----- #
 ixdat.config.plugins.activate_si_quant()
 
-quant_cal = ms.gas_flux_calibration(mol="He", mass="M4", tspan=[100, 200])
+quant_cal = ms.siq_gas_flux_calibration(mol="He", mass="M4", tspan=[100, 200])
 print(quant_cal)  # A CalPoint object of the external package
+
+calibration = ixdat.plugins.siq.Calibration(cal_list=[quant_cal])
+
+print(calibration + quant_cal)

--- a/development_scripts/siq_integration_demo.py
+++ b/development_scripts/siq_integration_demo.py
@@ -12,21 +12,21 @@ ms = Measurement.read(
 )  # an MSMeasurement
 # ms.plot()
 
-# ---- Spectro Inlets calibration inaccessible without use_si_quant ----- #
-print(ixdat.config.plugins.use_si_quant)  # False
+# ---- Spectro Inlets calibration inaccessible without activating siq ----- #
+print(ixdat.config.plugins.use_siq)  # False
 try:
-    native_cal = ms.gas_flux_calibration(mol="He", mass="M4", tspan=[100, 200])
+    native_cal = ms.siq_gas_flux_calibration(mol="He", mass="M4", tspan=[100, 200])
 except Exception as e:
     print(e)  # explains that native ixdat requires an MSInlet to be specifically defined
 
 # ---- Native calibration ----- #
-native_cal = MSInlet().gas_flux_calibration(
-    mol="He", mass="M4", measurement=ms, tspan=[100, 200]
+native_cal = ms.gas_flux_calibration(
+    inlet=MSInlet(), mol="He", mass="M4", tspan=[100, 200]
 )
 print(native_cal)  # An ixdat MSCalResult object
 
 # ---- Spectro Inlets calibration ----- #
-ixdat.config.plugins.activate_si_quant()
+ixdat.config.plugins.activate_siq()
 
 quant_cal = ms.siq_gas_flux_calibration(mol="He", mass="M4", tspan=[100, 200])
 print(quant_cal)  # A CalPoint object of the external package

--- a/src/ixdat/config.py
+++ b/src/ixdat/config.py
@@ -74,51 +74,66 @@ class _PluginOptions:
     """
 
     def __init__(self):
-        self._use_si_quant = False
-        self.si_quant = _SIQuantDeps()
+        self._use_siq = False
+        self.siq = _SIQ()
         self.cinfdata = _CinfData()
 
     @property
-    def use_si_quant(self):
-        return self._use_si_quant
+    def use_siq(self):
+        return self._use_siq
 
-    def activate_si_quant(self):
+    def activate_siq(self):
         """Changes mass spec methods to use spectro_inlets_quantification"""
-        self._use_si_quant = True
-        self.si_quant.populate()
+        self._use_siq = True
+        self.siq.populate()
 
-    def deactivate_si_quant(self):
+    def deactivate_siq(self):
         """Changes mass spec methods to use ixdat's native MS quantification"""
-        self._use_si_quant = False
-
-    @property
-    @deprecate(
-        last_supported_release="0.2.4",
-        update_message="This has changed to lower-case: `use_si_quant`",
-        remove_release="0.2.5",
-    )
-    def USE_QUANT(self):
-        return self.use_si_quant
-
-    @USE_QUANT.setter
-    @deprecate(
-        last_supported_release="0.2.4",
-        update_message="Use the methods `activate_si_quant()` and "
-        "`deactivate_si_quant()` instead.",
-        remove_release="0.2.5",
-    )
-    def USE_QUANT(self, use_quant):
-        if use_quant:
-            self.activate_si_quant()
-        else:
-            self.deactivate_si_quant()
+        self._use_siq = False
 
     def activate_cinfdata(self):
         self.cinfdata.activate()
 
+    @deprecate(
+        last_supported_release="0.2.6",
+        update_message="`siq` is the universal abreviation "
+        "for `spectro_inlets_quantification`. "
+        "Thus, `ixdat.plugins.activate_si_quant` "
+        "is now `ixdat.plugins.activate_siq`",
+        hard_deprecation_release="0.3.0",
+        remove_release="1.0.0",
+    )
+    def activate_si_quant(self):
+        return self.activate_siq()
 
-class _SIQuantDeps:
-    """Class storing items of the external MS quantification package.
+    @property
+    @deprecate(
+        last_supported_release="0.2.6",
+        update_message="`siq` is the universal abreviation "
+        "for `spectro_inlets_quantification`. "
+        "Thus, `ixdat.plugins.use_si_quant` "
+        "is now `ixdat.plugins.use_siq`",
+        hard_deprecation_release="0.3.0",
+        remove_release="1.0.0",
+    )
+    def use_si_quant(self):
+        return self.use_siq
+
+    @property
+    @deprecate(
+        last_supported_release="0.2.6",
+        update_message="`siq` is the universal abreviation "
+        "for `spectro_inlets_quantification`. "
+        "Thus, `ixdat.plugins.si_quant` is now `ixdat.plugins.siq`",
+        hard_deprecation_release="0.3.0",
+        remove_release="1.0.0",
+    )
+    def si_quant(self):
+        return self.siq
+
+
+class _SIQ:
+    """Class storing items of `spectro_inlets_quantification`.
 
     This class has one instance, which is an attribute of `plugins`. To print this
     docstring, you would type:

--- a/src/ixdat/techniques/ec_ms.py
+++ b/src/ixdat/techniques/ec_ms.py
@@ -202,7 +202,7 @@ class ECMSMeasurement(ECMeasurement, MSMeasurement):
             ax.plot(n_fit * 1e9, Y_fit * 1e9, "--", color=color)
 
         if plugins.use_si_quant:
-            cal = plugins.si_quant.CalPoint(
+            cal = plugins.siq.CalPoint(
                 mol=mol, mass=mass, F_type="internal", F=F, date=self.yyMdd
             )
         else:

--- a/src/ixdat/techniques/ec_ms.py
+++ b/src/ixdat/techniques/ec_ms.py
@@ -2,7 +2,7 @@
 import numpy as np
 from ..constants import FARADAY_CONSTANT
 from .ec import ECMeasurement, ECCalibration
-from .ms import MSMeasurement, MSCalResult, MSCalibration
+from .ms import MSMeasurement, MSCalResult, MSCalibration, _with_siq_quantifier
 from .cv import CyclicVoltammogram
 from ..exporters.ecms_exporter import ECMSExporter
 from ..plotters.ecms_plotter import ECMSPlotter
@@ -80,6 +80,7 @@ class ECMSMeasurement(ECMeasurement, MSMeasurement):
         """The tspan of an MS measurement is the tspan of its potential data"""
         return [self.t[0], self.t[-1]]
 
+    @_with_siq_quantifier
     def as_cv(self):
         self_as_dict = self.as_dict()
 
@@ -89,8 +90,6 @@ class ECMSMeasurement(ECMeasurement, MSMeasurement):
         self_as_dict["series_list"] = self.series_list
 
         ecms_cv = ECMSCyclicVoltammogram.from_dict(self_as_dict)
-        if self.quantifier:
-            ecms_cv.set_quantifier(self.quantifier)
 
         return ecms_cv
 
@@ -201,7 +200,7 @@ class ECMSMeasurement(ECMeasurement, MSMeasurement):
             Y_fit = n_fit * pfit[0] + pfit[1]
             ax.plot(n_fit * 1e9, Y_fit * 1e9, "--", color=color)
 
-        if plugins.use_si_quant:
+        if plugins.use_siq:
             cal = plugins.siq.CalPoint(
                 mol=mol, mass=mass, F_type="internal", F=F, date=self.yyMdd
             )

--- a/src/ixdat/techniques/ms.py
+++ b/src/ixdat/techniques/ms.py
@@ -114,7 +114,7 @@ class MSMeasurement(Measurement):
                 Defaults to False, but in grab_flux it defaults to True.
             include_endpoints (bool): Whether to ensure tspan[0] and tspan[-1] are in t
         """
-        if plugins.use_si_quant and item.startswith("n_dot_"):
+        if plugins.use_siq and item.startswith("n_dot_"):
             return self.grab_flux(
                 item.removeprefix("n_dot_"),
                 tspan=tspan,
@@ -173,10 +173,10 @@ class MSMeasurement(Measurement):
         """Return the flux of mol (calibrated signal) in [mol/s]
 
         Note:
-        - With native ixdat quantification (use_si_quant=False),
+        - With native ixdat quantification (use_siq=False),
           `grab_flux(mol, ...)` is identical to `grab(f"n_dot_{mol}", ...)` with
           remove_background=True by default. An MSCalibration does the maths.
-        - With an external quantification package (use_si_quant=True), the maths are done
+        - With an external quantification package (use_siq=True), the maths are done
           here with the help of self.quantifier
 
         Args:
@@ -192,7 +192,7 @@ class MSMeasurement(Measurement):
         if removebackground is not None:
             remove_background = removebackground
 
-        if plugins.use_si_quant:
+        if plugins.use_siq:
             # We have to calculate the fluxes of all the mols and masses in the
             # quantifier's sensitivity matrix. But this method only returns one.
             # TODO: The results should therefore be cached. But how to know when they
@@ -238,11 +238,11 @@ class MSMeasurement(Measurement):
                 Defaults to True..
             include_endpoints (bool): Whether to interpolate for tspan[0] and tspan[-1]
         """
-        if not plugins.use_si_quant:
+        if not plugins.use_siq:
             raise QuantificationError(
                 "`MSMeasurement.gas_flux_calibration` only works when using an "
                 "external MS quantification package "
-                "(`ixdat.plugins.activate_si_quant()`). "
+                "(`ixdat.plugins.activate_siq()`). "
                 "For native ixdat MS quantification, `gas_flux_calibration` has to be"
                 "called from an instance of `MSInlet`."
             )
@@ -552,11 +552,11 @@ class MSMeasurement(Measurement):
         Returns CalPoint: An object from the external MS quantification package,
            representing the calibration result
         """
-        if not plugins.use_si_qquant:
+        if not plugins.use_siq:
             raise QuantificationError(
                 "`MSMeasurement.gas_flux_calibration_siq` only works when using an "
                 "external MS quantification package "
-                "(`ixdat.options.use_si_quant = True`). "
+                "(`ixdat.options.activate_siq()`). "
                 "For native ixdat MS quantification, `gas_flux_calibration` has to be"
                 "called from an instance of `MSInlet`."
             )
@@ -615,11 +615,11 @@ class MSMeasurement(Measurement):
             periods.
         TODO: automatically recognize the pressure from measurement (if available)
         """
-        if not plugins.use_si_quant:
+        if not plugins.use_siq:
             raise QuantificationError(
                 "`MSMeasurement.gas_flux_calibration` only works when using an "
                 "external MS quantification package "
-                "(`ixdat.options.use_si_quant = True`). "
+                "(`ixdat.options.activate_siq()`). "
                 "For native ixdat MS quantification, `gas_flux_calibration` has to be"
                 "called from an instance of `MSInlet`."
             )
@@ -694,11 +694,11 @@ class MSMeasurement(Measurement):
         Returns Calibration: An object from the external MS quantification package,
            representing all the calibration results from the calibration.
         """
-        if not plugins.use_si_quant:
+        if not plugins.use_siq:
             raise QuantificationError(
                 "`MSMeasurement.gas_flux_calibration` only works when using an "
                 "external MS quantification package "
-                "(`ixdat.plugins.activate_si_quant()`). "
+                "(`ixdat.plugins.activate_siq()`). "
                 "For native ixdat MS quantification, `gas_flux_calibration` has to be"
                 "called from an instance of `MSInlet`."
             )
@@ -796,11 +796,11 @@ class MSMeasurement(Measurement):
                we'll use all the masses in the Calibration.
             carrier (optional, str): The carrier gas in the experiment. Defaults to "He".
         """
-        if not plugins.use_si_quant:
+        if not plugins.use_siq:
             raise QuantificationError(
                 "`MSMeasurement.set_quatnifier` only works when using an "
                 "external MS quantification package "
-                "(`ixdat.options.use_si_quant = True`). "
+                "(`ixdat.options.activate_siq()`). "
                 "For native ixdat MS quantification, use `MSMeasurement.calibrate`"
             )
         Quantifier = plugins.siq.Quantifier


### PR DESCRIPTION
This PR resolves https://github.com/ixdat/ixdat/issues/122.

I've put the prefix "siq_" in front of the MS calibration methods that use ``spectro_inlets_quantification``. I've also moved the native MS calibration methods from ``MSInlet`` to ``MSMeasurement``. I've left deprecated methods in MSInlet which call the MSMeasurement methods so that all scripts using the native ixdat calibration the old way will keep working for now.
I've also put `siq_` in front of everything to do with siq, which meant replacing `si_quant` where that had been used.

It's demo'd in development_scripts/siq_integration_demo which makes use of data in the ixdat-large-test-files submodule.

Should be a quick and easy review since we discussed the issue beforehand.
Once it's merged, however, I will (as promised) make a new issue calling for the spinning out of molecule data to a separate repo.
