### PR TITLE
Background class

### DIFF
--- a/NEXT_CHANGES.rst
+++ b/NEXT_CHANGES.rst
@@ -20,5 +20,11 @@ ixdat 0.2.9
 techniques
 ^^^^^^^^^^
 
+``MSMeasurement.remove_matrix_interference`` associates a background with the measurement
+  which subtracts a ratio (measured when there's only solvent) times the signal of the primary solvent
+  mass from the signal of specified masses. To use the background, put ``remove_background=True``
+  as argument to ``plot()`` or ``grab``.
+  Background classes are implemented in a way parallel to Calibration classes.
+
 ECOpticalMeasurement.get_spectrum() now has an option not to interpolate.
   Passing the argument `interpolate=False` gets it to choose nearest spectrum instead.

--- a/development_scripts/demo_matrix_interference_background.py
+++ b/development_scripts/demo_matrix_interference_background.py
@@ -11,11 +11,14 @@ from ixdat import Measurement
 data_dir = Path.home() / (
     "Dropbox/WORKSPACES/ICL people/Daisy/data/21D_LIB/2021-04-28 14_56_39 21D28_NMC_Li_mesh"
 )
-
-
-ms = Measurement.read(
-    data_dir / "2021-04-28 14_56_39 21D28_NMC_Li_mesh.tsv", technique="MS",
-)
+export_file = data_dir / "exported.csv"
+if False:  # load raw data
+    ms = Measurement.read(
+        data_dir / "2021-04-28 14_56_39 21D28_NMC_Li_mesh.tsv", technique="MS",
+    )
+    ms.export(export_file, tspan=ms.tspan, time_step=120)
+else:  # load exported data
+    ms = Measurement.read(export_file, reader="ixdat")
 
 
 ms.plot()
@@ -29,19 +32,19 @@ background = ms.remove_matrix_interference(
     tspan_norm = [16500, 17000]
 )
 
-diff1 = background.remove_bg_from_series("M44").data - ms["M44"].data
+diff1 = background.remove_bg_from_series("M44-bg-subtracted").data - ms["M44"].data
 
 print("diff1:")
-print(diff1)
+# print(diff1)
 
 # sanity check:
 ratio = diff1 / ms.grab_for_t("M15", ms["M44"].t)
 print("ratio:")
-print(ratio)  # should be constant
+# print(ratio)  # should be constant
 
 
 diff2 = ms.grab("M44", remove_background=True)[1] - ms.grab("M44", remove_background=False)[1]
 print("diff2 (should equal diff1):")
-print(diff2)
+# print(diff2)
 
 ms.plot(mass_list=["M15", "M44", "M26", "M2"], logplot=False, remove_background=True)

--- a/development_scripts/demo_matrix_interference_background.py
+++ b/development_scripts/demo_matrix_interference_background.py
@@ -14,7 +14,8 @@ data_dir = Path.home() / (
 export_file = data_dir / "exported.csv"
 if False:  # load raw data
     ms = Measurement.read(
-        data_dir / "2021-04-28 14_56_39 21D28_NMC_Li_mesh.tsv", technique="MS",
+        data_dir / "2021-04-28 14_56_39 21D28_NMC_Li_mesh.tsv",
+        technique="MS",
     )
     ms.export(export_file, tspan=ms.tspan, time_step=120)
 else:  # load exported data
@@ -27,9 +28,7 @@ ms.plot()
 ms.plot(mass_list=["M15", "M44", "M26", "M2"], logplot=False)
 
 background = ms.remove_matrix_interference(
-    mass_ref = "M15",
-    mass_list = ["M44", "M26"],
-    tspan_norm = [16500, 17000]
+    mass_ref="M15", mass_list=["M44", "M26"], tspan_norm=[16500, 17000]
 )
 
 diff1 = background.remove_bg_from_series("M44-bg-subtracted").data - ms["M44"].data
@@ -43,7 +42,10 @@ print("ratio:")
 # print(ratio)  # should be constant
 
 
-diff2 = ms.grab("M44", remove_background=True)[1] - ms.grab("M44", remove_background=False)[1]
+diff2 = (
+    ms.grab("M44", remove_background=True)[1]
+    - ms.grab("M44", remove_background=False)[1]
+)
 print("diff2 (should equal diff1):")
 # print(diff2)
 

--- a/development_scripts/demo_matrix_interference_background.py
+++ b/development_scripts/demo_matrix_interference_background.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+"""
+Created on Thu Dec 21 15:26:19 2023
+
+@author: Søren
+"""
+from pathlib import Path
+from ixdat import Measurement
+
+
+data_dir = Path.home() / (
+    "Dropbox/WORKSPACES/ICL people/Daisy/data/21D_LIB/2021-04-28 14_56_39 21D28_NMC_Li_mesh"
+)
+
+
+ms = Measurement.read(
+    data_dir / "2021-04-28 14_56_39 21D28_NMC_Li_mesh.tsv", technique="MS",
+)
+
+
+ms.plot()
+
+
+ms.plot(mass_list=["M15", "M44", "M26", "M2"], logplot=False)
+
+background = ms.remove_matrix_interference(
+    mass_ref = "M15",
+    mass_list = ["M44", "M26"],
+    tspan_norm = [16500, 17000]
+)
+
+diff1 = background.remove_bg_from_series("M44").data - ms["M44"].data
+
+print("diff1:")
+print(diff1)
+
+# sanity check:
+ratio = diff1 / ms.grab_for_t("M15", ms["M44"].t)
+print("ratio:")
+print(ratio)  # should be constant
+
+
+diff2 = ms.grab("M44", remove_background=True)[1] - ms.grab("M44", remove_background=False)[1]
+print("diff2 (should equal diff1):")
+print(diff2)
+
+ms.plot(mass_list=["M15", "M44", "M26", "M2"], logplot=False, remove_background=True)

--- a/src/ixdat/measurements.py
+++ b/src/ixdat/measurements.py
@@ -10,6 +10,7 @@ also defines the base class for Calibration, while technique-specific Calibratio
 classes will be defined in the corresponding module in ./techniques/
 """
 import json
+import warnings
 import numpy as np
 from .db import Saveable, PlaceHolderObject, fill_object_list
 from .data_series import (
@@ -49,7 +50,10 @@ class Measurement(Saveable):
         "measurement_series": ("data_series", "s_ids"),
     }
     child_attrs = [
-        "component_measurements", "calibration_list", "series_list", "background_list"
+        "component_measurements",
+        "calibration_list",
+        "series_list",
+        "background_list",
     ]
     # TODO: child_attrs should be derivable from extra_linkers?
 
@@ -137,10 +141,14 @@ class Measurement(Saveable):
             component_measurements, m_ids, cls=Measurement
         )
         self._calibration_list = fill_object_list(
-            calibration_list, c_ids, cls=Calibration,
+            calibration_list,
+            c_ids,
+            cls=Calibration,
         )
         self._background_list = fill_object_list(
-            background_list, b_ids, cls=Background,
+            background_list,
+            b_ids,
+            cls=Background,
         )
 
         self._tstamp = tstamp
@@ -514,7 +522,6 @@ class Measurement(Saveable):
         self._background_list = [background] + self._background_list
         self.clear_cache()
 
-
     def calibrate(self, *args, **kwargs):
         """Add a calibration of the Measurement's default calibration type
 
@@ -847,12 +854,12 @@ class Measurement(Saveable):
         self.replace_series(value_name, new_vseries)
 
     def grab(
-            self,
-            item,
-            tspan=None,
-            include_endpoints=False,
-            tspan_bg=None,
-            remove_background=False,
+        self,
+        item,
+        tspan=None,
+        include_endpoints=False,
+        tspan_bg=None,
+        remove_background=False,
     ):
         """Return a value vector with the corresponding time vector
 
@@ -885,9 +892,10 @@ class Measurement(Saveable):
             try:
                 vseries = self[item + "-bg-subtracted"]
             except SeriesNotFoundError:
-                UserWarning(
+                warnings.warn(
                     f"{self!r} tried to subtract background from {item} "
-                    f"but no relevant background available"
+                    f"but no relevant background available",
+                    stacklevel=2,
                 )
                 vseries = self[item]
         else:
@@ -1495,6 +1503,7 @@ class Calibration(Saveable):
         FIXME: Add more documentation about how to write this in inheriting classes.
         """
         raise NotImplementedError
+
 
 class Background(Saveable):
     """Base class for backgrounds."""

--- a/src/ixdat/plotters/ms_plotter.py
+++ b/src/ixdat/plotters/ms_plotter.py
@@ -25,7 +25,7 @@ class MSPlotter(MPLPlotter):
         mol_lists=None,
         tspan=None,
         tspan_bg=None,
-        remove_background=None,
+        remove_background=False,
         unit=None,
         x_unit=None,
         logplot=True,
@@ -65,7 +65,7 @@ class MSPlotter(MPLPlotter):
                 must also be two timespans - one for each axis. Default is `None` for no
                 background subtraction.
             remove_background (bool): Whether otherwise to subtract pre-determined
-                background signals if available. Defaults to (not logplot)
+                background signals if available. Defaults to False
             unit (str): unit of the y axis. defaults to "A" or "mol/s"
             x_unit (str): unit of the x axis variable (usually time). defaults to "s"
             logplot (bool): Whether to plot the MS data on a log scale (default True)
@@ -75,8 +75,6 @@ class MSPlotter(MPLPlotter):
             kwargs: extra key-word args are passed on to matplotlib's plot()
         """
         measurement = measurement or self.measurement
-        if remove_background is None:
-            remove_background = not logplot
 
         # Figure out, based on the inputs, whether or not to plot calibrated results
         # (`quantified`), specifications for the axis to plot on now (`specs_this_axis`)

--- a/src/ixdat/techniques/__init__.py
+++ b/src/ixdat/techniques/__init__.py
@@ -48,3 +48,10 @@ CALIBRATION_CLASSES = {
     "EC-MS": ECMSCalibration,
     "reactor": ReactorCalibration,
 }
+
+BACKGROUND_CLASSES = {
+    "EC": ECBackground,
+    "CV": ECBackground,
+    "MS": MSBackground,
+    "EC-MS": ECMSBackground,
+}

--- a/src/ixdat/techniques/__init__.py
+++ b/src/ixdat/techniques/__init__.py
@@ -9,7 +9,7 @@ Constants:
 
 from .ec import ECMeasurement, ECCalibration
 from .cv import CyclicVoltammogram, CyclicVoltammagram  # The latter is deprecated.
-from .ms import MSMeasurement, MSCalibration, SpectroMSMeasurement
+from .ms import MSMeasurement, MSCalibration, SpectroMSMeasurement, MSBackground
 from .ec_ms import ECMSMeasurement, ECMSCalibration
 from .spectroelectrochemistry import (
     SpectroECMeasurement,
@@ -50,8 +50,8 @@ CALIBRATION_CLASSES = {
 }
 
 BACKGROUND_CLASSES = {
-    "EC": ECBackground,
-    "CV": ECBackground,
+ #    "EC": ECBackground,
+ #   "CV": ECBackground,
     "MS": MSBackground,
-    "EC-MS": ECMSBackground,
+ #  "EC-MS": ECMSBackground,
 }

--- a/src/ixdat/techniques/__init__.py
+++ b/src/ixdat/techniques/__init__.py
@@ -50,8 +50,8 @@ CALIBRATION_CLASSES = {
 }
 
 BACKGROUND_CLASSES = {
- #    "EC": ECBackground,
- #   "CV": ECBackground,
+    #    "EC": ECBackground,
+    #   "CV": ECBackground,
     "MS": MSBackground,
- #  "EC-MS": ECMSBackground,
+    #  "EC-MS": ECMSBackground,
 }

--- a/src/ixdat/techniques/ms.py
+++ b/src/ixdat/techniques/ms.py
@@ -1166,7 +1166,6 @@ class MSCalibration(Calibration):
         )
 
 
-
 class MSBackground(Background):
 
     extra_column_attrs = ["mass_list"]
@@ -1178,8 +1177,6 @@ class MSBackground(Background):
         """
         super().__init__(**kwargs)
         self.mass_list = mass_list
-
-
 
 
 class MatrixInterferenceBackground(MSBackground):
@@ -1221,7 +1218,6 @@ class MatrixInterferenceBackground(MSBackground):
         self.mass_ref = mass_ref
         self.ratios = {}
 
-
     def remove_bg_from_series(self, key, measurement=None):
         """Return a calibrated series for `key` if possible.
 
@@ -1257,10 +1253,10 @@ class MatrixInterferenceBackground(MSBackground):
         mass_signal_bg_removed = signal - mass_moving_bg
 
         return ValueSeries(
-            name = signal_series.name + " minus matrix interference",
-            unit_name = signal_series.unit_name,
-            data = mass_signal_bg_removed,
-            tseries = signal_series.tseries,
+            name=signal_series.name + " minus matrix interference",
+            unit_name=signal_series.unit_name,
+            data=mass_signal_bg_removed,
+            tseries=signal_series.tseries,
         )
 
     def get_ratio(self, mass):
@@ -1271,9 +1267,7 @@ class MatrixInterferenceBackground(MSBackground):
         matrix_ref_primary = np.mean(
             self.measurement.grab(self.mass_ref, tspan=self.tspan_norm)[1]
         )
-        matrix_ref_M = np.mean(
-            self.measurement.grab(mass, tspan=self.tspan_norm)[1]
-        )
+        matrix_ref_M = np.mean(self.measurement.grab(mass, tspan=self.tspan_norm)[1])
         ratio = matrix_ref_M / matrix_ref_primary
 
         self.ratios[mass] = ratio


### PR DESCRIPTION
@ScottSoren and I implemented a background-class based on the calibration class, as discussed.

- We left the option `"tspan_bg" `which will subtract a constant background as a possibility in `grab()`. 
   Rationale to that decision: 
-- It's the simplest possible background
-- We might want to do that on top of a more sophisticated background anyway. 
-- It would require a lot of refactoring to remove the option without clear benefit.

- So far, one type of background is implemented: The class `MatrixInterferenceBackground,` which allows to subtract the signal of a matrix mass (eg solvent) multiplied by a factor determined where the only contribution to M is from the matrix molecule.
- The background subtraction works both for masses and mols (i.e. calibrated and uncalibrated data)
- This is a first start to solving #79 

We need to decide:
a) do we merge this now and then discuss whether there should be a common base class for calibration, background and filter, or should we refactor now and merge later? (I am pro merging now)
b) define other background classes before merging? (Eg some linear between points, ...)

Did I forget anything, @ScottSoren?