### PR TITLE
RFC: Series summary __str__

### DIFF
--- a/NEXT_CHANGES.rst
+++ b/NEXT_CHANGES.rst
@@ -21,9 +21,9 @@ readers
 
 - Zilien MS spectrum reader fixed.
   Resolves `Issue #117 <https://github.com/ixdat/ixdat/issues/117>`_
- 
-- ``Spectrum.read(reader="zilien")`` rather than ``reader="zilien_spec"`` as 
-  before for reading in a zilien spectrum. This is accomplished by different 
+
+- ``Spectrum.read(reader="zilien")`` rather than ``reader="zilien_spec"`` as
+  before for reading in a zilien spectrum. This is accomplished by different
   groups of reader for ``Spectrum.read`` and ``Measurement.read``
   Also, zilien-read spectra now know their duration.
 
@@ -45,10 +45,10 @@ techniques
 ^^^^^^^^^^
 - ECOpticalMeasurement.get_spectrum() now has an option not to interpolate.
   Passing the argument `interpolate=False` gets it to choose nearest spectrum instead.
-  
+
 - Indexing a ``SpectroMeasurement`` with an integer returns a ``Spectrum``.
   For example, ``zilien_meas_with_spectra[0].plot()``  plots the first mass scan
-  
+
 plotters
 ^^^^^^^^
 - ``SpectrumPlotter.heat_plot()`` and methods that rely on it can now plot discrete heat plots, with
@@ -59,3 +59,41 @@ plotters
   (in which case durations are available).
   ``ECOpticalMeasurement``s read by "msrh_sec" have an unchanged (continuous) default plot.
   resolves `Issue #140 <https://github.com/ixdat/ixdat/issues/140
+
+General
+^^^^^^^
+
+- The string representation, which is what is printed if an object is printed, has been
+  changed for ``TimeSeries``, ``ValueSeries`` and ``Measurement``. The data series have
+  changed, so that they will return a helpful summary, displaying the name, min, max and
+  the timestamp for a ``TimeSeries`` as opposed to the class name and ``__init__``
+  argument form, which is normally inherited from ``__repr__``. In short::
+
+    Before: TimeSeries(id=1, name='Potential time [s]')
+    After: TimeSeries: 'Potential time [s]'. Min, max: 699, 1481s @ 21B01 17:44:12
+
+    Before: ValueSeries(id=2, name='Voltage [V]')
+    After: ValueSeries: 'Voltage [V]'. Min, max: 1.4e+00, 5.4e+00 [V]
+
+  These new string representations should be helpful on their own, but the main goal of
+  changing them, was to make them useful in the new string representation of
+  ``Measurement``, which is inherited by all measurements. It will now display a summary
+  of all data series in the measurement, along with information about their internal
+  connections, like which ``ValueSeries`` depends on which ``TimeSeries``. For an ECMS
+  measurement the form is::
+
+    ECMSMeasurement '2021-02-01 17_44_12' with 48 series
+
+    Series list:
+    ┏ TimeSeries: 'Potential time [s]'. Min, max: 699, 1481 [s] @ 21B01 17:44:12
+    ┣━ ValueSeries: 'Voltage [V]'. Min, max: 1.4e+00, 5.4e+00 [V]
+    ┣━ ValueSeries: 'Current [mA]'. Min, max: -2.5e-02, 2.5e-02 [mA]
+    ┗━ ValueSeries: 'Cycle [n]'. Min, max: 1.0e+00, 1.0e+00 [n]
+    ┏ TimeSeries: 'Iongauge value time [s]'. Min, max: 1, 3042 [s] @ 21B01 17:44:12
+    ┗━ ValueSeries: 'Iongauge value [mbar]'. Min, max: 6.6e-09, 6.9e-07 [mbar]
+    << SNIP MORE SYSTEM CHANNELS >>
+    ┏ TimeSeries: 'C0M2 time [s]'. Min, max: 1, 3041 [s] @ 21B01 17:44:12
+    ┗━ ValueSeries: 'M2 [A]'. Min, max: 3.4e-12, 2.0e-11 [A]
+    ┏ TimeSeries: 'C1M4 time [s]'. Min, max: 1, 3041 [s] @ 21B01 17:44:12
+    ┗━ ValueSeries: 'M4 [A]'. Min, max: 1.2e-17, 2.7e-10 [A]
+    << SNIP MORE MASS CHANNELS>>

--- a/development_scripts/demo_fancy_str/demo_fancy_measurement_str.py
+++ b/development_scripts/demo_fancy_str/demo_fancy_measurement_str.py
@@ -1,0 +1,27 @@
+"""For use in development of the zilien reader(s). Requires access to sample data."""
+
+from pathlib import Path
+
+from ixdat import Measurement
+from ixdat.techniques import MSMeasurement, ECMeasurement
+
+data_dir = Path(
+    r"/home/kenneth/Spectro Inlets Dropbox/Kenneth Nielsen/ixdat_resources/test_data/zilien_with_ec"
+)
+
+path_to_file = data_dir / "2021-02-01 17_44_12.tsv"
+
+# This imports it with the EC data
+ecms = Measurement.read(path_to_file, reader="zilien")
+voltage = ecms["Voltage [V]"]
+print()
+print("Voltage __repr__:", repr(voltage))
+print("Voltage __str__:", voltage)
+print()
+voltage_time = voltage_time = voltage.tseries
+print("Voltage time __repr__:", repr(voltage_time))
+print("Voltage time __str__:", voltage_time)
+print()
+print("ECMS repr", repr(ecms))
+print("The __str__ is:")
+print(ecms)

--- a/development_scripts/demo_fancy_str/search_for_raise_with_fstring.py
+++ b/development_scripts/demo_fancy_str/search_for_raise_with_fstring.py
@@ -1,0 +1,31 @@
+import re
+from pathlib import Path
+
+THIS_DIR = Path(__file__).resolve().parent
+
+
+RAISE = re.compile("raise .*?\([\s\S]*?\)")
+
+
+count = 0
+for f in THIS_DIR.glob("**/*"):
+    if f.suffix != ".py":
+        continue
+
+    with open(f) as file_:
+        content = file_.read()
+
+    search_res = RAISE.findall(content)
+    good_matches = []
+    if search_res:
+        for m in search_res:
+            if 'f"' in m:
+                good_matches.append(m)
+                count += 1
+
+    if good_matches:
+        print("\n### FILE ###", f.relative_to(THIS_DIR))
+        for good_match in good_matches:
+            print(good_match)
+
+print(count)

--- a/development_scripts/demo_fancy_str/search_for_raise_with_fstring.py
+++ b/development_scripts/demo_fancy_str/search_for_raise_with_fstring.py
@@ -1,9 +1,13 @@
+"""This file will look for f-strings in exceptions messages of any .py files **in the folder it is
+placed in** or its sub folders."""
+
 import re
 from pathlib import Path
 
 THIS_DIR = Path(__file__).resolve().parent
 
 
+# Look for the 'raise' keyword and capture anything in parentheses (non greedily) after that keyword
 RAISE = re.compile("raise .*?\([\s\S]*?\)")
 
 
@@ -18,6 +22,7 @@ for f in THIS_DIR.glob("**/*"):
     search_res = RAISE.findall(content)
     good_matches = []
     if search_res:
+        # Look for the f-string marker in the found exceptions strings
         for m in search_res:
             if 'f"' in m:
                 good_matches.append(m)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,3 +11,4 @@ twine
 setuputils3
 tox
 invoke
+dateutil  # For timezone handling in tests

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,4 +11,4 @@ twine
 setuputils3
 tox
 invoke
-dateutil  # For timezone handling in tests
+python-dateutil  # For timezone handling in tests

--- a/src/ixdat/config.py
+++ b/src/ixdat/config.py
@@ -26,10 +26,10 @@ class _Config:
             ixdat will make the directory if it does not exist.
         standard_metadata_suffix (str): The file ext. for JSON format metadata files
         standard_data_suffix (str): The file extension for numpy.save format data files
-        timestamp_string_format (str): A format string for datetime.datetime.strftime. Defaults
-            to ixdats custom datetime format: 22E18 14:34:55
-        timezone (datetime.timezone): The timezone timestamps should use when formatted to
-            string. Defaults to the current local timestamp.
+        timestamp_string_format (str): A format string for datetime.datetime.strftime.
+            Defaults to ixdats custom datetime format: 22E18 14:34:55
+        timezone (datetime.timezone): The timezone timestamps should use when formatted
+            to string. Defaults to the current local timestamp.
     """
 
     def __init__(self):

--- a/src/ixdat/config.py
+++ b/src/ixdat/config.py
@@ -13,7 +13,7 @@ ixdat.config.plugins.use_si_quant = True  # use the spectro_inlets_quantificatio
 
 See `help(ixdat.options.plugins)` for information.
 """
-
+import datetime
 from pathlib import Path
 from .tools import deprecate
 
@@ -26,6 +26,10 @@ class _Config:
             ixdat will make the directory if it does not exist.
         standard_metadata_suffix (str): The file ext. for JSON format metadata files
         standard_data_suffix (str): The file extension for numpy.save format data files
+        timestamp_string_format (str): A format string for datetime.datetime.strftime. Defaults
+            to ixdats custom datetime format: 22E18 14:34:55
+        timezone (datetime.timezone): The timezone timestamps should use when formatted to
+            string. Defaults to the current local timestamp.
     """
 
     def __init__(self):
@@ -34,6 +38,8 @@ class _Config:
         self.standard_ixdat_directory = Path.home() / ".ixdat"
         self.standard_data_directory = self.standard_ixdat_directory / "projects"
         self.default_project_name = "test"
+        self.timestamp_string_format = "native"
+        self.timezone = datetime.datetime.now(datetime.timezone.utc).astimezone().tzinfo
 
     @property
     def ixdat_temp_dir(self):

--- a/src/ixdat/data_series.py
+++ b/src/ixdat/data_series.py
@@ -87,7 +87,7 @@ class TimeSeries(DataSeries):
         # On the form: TimeSeries: 'NAME', Span: 12..4000s @ 22E18 14:34:55
         return (
             f"{self.__class__.__name__}: '{self.name}', "
-            f"Span: {min(self.data):.0f}..{max(self.data):.0f} {self.unit.name} "
+            f"Span: {min(self.data):.0f}..{max(self.data):.0f}{self.unit.name} "
             f"@ {tstamp_to_string(self.tstamp)}"
         )
 
@@ -238,7 +238,7 @@ class ValueSeries(Field):
         """Return string representation"""
         return (
             f"{self.__class__.__name__}: '{self.name}', "
-            f"Span: {min(self.data):.1e}..{max(self.data):.1e} {self.unit.name}"
+            f"Span: {min(self.data):.1e}..{max(self.data):.1e}{self.unit.name}"
         )
 
     @property

--- a/src/ixdat/data_series.py
+++ b/src/ixdat/data_series.py
@@ -84,10 +84,10 @@ class TimeSeries(DataSeries):
 
     def __str__(self):
         """Return TimeSeries string representation"""
-        # On the form: TimeSeries: 'NAME', Span: 12..4000s @ 22E18 14:34:55
+        # On the form: TimeSeries: 'NAME'. Min, max: 12, 4000 [s] @ 22E18 14:34:55
         return (
-            f"{self.__class__.__name__}: '{self.name}', "
-            f"Span: {min(self.data):.0f}..{max(self.data):.0f}{self.unit.name} "
+            f"{self.__class__.__name__}: '{self.name}'. "
+            f"Min, max: {min(self.data):.0f}, {max(self.data):.0f} [{self.unit.name}] "
             f"@ {tstamp_to_string(self.tstamp)}"
         )
 
@@ -236,9 +236,11 @@ class ValueSeries(Field):
 
     def __str__(self):
         """Return string representation"""
+        # Return a string representation on the form:
+        # ValueSeries: 'NAME'. Min, max: -1.23, 4.56 [V]
         return (
-            f"{self.__class__.__name__}: '{self.name}', "
-            f"Span: {min(self.data):.1e}..{max(self.data):.1e}{self.unit.name}"
+            f"{self.__class__.__name__}: '{self.name}'. "
+            f"Min, max: {min(self.data):.1e}, {max(self.data):.1e} [{self.unit.name}]"
         )
 
     @property

--- a/src/ixdat/data_series.py
+++ b/src/ixdat/data_series.py
@@ -8,6 +8,7 @@ case, TimeSeries, which must know its absolute (unix) timestamp.
 
 import numpy as np
 from .db import Saveable
+from .tools import tstamp_to_string
 from .units import Unit
 from .exceptions import AxisError, BuildError
 
@@ -80,6 +81,15 @@ class TimeSeries(DataSeries):
         """
         super().__init__(name, unit_name, data)
         self.tstamp = tstamp
+
+    def __str__(self):
+        """Return TimeSeries string representation"""
+        # On the form: TimeSeries: 'NAME', Span: 12..4000s @ 22E18 14:34:55
+        return (
+            f"{self.__class__.__name__}: '{self.name}', "
+            f"Span: {min(self.data):.0f}..{max(self.data):.0f} {self.unit.name} "
+            f"@ {tstamp_to_string(self.tstamp)}"
+        )
 
     @property
     def t(self):
@@ -223,6 +233,13 @@ class ValueSeries(Field):
         # TODO: This could probably be handled more nicely with PlaceHolderObjects
         #   see: Measurement and
         #   https://github.com/ixdat/ixdat/pull/1#discussion_r551518461
+
+    def __str__(self):
+        """Return string representation"""
+        return (
+            f"{self.__class__.__name__}: '{self.name}', "
+            f"Span: {min(self.data):.1e}..{max(self.data):.1e} {self.unit.name}"
+        )
 
     @property
     def tseries(self):

--- a/src/ixdat/data_series.py
+++ b/src/ixdat/data_series.py
@@ -150,20 +150,20 @@ class Field(DataSeries):
         N = self.N_dimensions
         if len(self._a_ids) != N:
             raise AxisError(
-                f"{self} is {N}-D but initiated with {len(self._a_ids)} axis id's"
+                f"{self!r} is {N}-D but initiated with {len(self._a_ids)} axis id's"
             )
         if len(self._axes_series) != N:
             raise AxisError(
-                f"{self} is {N}-D but initiated with {len(self._axes_series)} axes"
+                f"{self!r} is {N}-D but initiated with {len(self._axes_series)} axes"
             )
         for n, (a_id, axis_series) in enumerate(zip(self._a_ids, self._axes_series)):
             if a_id is not None and axis_series is not None and a_id != axis_series.id:
                 raise AxisError(
-                    f"{self} initiated with contradicting id's for {n}'th axis"
+                    f"{self!r} initiated with contradicting id's for {n}'th axis"
                 )
             elif a_id is None and axis_series is None:
                 raise AxisError(
-                    f"{self} has no axis id for series or id for its {n}'th axis"
+                    f"{self!r} has no axis id for series or id for its {n}'th axis"
                 )
 
     @property
@@ -173,7 +173,7 @@ class Field(DataSeries):
             self._data = self.load_data()
             if len(self._data.shape) != self.N_dimensions:
                 raise AxisError(
-                    f"{self} has {self.N_dimensions} axes but its data is "
+                    f"{self!r} has {self.N_dimensions} axes but its data is "
                     f"{len(self._data.shape)}-dimensional."
                 )
         return self._data.copy()  # TODO: make data series data immutable with numpy flag
@@ -295,7 +295,7 @@ def append_series(series_list, sorted=True, name=None, tstamp=None):
             series_list, sorted=sorted, name=name, tstamp=tstamp
         )
     raise BuildError(
-        f"An algorithm of append_series for series like {s0} is not yet implemented"
+        f"An algorithm of append_series for series like {s0!r} is not yet implemented"
     )
 
 

--- a/src/ixdat/db.py
+++ b/src/ixdat/db.py
@@ -184,7 +184,7 @@ class Saveable:
                 #   ID by Saveable.__init__ ?
             else:
                 raise DataBaseError(
-                    f"{self} comes from {self.backend_name} "
+                    f"{self!r} comes from {self.backend_name} "
                     "but did not get an id from its backend."
                 )
         return self._id
@@ -259,7 +259,7 @@ class Saveable:
         exclude = exclude or []
         if self.column_attrs is None:
             raise DataBaseError(
-                f"{self} can't be serialized because the class "
+                f"{self!r} can't be serialized because the class "
                 f"{self.__class__.__name__} hasn't defined column_attrs"
             )
         self_as_dict = {  # FIXME: probably better as loop, fix with table definitions.

--- a/src/ixdat/measurements.py
+++ b/src/ixdat/measurements.py
@@ -172,8 +172,8 @@ class Measurement(Saveable):
                     out.append("┣━ " + str(value_series))
 
         return (
-            f"{self.__class__.__name__} '{self.name}' with {len(self.series_list)} series\n"
-            "\n"
+            f"{self.__class__.__name__} '{self.name}' with {len(self.series_list)} "
+            "series\n\n"
             "Series list:\n" + "\n".join(out)
         )
         return out

--- a/src/ixdat/measurements.py
+++ b/src/ixdat/measurements.py
@@ -494,7 +494,7 @@ class Measurement(Saveable):
             calibration_class = CALIBRATION_CLASSES[self.technique]
         else:
             raise TechniqueError(
-                f"{self} is of technique '{self.technique}', for which there is not an "
+                f"{self!r} is of technique '{self.technique}, for which there is not an "
                 "available default calibration. Instead, import one of the following "
                 "classes to initiate a calibration, and then use `add_calibration`. "
                 f"\nOptions: \n{CALIBRATION_CLASSES}"
@@ -731,7 +731,7 @@ class Measurement(Saveable):
                 if k == key:  # this would result in infinite recursion.
                     print(  # TODO: Real warnings.
                         "WARNING!!!\n"
-                        f"\t{self} has {key} in its aliases for {key}:\n"
+                        f"\t{self!r} has {key} in its aliases for {key}:\n"
                         f"\tself.aliases['{key}'] = {self.aliases[key]}"
                     )
                     continue
@@ -753,7 +753,7 @@ class Measurement(Saveable):
         if key.endswith("-v") or key.endswith("-y"):
             return self[key[:-2]]
 
-        raise SeriesNotFoundError(f"{self} does not contain '{key}'")
+        raise SeriesNotFoundError(f"{self!r} does not contain '{key}'")
 
     def replace_series(self, series_name, new_series=None):
         """Remove an existing series, add a series to the measurement, or both.
@@ -771,7 +771,7 @@ class Measurement(Saveable):
         """
         if new_series and not series_name == new_series.name:
             raise TypeError(
-                f"Cannot replace {series_name} in {self} with {new_series}. "
+                f"Cannot replace {series_name} in {self!r} with {new_series}. "
                 f"Names must agree."
             )
         if series_name in self._cached_series:
@@ -1146,7 +1146,7 @@ class Measurement(Saveable):
         if args:
             if not self.selector_name:
                 raise BuildError(
-                    f"{self} does not have a default selection string "
+                    f"{self!r} does not have a default selection string "
                     f"(Measurement.sel_str), and so selection only works with kwargs."
                 )
             kwargs[self.selector_name] = args[0]
@@ -1212,7 +1212,7 @@ class Measurement(Saveable):
             selector_name = selector_name or self.selector_name
             if not selector_name:
                 raise BuildError(
-                    f"{self} does not have a default selector_name "
+                    f"{self:r} does not have a default selector_name "
                     f"(Measurement.selector_name), and so selection only works "
                     f"with a selector_name specified "
                     f"(see `help(Measurement.select_values)`)"

--- a/src/ixdat/measurements.py
+++ b/src/ixdat/measurements.py
@@ -149,6 +149,35 @@ class Measurement(Saveable):
         #    dynamically choose plotters (Nice idea from Anna:
         #    https://github.com/ixdat/ixdat/issues/32)
 
+    def __str__(self):
+        """Return string representation"""
+        tseries_to_valueseries = {}
+        for series in self.series_list:
+            if isinstance(series, TimeSeries):
+                if series not in tseries_to_valueseries:
+                    tseries_to_valueseries[series] = []
+            else:
+                if series.tseries in tseries_to_valueseries:
+                    tseries_to_valueseries[series.tseries].append(series)
+                else:
+                    tseries_to_valueseries[series.tseries] = [series]
+
+        out = []
+        for tseries, value_serieses in tseries_to_valueseries.items():
+            out.append("┏ " + str(tseries))
+            for n, value_series in enumerate(value_serieses):
+                if n == len(value_serieses) - 1:
+                    out.append("┗━ " + str(value_series))
+                else:
+                    out.append("┣━ " + str(value_series))
+
+        return (
+            f"{self.__class__.__name__} '{self.name}' with {len(self.series_list)} series\n"
+            "\n"
+            "Series list:\n" + "\n".join(out)
+        )
+        return out
+
     @classmethod
     def from_dict(cls, obj_as_dict):
         """Return an object of the measurement class of the right technique

--- a/src/ixdat/measurements.py
+++ b/src/ixdat/measurements.py
@@ -1411,7 +1411,8 @@ class Calibration(Saveable):
             measurement (Measurement): Optional. A measurement to calibrate by default.
         """
         super().__init__()
-        self.name = name or f"{self.__class__.__name__}({measurement})"
+        # NOTE: The :r syntax in f-strings doesn't work on None
+        self.name = name or f"{self.__class__.__name__}({repr(measurement)})"
         self.technique = technique
         self.tstamp = tstamp or (measurement.tstamp if measurement else None)
         self.measurement = measurement

--- a/src/ixdat/measurements.py
+++ b/src/ixdat/measurements.py
@@ -26,7 +26,7 @@ from .projects.lablogs import LabLog
 from .exporters.csv_exporter import CSVExporter
 from .plotters.value_plotter import ValuePlotter
 from .exceptions import BuildError, SeriesNotFoundError, TechniqueError, ReadError
-from .tools import deprecate, tstamp_to_yyMdd
+from .tools import deprecate, tstamp_to_string
 
 
 class Measurement(Saveable):
@@ -444,7 +444,7 @@ class Measurement(Saveable):
 
     @property
     def yyMdd(self):
-        return tstamp_to_yyMdd(self.tstamp)
+        return tstamp_to_string(self.tstamp, string_format="native_date")
 
     @property
     def metadata_json_string(self):

--- a/src/ixdat/spectra.py
+++ b/src/ixdat/spectra.py
@@ -572,7 +572,7 @@ class SpectrumSeries(Spectrum):
     def yseries(self):
         # Should this return an average or would that be counterintuitive?
         raise BuildError(
-            f"{self} has no single y-series. Index it to get a Spectrum "
+            f"{self!r} has no single y-series. Index it to get a Spectrum "
             "or see `y_average`"
         )
 

--- a/src/ixdat/techniques/cv.py
+++ b/src/ixdat/techniques/cv.py
@@ -273,7 +273,7 @@ class CyclicVoltammogram(ECMeasurement):
         if not len(my_sweep_specs) == len(others_sweep_specs):
             raise BuildError(
                 "Can only make diff of CyclicVoltammograms with same number of sweeps."
-                f"{self} has {my_sweep_specs} and {other} has {others_sweep_specs}."
+                f"{self!r} has {my_sweep_specs} and {other!r} has {others_sweep_specs}."
             )
 
         diff_values = {name: np.array([]) for name in v_list}
@@ -284,7 +284,7 @@ class CyclicVoltammogram(ECMeasurement):
             if not other_spec[1] == sweep_type:
                 raise BuildError(
                     "Corresponding sweeps must be of same type when making diff."
-                    f"Can't align {self}'s {my_spec} with {other}'s {other_spec}."
+                    f"Can't align {self!r}'s {my_spec} with {other!r}'s {other_spec}."
                 )
             my_tspan = my_spec[0]
             other_tspan = other_spec[0]

--- a/src/ixdat/techniques/ms.py
+++ b/src/ixdat/techniques/ms.py
@@ -344,7 +344,7 @@ class MSMeasurement(Measurement):
         new_item = self.reverse_aliases[item][0]
         if self.is_mass(new_item):
             return self.as_mass(new_item)
-        raise TypeError(f"{self} does not recognize '{item}' as a mass.")
+        raise TypeError(f"{self!r} does not recognize '{item}' as a mass.")
 
     @deprecate(
         "0.2.6",
@@ -1053,7 +1053,7 @@ class MSCalibration(Calibration):
         cal_list_for_mol = [cal for cal in self if cal.mol == mol or cal.name == mol]
         Fs = [cal.F for cal in cal_list_for_mol]
         if not Fs:
-            raise QuantificationError(f"{self} has no sensitivity factor for {mol}")
+            raise QuantificationError(f"{self!r} has no sensitivity factor for {mol}")
         index = np.argmax(np.array(Fs))
 
         the_good_cal = cal_list_for_mol[index]
@@ -1069,7 +1069,7 @@ class MSCalibration(Calibration):
         F_list = [cal.F for cal in cal_list_for_mol_at_mass]
         if not F_list:
             raise QuantificationError(
-                f"{self} has no sensitivity factor for {mol} at {mass}"
+                f"{self!r} has no sensitivity factor for {mol} at {mass}"
             )
         return np.mean(np.array(F_list))
 

--- a/src/ixdat/tools.py
+++ b/src/ixdat/tools.py
@@ -1,13 +1,16 @@
 """This module contains general purpose tools"""
+import datetime
 import inspect
 import time
 import warnings
 from functools import wraps
+from string import ascii_uppercase
 
 import numpy as np
 from packaging import version
 
 from ixdat.exceptions import DeprecationError
+from ixdat.config import CFG
 from ixdat import __version__
 
 warnings.simplefilter("default")
@@ -259,17 +262,21 @@ def deprecate(
     return decorator
 
 
-def tstamp_to_yyMdd(tstamp: float) -> str:
-    """Return the date in compact form "yyMdd" format given the unix time (float).
+def tstamp_to_string(tstamp):
+    """Return a string representation if unix timestamps `tstamp`"""
+    dt = datetime.datetime.fromtimestamp(tstamp)
+    print(dt.tzinfo)
+    string_format = CFG.timestamp_string_format
+    if string_format == "native":
+        # ixdat shows months as capital letters, where Jan->A, Feb->B etc.
+        month_letter = ascii_uppercase[dt.month - 1]
+        # Brings to the total format to: 22E18 14:34:55
+        string_format = f"%y{month_letter}%d %H:%M:%S"
+    return dt.astimezone(CFG.timezone).strftime(string_format)
 
-    In this format the month is given as a capital letter, starting with A for January.
-    E.g. June 4th, 2022 will become 22F04.
-    """
-    a = time.localtime(tstamp)
-    year = a.tm_year
-    month = a.tm_mon
-    day = a.tm_mday
-    date_string = "{0:02d}{1:1s}{2:02d}".format(
-        year % 100, chr(ord("A") + month - 1), day
-    )
-    return date_string
+
+if __name__ == "__main__":
+    from time import time
+
+    t0 = time()
+    print(tstamp_to_string(t0))

--- a/src/ixdat/tools.py
+++ b/src/ixdat/tools.py
@@ -294,11 +294,11 @@ def tstamp_to_string(tstamp: float, string_format: Optional[str] = None) -> str:
 
     Args:
         tstamp (float): The unix time stamp to convert
-        string_format (str): Optional. The datetime string format to use. If not given, the
-            value of ``ixdat.config.config.timestamp_string_format`` will be used. Accepted values
-            are format strings accepted by `datetime.datetime.strftime` or "native" or
-            "native_date", which will produce ixdat native datetime strings or date string
-            respectively.
+        string_format (str): Optional. The datetime string format to use. If not given,
+            the value of ``ixdat.config.config.timestamp_string_format`` will be used.
+            Accepted values are format strings accepted by `datetime.datetime.strftime`
+            or "native" or "native_date", which will produce ixdat native datetime
+            strings or date string respectively.
 
     """
     dt = datetime.datetime.fromtimestamp(tstamp, ixdat.config.config.timezone)

--- a/src/ixdat/tools.py
+++ b/src/ixdat/tools.py
@@ -10,7 +10,9 @@ import numpy as np
 from packaging import version
 
 from ixdat.exceptions import DeprecationError
-from ixdat.config import CFG
+import ixdat.config
+
+# from ixdat.config import CFG
 from ixdat import __version__
 
 warnings.simplefilter("default")
@@ -280,14 +282,13 @@ def tstamp_to_yyMdd(tstamp: float) -> str:
 def tstamp_to_string(tstamp: float) -> str:
     """Return a string representation if unix timestamps `tstamp`"""
     dt = datetime.datetime.fromtimestamp(tstamp)
-    print(dt.tzinfo)
-    string_format = CFG.timestamp_string_format
+    string_format = ixdat.config.config.timestamp_string_format
     if string_format == "native":
         # ixdat shows months as capital letters, where Jan->A, Feb->B etc.
         month_letter = ascii_uppercase[dt.month - 1]
         # Brings to the total format to: 22E18 14:34:55
         string_format = f"%y{month_letter}%d %H:%M:%S"
-    return dt.astimezone(CFG.timezone).strftime(string_format)
+    return dt.astimezone(ixdat.config.config.timezone).strftime(string_format)
 
 
 if __name__ == "__main__":

--- a/src/ixdat/tools.py
+++ b/src/ixdat/tools.py
@@ -292,7 +292,5 @@ def tstamp_to_string(tstamp: float) -> str:
 
 
 if __name__ == "__main__":
-    from time import time
-
-    t0 = time()
+    t0 = time.time()
     print(tstamp_to_string(t0))

--- a/src/ixdat/tools.py
+++ b/src/ixdat/tools.py
@@ -281,14 +281,14 @@ def tstamp_to_yyMdd(tstamp: float) -> str:
 
 def tstamp_to_string(tstamp: float) -> str:
     """Return a string representation if unix timestamps `tstamp`"""
-    dt = datetime.datetime.fromtimestamp(tstamp)
+    dt = datetime.datetime.fromtimestamp(tstamp, ixdat.config.config.timezone)
     string_format = ixdat.config.config.timestamp_string_format
     if string_format == "native":
         # ixdat shows months as capital letters, where Jan->A, Feb->B etc.
         month_letter = ascii_uppercase[dt.month - 1]
         # Brings to the total format to: 22E18 14:34:55
         string_format = f"%y{month_letter}%d %H:%M:%S"
-    return dt.astimezone(ixdat.config.config.timezone).strftime(string_format)
+    return dt.strftime(string_format)
 
 
 if __name__ == "__main__":

--- a/src/ixdat/tools.py
+++ b/src/ixdat/tools.py
@@ -298,7 +298,7 @@ def tstamp_to_string(tstamp: float, string_format: Optional[str] = None) -> str:
             the value of ``ixdat.config.config.timestamp_string_format`` will be used.
             Accepted values are format strings accepted by `datetime.datetime.strftime`
             or "native" or "native_date", which will produce ixdat native datetime
-            strings or date string respectively.
+            strings or date strings respectively.
 
     """
     dt = datetime.datetime.fromtimestamp(tstamp, ixdat.config.config.timezone)

--- a/src/ixdat/tools.py
+++ b/src/ixdat/tools.py
@@ -262,7 +262,22 @@ def deprecate(
     return decorator
 
 
-def tstamp_to_string(tstamp):
+def tstamp_to_yyMdd(tstamp: float) -> str:
+    """Return the date in compact form "yyMdd" format given the unix time (float).
+    In this format the month is given as a capital letter, starting with A for January.
+    E.g. June 4th, 2022 will become 22F04.
+    """
+    a = time.localtime(tstamp)
+    year = a.tm_year
+    month = a.tm_mon
+    day = a.tm_mday
+    date_string = "{0:02d}{1:1s}{2:02d}".format(
+        year % 100, chr(ord("A") + month - 1), day
+    )
+    return date_string
+
+
+def tstamp_to_string(tstamp: float) -> str:
     """Return a string representation if unix timestamps `tstamp`"""
     dt = datetime.datetime.fromtimestamp(tstamp)
     print(dt.tzinfo)

--- a/src/ixdat/tools.py
+++ b/src/ixdat/tools.py
@@ -5,6 +5,7 @@ import time
 import warnings
 from functools import wraps
 from string import ascii_uppercase
+from typing import Optional
 
 import numpy as np
 from packaging import version
@@ -264,6 +265,15 @@ def deprecate(
     return decorator
 
 
+@deprecate(
+    last_supported_release="0.2.8",
+    update_message=(
+        "Please use `ixdat.tools.tstamp_to_string` with the keyword argument "
+        "`string_format='native_date'` instead."
+    ),
+    hard_deprecation_release="0.2.12",
+    remove_release="0.2.14",
+)
 def tstamp_to_yyMdd(tstamp: float) -> str:
     """Return the date in compact form "yyMdd" format given the unix time (float).
     In this format the month is given as a capital letter, starting with A for January.
@@ -279,15 +289,31 @@ def tstamp_to_yyMdd(tstamp: float) -> str:
     return date_string
 
 
-def tstamp_to_string(tstamp: float) -> str:
-    """Return a string representation if unix timestamps `tstamp`"""
+def tstamp_to_string(tstamp: float, string_format: Optional[str] = None) -> str:
+    """Return a string representation of unix timestamps `tstamp`
+
+    Args:
+        tstamp (float): The unix time stamp to convert
+        string_format (str): Optional. The datetime string format to use. If not given, the
+            value of ``ixdat.config.config.timestamp_string_format`` will be used. Accepted values
+            are format strings accepted by `datetime.datetime.strftime` or "native" or
+            "native_date", which will produce ixdat native datetime strings or date string
+            respectively.
+
+    """
     dt = datetime.datetime.fromtimestamp(tstamp, ixdat.config.config.timezone)
-    string_format = ixdat.config.config.timestamp_string_format
-    if string_format == "native":
+    if string_format is None:
+        string_format = ixdat.config.config.timestamp_string_format
+
+    if string_format in ("native", "native_date"):
         # ixdat shows months as capital letters, where Jan->A, Feb->B etc.
         month_letter = ascii_uppercase[dt.month - 1]
-        # Brings to the total format to: 22E18 14:34:55
-        string_format = f"%y{month_letter}%d %H:%M:%S"
+        if string_format == "native":
+            # Brings to the total format to: 22E18 14:34:55
+            string_format = f"%y{month_letter}%d %H:%M:%S"
+        else:
+            string_format = f"%y{month_letter}%d"
+
     return dt.strftime(string_format)
 
 

--- a/tests/unit/test_data_series.py
+++ b/tests/unit/test_data_series.py
@@ -31,9 +31,9 @@ class TestTimeSeries:
             tseries = TimeSeries(
                 "time series", "s", arange(10.9, 1000.0, 100), dt.timestamp()
             )
-        assert (
-            str(tseries)
-            == f"TimeSeries: 'time series', Span: 11..911s @ 22{month_letter}18 15:17:14"
+        assert str(tseries) == (
+            f"TimeSeries: 'time series'. Min, max: 11, 911 [s] @ 22{month_letter}18 "
+            "15:17:14"
         )
 
 
@@ -49,5 +49,6 @@ class TestValueSeries:
             tseries=TimeSeries("time", "s", array([0.0, 0.1]), tstamp=100.0),
         )
         assert (
-            str(value_series) == "ValueSeries: 'MFC1 flow', Span: 4.6e-06..1.2e-03ml/min"
+            str(value_series)
+            == "ValueSeries: 'MFC1 flow'. Min, max: 4.6e-06, 1.2e-03 [ml/min]"
         )

--- a/tests/unit/test_data_series.py
+++ b/tests/unit/test_data_series.py
@@ -1,0 +1,53 @@
+"""Unit tests for data series"""
+
+from datetime import timezone, timedelta, datetime
+from string import ascii_uppercase
+from unittest.mock import patch
+
+import pytest
+from dateutil.relativedelta import relativedelta
+from numpy import arange, array
+
+from ixdat.data_series import TimeSeries, ValueSeries
+from ixdat.config import config
+
+
+@pytest.fixture
+def cfg():
+    """Fixture that patches out certain items on config.config"""
+    with patch.object(config, "timezone", timezone(timedelta(hours=2), "CEST")):
+        with patch.object(config, "timestamp_string_format", "native"):
+            yield config
+
+
+class TestTimeSeries:
+    """Test the TimeSeries class"""
+
+    def test_str(self, cfg):
+        """Test __str__ method"""
+        for n, month_letter in enumerate(ascii_uppercase[:12]):
+            # The timestamp is equal to 20A18 15:17:14 in UTC+2
+            dt = datetime.fromtimestamp(1642511834.9103568) + relativedelta(months=n)
+            tseries = TimeSeries(
+                "time series", "s", arange(10.9, 1000.0, 100), dt.timestamp()
+            )
+        assert (
+            str(tseries)
+            == f"TimeSeries: 'time series', Span: 11..911s @ 22{month_letter}18 15:17:14"
+        )
+
+
+class TestValueSeries:
+    """test the ValueSeries class"""
+
+    def test_str(self):
+        """Test __str__ method"""
+        value_series = ValueSeries(
+            "MFC1 flow",
+            "ml/min",
+            array([1.21111e-3, 4.58888e-6]),
+            tseries=TimeSeries("time", "s", array([0.0, 0.1]), tstamp=100.0),
+        )
+        assert (
+            str(value_series) == "ValueSeries: 'MFC1 flow', Span: 4.6e-06..1.2e-03ml/min"
+        )

--- a/tests/unit/test_data_series.py
+++ b/tests/unit/test_data_series.py
@@ -11,11 +11,14 @@ from numpy import arange, array
 from ixdat.data_series import TimeSeries, ValueSeries
 from ixdat.config import config
 
+TZ = timezone(timedelta(hours=2), "CEST")
+
 
 @pytest.fixture
 def cfg():
     """Fixture that patches out certain items on config.config"""
-    with patch.object(config, "timezone", timezone(timedelta(hours=2), "CEST")):
+    print("TZ", type(config.timezone), repr(config.timezone))
+    with patch.object(config, "timezone", TZ):
         with patch.object(config, "timestamp_string_format", "native"):
             yield config
 
@@ -27,14 +30,16 @@ class TestTimeSeries:
         """Test __str__ method"""
         for n, month_letter in enumerate(ascii_uppercase[:12]):
             # The timestamp is equal to 20A18 15:17:14 in UTC+2
-            dt = datetime.fromtimestamp(1642511834.9103568) + relativedelta(months=n)
+            dt = datetime.fromtimestamp(1642511834.9103568, tz=TZ) + relativedelta(
+                months=n
+            )
             tseries = TimeSeries(
                 "time series", "s", arange(10.9, 1000.0, 100), dt.timestamp()
             )
-        assert str(tseries) == (
-            f"TimeSeries: 'time series'. Min, max: 11, 911 [s] @ 22{month_letter}18 "
-            "15:17:14"
-        )
+            assert str(tseries) == (
+                f"TimeSeries: 'time series'. Min, max: 11, 911 [s] @ 22{month_letter}18 "
+                f"15:17:14"
+            )
 
 
 class TestValueSeries:


### PR DESCRIPTION
This PR implements one possible solution (see discussion below for alternatives) for the measurement series summary PR, which is implemented by modifying the `__str__` or series and measurements.

At the most basic level, the `__str__` of data series has been changed, to show, what I hope, is a more information version for user (note, that the `__repr__` stays the same programmer oriented default and we can use that internally in places where we want that) It looks like this for a ValueSeries and TimeSeries (the part after the ":"):
```text
Voltage __repr__: ValueSeries(id=2, name='Voltage [V]')
Voltage __str__: ValueSeries: 'Voltage [V]', Span: 1.4e+00..5.4e+00V

Voltage time __repr__: TimeSeries(id=1, name='Potential time [s]')
Voltage time __str__: TimeSeries: 'Potential time [s]', Span: 699..1481s @ 21B01 17:44:12
```
As you can see, the TimeSeries shows its name, span and starting date and timestamp in a compact way. The ValueSeries also shows its name, span (although possibly less relevant for value series, although it might e.g. show you the effect of a calibration in the future).

I had some debates with myself about whether to do spaces between the number and the units or not in these, so I happy to be swayed by someone else's opinion.

Built on top of this, is the implementation for measurements, which shows all the series (both time and value) and their internal relationships. This `__str__` uses the `__str__` of the series to produce nice output. It looks like this:
```text
ECMSMeasurement '2021-02-01 17_44_12' with 48 series

Series list:
┏ TimeSeries: 'Potential time [s]', Span: 699..1481s @ 21B01 17:44:12
┣━ ValueSeries: 'Voltage [V]', Span: 1.4e+00..5.4e+00V
┣━ ValueSeries: 'Current [mA]', Span: -2.5e-02..2.5e-02mA
┗━ ValueSeries: 'Cycle [n]', Span: 1.0e+00..1.0e+00n
┏ TimeSeries: 'Iongauge value time [s]', Span: 1..3042s @ 21B01 17:44:12
┗━ ValueSeries: 'Iongauge value [mbar]', Span: 6.6e-09..6.9e-07mbar
┏ TimeSeries: 'MFC1 setpoint time [s]', Span: 1..3043s @ 21B01 17:44:12
┗━ ValueSeries: 'MFC1 setpoint [ml/min]', Span: 5.0e+00..5.0e+00ml/min
┏ TimeSeries: 'MFC1 value time [s]', Span: 1..3043s @ 21B01 17:44:12
┗━ ValueSeries: 'MFC1 value [ml/min]', Span: -4.4e-01..5.0e+00ml/min
┏ TimeSeries: 'MFC2 setpoint time [s]', Span: 1..3043s @ 21B01 17:44:12
┗━ ValueSeries: 'MFC2 setpoint [ml/min]', Span: 1.0e+00..1.0e+00ml/min
┏ TimeSeries: 'MFC2 value time [s]', Span: 1..3043s @ 21B01 17:44:12
┗━ ValueSeries: 'MFC2 value [ml/min]', Span: -3.2e-02..-3.1e-02ml/min
┏ TimeSeries: 'PC setpoint time [s]', Span: 1..3043s @ 21B01 17:44:12
┗━ ValueSeries: 'PC setpoint [mbar]', Span: 1.0e+03..1.0e+03mbar
┏ TimeSeries: 'PC value time [s]', Span: 1..3043s @ 21B01 17:44:12
┗━ ValueSeries: 'PC value [mbar]', Span: 9.8e+02..1.1e+03mbar
┏ TimeSeries: 'Pirani1 value time [s]', Span: 1..3042s @ 21B01 17:44:12
┗━ ValueSeries: 'Pirani1 value [mbar]', Span: 1.0e-05..5.0e-02mbar
┏ TimeSeries: 'Pirani2 value time [s]', Span: 1..3043s @ 21B01 17:44:12
┗━ ValueSeries: 'Pirani2 value [mbar]', Span: 4.7e-02..8.7e-02mbar
┏ TimeSeries: 'Pirani3 value time [s]', Span: 1..3043s @ 21B01 17:44:12
┗━ ValueSeries: 'Pirani3 value [mbar]', Span: 1.0e-05..5.2e-02mbar
┏ TimeSeries: 'C0M2 time [s]', Span: 1..3041s @ 21B01 17:44:12
┗━ ValueSeries: 'M2 [A]', Span: 3.4e-12..2.0e-11A
┏ TimeSeries: 'C1M4 time [s]', Span: 1..3041s @ 21B01 17:44:12
┗━ ValueSeries: 'M4 [A]', Span: 1.2e-17..2.7e-10A
┏ TimeSeries: 'C2M18 time [s]', Span: 1..3041s @ 21B01 17:44:12
┗━ ValueSeries: 'M18 [A]', Span: 8.8e-14..5.6e-12A
┏ TimeSeries: 'C3M28 time [s]', Span: 1..3041s @ 21B01 17:44:12
┗━ ValueSeries: 'M28 [A]', Span: 7.9e-14..1.5e-11A
┏ TimeSeries: 'C4M32 time [s]', Span: 1..3042s @ 21B01 17:44:12
┗━ ValueSeries: 'M32 [A]', Span: 3.3e-18..1.8e-12A
┏ TimeSeries: 'C5M40 time [s]', Span: 1..3042s @ 21B01 17:44:12
┗━ ValueSeries: 'M40 [A]', Span: 1.1e-17..4.0e-12A
┏ TimeSeries: 'C6M44 time [s]', Span: 1..3042s @ 21B01 17:44:12
┗━ ValueSeries: 'M44 [A]', Span: 7.9e-18..6.3e-12A
┏ TimeSeries: 'C7M104 time [s]', Span: 1..3042s @ 21B01 17:44:12
┗━ ValueSeries: 'M104 [A]', Span: 6.8e-22..4.3e-14A
┏ TimeSeries: 'C8M26 time [s]', Span: 1..3042s @ 21B01 17:44:12
┗━ ValueSeries: 'M26 [A]', Span: 3.4e-17..2.5e-12A
┏ TimeSeries: 'C9M77 time [s]', Span: 1..3042s @ 21B01 17:44:12
┗━ ValueSeries: 'M77 [A]', Span: 1.1e-17..9.6e-13A
┏ TimeSeries: 'C10M88 time [s]', Span: 1..3042s @ 21B01 17:44:12
┗━ ValueSeries: 'M88 [A]', Span: 5.8e-18..4.2e-14A
┏ TimeSeries: 'C11M15 time [s]', Span: 1..3042s @ 21B01 17:44:12
┗━ ValueSeries: 'M15 [A]', Span: 3.4e-14..9.5e-12A
```

This output, as you can see, is very explicit, which is good in the sense that we don't hide anything. But it also may go into more detail than we want for a function like this. Like e.g. I'm not sure it is really useful to show the relation to time series on lines for themselves and it may be considered a waste of vertical space. I'm not married to the form of this output, so I'm very willing to take input, but if you don't all agree with each other on what should go instead, I will **make** you fight about it, since I don't think I should basically get a vote, since I'm not a "good user".

If one wanted to keep the information, but make it more compact, one might consider listing the time series in a "as function of" type to the right of the values series and to align the start of the time series vertically to make it easy to see which ones shares tseries:
```text
ValueSeries: 'Voltage [V]', Span: 1.4e+00..5.4e+00V              ('Potential time [s]', Span: 699..1481s @ 21B01 17:44:12)
ValueSeries: 'Current [mA]', Span: -2.5e-02..2.5e-02mA           ('Potential time [s]', Span: 699..1481s @ 21B01 17:44:12)
ValueSeries: 'Cycle [n]', Span: 1.0e+00..1.0e+00n                ('Potential time [s]', Span: 699..1481s @ 21B01 17:44:12)
ValueSeries: 'Iongauge value [mbar]', Span: 6.6e-09..6.9e-07mbar ('Iongauge value time [s]', Span: 1..3042s @ 21B01 17:44:12)
ValueSeries: 'M2 [A]', Span: 3.4e-12..2.0e-11A                   ('C0M2 time [s]', Span: 1..3041s @ 21B01 17:44:12)
```
But! Even with these series names, we are reaching 126 chars to a line, which might cause it to wrap around, depending on where it is output, which will ruin the experience. So again, I open to discussions about the form.

## `__str__` vs pandas style `describe`

I remember we discussed this idea once, about doing this with a dedicated `describe` method instead of changing the `__str__`, but I don't remember what the conclusion was. As I see it:

**`__str__`**
Pros: More discoverable
Cons: On the development side, we have to do extra work, when specifically we want a traditional repr-style string representation, like e.g. in exception strings. This has been done in this PR, so you can see what it looks like. And I also added a small tool, to look for all the exception that gets an f-string as input, so I could check that I caught them all. But this might of course be missed by someone else.

**`describe`**
Pros: Can take arguments or have more varieties, e.g. to tweak the detail level. No modification need to other code, since no mod of `__str__`
Cons: Less discoverable.

**NOTE:** I want to point out, that `__str__` is intended (Pythonic) to be modified, with whatever the author considers the canonical string representation. It is only because it falls back to the `__repr__` when not implemented, that we have come to expect this sort of very programmer oriented `ValueSeries(id=2, name='Voltage [V]')`.

## Date stamps

In, what I suppose will be the most controversial part of this PR at all, I have committed the heresy of making the format of the date part of the datetime stamps used in the `__str__`'s user configurable. This is out of concern for any user who might dare to not consider the Scott style date format the one true way, should any such agitators exist.