### PR TITLE
How to implement units?

### DIFF
--- a/development_scripts/demo_units.py
+++ b/development_scripts/demo_units.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+"""
+Created on Mon Dec 11 22:15:11 2023
+
+@author: Søren
+"""
+from pathlib import Path
+from ixdat import Measurement
+from matplotlib import pyplot as plt
+
+
+PATH_TO_DATAFILE = Path(__file__).parent / "../test_data/biologic/Pt_poly_cv_CUT.mpt"
+
+ec_measurement = Measurement.read(PATH_TO_DATAFILE, reader="biologic")
+
+t_hr, I_uA = ec_measurement.grab("raw_current", unit_name="uA", t_unit_name="hour")
+
+fig, ax = plt.subplots()
+
+ax.plot(t_hr, I_uA, "k")

--- a/src/ixdat/db.py
+++ b/src/ixdat/db.py
@@ -400,6 +400,10 @@ class Saveable:
         """Return an object built from its serialization."""
         return cls(**obj_as_dict)
 
+    def copy(self):
+        """Make a copy of the Measurement via its dictionary representation"""
+        return self.__class__.from_dict(self.as_dict())
+
     @classmethod
     def get(cls, i, backend=None):
         """Open an object of cls given its id (the table is cls.table_name)"""

--- a/src/ixdat/units.py
+++ b/src/ixdat/units.py
@@ -2,6 +2,10 @@
 
 TODO: look into using an available unit's package like astropy's
 """
+from pint import UnitRegistry, UndefinedUnitError
+
+
+ureg = UnitRegistry()
 
 
 class Unit:
@@ -9,8 +13,10 @@ class Unit:
 
     def __init__(self, name):
         self.name = name or ""
-        self.si_unit = None
-        self.si_conversion_factor = None
+        try:
+            self.u = ureg(self.name)
+        except UndefinedUnitError:
+            self.u = None
 
     def __repr__(self):
         return f"Unit('{self.name}')"


### PR DESCRIPTION
This is a request for comment on how best to implement units. 

Now I've just given the `Unit` class that had been included without content in ixdat an attribute `u` which is the `pint´ unit, and the minimal amount of manipulation such that `grab` can take a `unit` and a `t_unit` as an argument.

The API change is demo'd here: https://github.com/ixdat/ixdat/blob/units/development_scripts/demo_units.py

(A lot of the code change has to do with debugging the way the references to `axes_series` are passed on when a `Field` is copied. Before, it would erroneously try to load an axis series from a directory backend. Now it correctly retrieves it from the MemoryBackend.)

Is this the way we want units to be used in ixdat? What additional methods do we need? As an incomplete lists (please add!):

- all plotting functions which take units as inputs should use pint for the unit conversions (#65) 
- A unit specification should be able to determine whether normalized or raw current is returned or plotted (#130) **Help! How do you see this being implemented??**
- DataSeries appending should try a unit conversion when units don't match and raise an error if a conversion can't get them to match
- More plotting functions should take units arguments (#63) .... is there a smart way to implement this for many plotting functions at once?