### PR TITLE
updated dead link to development page

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -136,4 +136,4 @@ Join us
 ``ixdat`` is free and open source software and we welcome input and new collaborators. Please help us improve ``ixdat``!
 
 Contact us (https://github.com/ixdat/ixdat/discussions or sbscott@ic.ac.uk) or just
-`get started developing <https://ixdat.readthedocs.io/en/latest/developing.html>`_.
+`get started developing <https://ixdat.readthedocs.io/en/latest/developing/index.html>`_.


### PR DESCRIPTION
The link to the Development page  on readthedocs in the README is a dead link. This PR updates the link address. 