### PR TITLE
Patch Zilien datasets parsing

### DIFF
--- a/src/ixdat/measurements.py
+++ b/src/ixdat/measurements.py
@@ -176,7 +176,6 @@ class Measurement(Saveable):
             "series\n\n"
             "Series list:\n" + "\n".join(out)
         )
-        return out
 
     @classmethod
     def from_dict(cls, obj_as_dict):

--- a/src/ixdat/readers/zilien.py
+++ b/src/ixdat/readers/zilien.py
@@ -115,7 +115,7 @@ def determine_class(technique):
     else:
         raise TechniqueError(
             f'Unknown technique given: "{technique}". '
-            'Use one of the following: "EC-MS", "EC, "MS".'
+            'Use one of the following (in upper-case): "EC-MS", "EC, "MS".'
         )
 
 
@@ -132,7 +132,7 @@ class ZilienTSVReader:
         # a dictionary with metadata general information about the Zilien measurement
         self._metadata = None
         # a list with the Zilien TSV series headers,
-        # such as "Ionguage value" (see module docstring)
+        # such as "Iongauge value" (see module docstring)
         self._series_headers = None
         # a list with the Zilien TSV columns headers,
         # such as "Time [s]" and "Pressure [mbar]"

--- a/src/ixdat/readers/zilien.py
+++ b/src/ixdat/readers/zilien.py
@@ -13,6 +13,7 @@ Biologic dataset. These are grouped under the series header "EC-lab".
 """
 
 import re
+import sys
 import time
 from collections import defaultdict
 from itertools import groupby, zip_longest
@@ -26,7 +27,7 @@ from ..data_series import DataSeries, TimeSeries, ValueSeries, Field
 from ..techniques import ECMSMeasurement, MSMeasurement, ECMeasurement, Measurement
 from ..techniques.ms import MSSpectrum, MSSpectrumSeries
 from .reading_tools import timestamp_string_to_tstamp
-from ..exceptions import ReadError
+from ..exceptions import ReadError, TechniqueError
 
 
 ZILIEN_TIMESTAMP_FORM = "%Y-%m-%d %H_%M_%S"  # like 2021-03-15 18_50_10
@@ -66,7 +67,7 @@ def parse_metadata_line(line):
         full_name = name
 
     # Type convert the metadata (the specification for version 1 also has a color type,
-    # but as of yet it is not used)
+    # but it is not used yet)
     if type_as_str == "string":
         return full_name, value
     elif type_as_str == "int":
@@ -102,6 +103,22 @@ def to_mass(string):
     return None
 
 
+def determine_class(technique):
+    """Choose appropriate measurement class according to a given technique."""
+
+    if technique == "EC-MS":
+        return ECMSMeasurement
+    elif technique == "EC":
+        return ECMeasurement
+    elif technique == "MS":
+        return MSMeasurement
+    else:
+        raise TechniqueError(
+            f'Unknown technique given: "{technique}". '
+            'Use one of the following: "EC-MS", "EC, "MS".'
+        )
+
+
 class ZilienTSVReader:
     """Class for reading files saved by Spectro Inlets' Zilien software"""
 
@@ -126,7 +143,7 @@ class ZilienTSVReader:
     def read(
         self,
         path_to_file,
-        cls=ECMSMeasurement,
+        cls=None,
         name=None,
         include_mass_scans=True,
         **kwargs,
@@ -136,12 +153,12 @@ class ZilienTSVReader:
         Args:
             path_to_file (Path or str): The path of the file to read
             cls (Measurement): The measurement class to read the file as. Zilien tsv
-                files can be read both as an EC-MS measurement, a MS measurement (which
-                will exclude the EC series from the measurement) and as a ECMeasurement
+                files can be read both as an EC-MS measurement, an MS measurement (which
+                will exclude the EC series from the measurement) and as an EC measurement
                 (which will exclude the MS series from the measurement). To avoid
                 importing classes, this behavior can also be controlled by setting the
-                `technique` argument to either 'EC-MS', 'MS' or 'EC'. The default is a
-                ECMSMeasurement.
+                `technique` argument to either 'EC-MS', 'MS' or 'EC'. The default is
+                determined according to what is parsed from the dataset.
             name (str): The name of the measurement. Will default to the part of the
                 filename before the '.tsv' extension
             include_mass_scans (bool): Whether to include mass scans (if available) and
@@ -158,24 +175,6 @@ class ZilienTSVReader:
             )
             return self._measurement
 
-        if "technique" in kwargs:
-            if kwargs["technique"] == "EC-MS":
-                cls = ECMSMeasurement
-            if kwargs["technique"] == "EC":
-                cls = ECMeasurement
-            if kwargs["technique"] == "MS":
-                cls = MSMeasurement
-        else:
-            if cls is Measurement:
-                cls = ECMSMeasurement
-            if issubclass(cls, ECMSMeasurement):
-                kwargs["technique"] = "EC-MS"
-            elif issubclass(cls, ECMeasurement):
-                kwargs["technique"] = "EC"
-            elif issubclass(cls, MSMeasurement):
-                kwargs["technique"] = "MS"
-        self._cls = cls
-
         self._path_to_file = Path(path_to_file)
 
         # Parse metadata items
@@ -191,6 +190,14 @@ class ZilienTSVReader:
         with open(self._path_to_file, "rb") as file_handle:
             file_handle.seek(file_position)
             self._data = np.genfromtxt(file_handle, delimiter="\t")
+
+        if "technique" not in kwargs:
+            kwargs["technique"] = self._get_technique()
+
+        if cls is Measurement or cls is None:
+            self._cls = determine_class(kwargs["technique"])
+        else:
+            self._cls = cls
 
         # Part of filename before the extension
         file_stem = self._path_to_file.stem
@@ -220,7 +227,7 @@ class ZilienTSVReader:
             "metadata": self._metadata,
         }
         measurement_kwargs.update(kwargs)
-        self._measurement = cls(**measurement_kwargs)
+        self._measurement = self._cls(**measurement_kwargs)
 
         if include_mass_scans:
             # Check if there are MS spectra.
@@ -267,6 +274,49 @@ class ZilienTSVReader:
         column_headers = file_handle.readline().strip("\n").split("\t")
 
         return metadata, series_headers, column_headers
+
+    def _get_technique(self):
+        """Get technique according to parsed series headers and column headers.
+
+        This method covers the following cases:
+          - "pot" and "EC-lab" is in the metadata and in the headers. There is "EC-lab" data.
+          - "pot" and "EC-lab" is in the metadata and in the headers. There is no "EC-lab" data. (bug)
+          - "pot" is not in the metadata, but it is in the headers and the data part is filled with NaN. (bug)
+          - "pot" is neither in the metadata, nor in the headers.
+
+        """
+        pot_in_metadata = "pot_pot_count" in self._metadata
+        pot_in_series_headers = "pot" in self._series_headers
+
+        result = ""
+        # there was EC measurement
+        if pot_in_metadata and pot_in_series_headers:
+            result = "EC-MS"
+
+            # BUG CASE: EC-lab series header gets included, but .mpt data don't
+            if (
+                len(self._column_headers) < len(self._series_headers)
+                and self._series_headers[-1] == "EC-lab"
+            ):
+                result = "MS"
+                sys.stderr.write(
+                    "EC-lab data is missing in the dataset. That means Zilien did not"
+                    "find .mpt files when creating it. You can convert .mpr files into "
+                    ".mpt files in EC-lab (or read the .mpr files directly) and then "
+                    "connect the two Measurement objects.\n"
+                    "Reading only the Mass Scan part of the dataset.\n\n"
+                )
+        # BUG CASE: Zilien internal bug (https://github.com/ixdat/ixdat/issues/114)
+        elif not pot_in_metadata and pot_in_series_headers:
+            result = "MS"
+        # no EC did run and EC is not included in the settings dialog
+        elif not pot_in_metadata and not pot_in_series_headers:
+            result = "MS"
+        else:
+            # unexpected case, so go with the safest option
+            result = "MS"
+
+        return result
 
     def _form_series(self):
         """Form the series and series aliases

--- a/tests/regression/test_zilien_reader.py
+++ b/tests/regression/test_zilien_reader.py
@@ -1,0 +1,83 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+from ixdat import Measurement
+from ixdat.exceptions import SeriesNotFoundError
+from ixdat.techniques.ec_ms import (
+    ECMSMeasurement,
+    MSMeasurement,
+)
+
+
+DIR_FAILING = Path(__file__).parent.parent.parent / "submodules/ixdat-large-test-files/failing_datasets"
+
+OK_ECMS_DATASET = DIR_FAILING / "2024-01-17 15_21_57 ec-included/2024-01-17 15_21_57 ec-included.tsv"
+OK_MS_DATASET = DIR_FAILING / "2024-01-17 15_06_41 no-ec-nonincluded/2024-01-17 15_06_41 no-ec-nonincluded.tsv"
+MISSING_POT_SERIES_BUG = DIR_FAILING / "2024-01-17 15_08_29 no-ec-included/2024-01-17 15_08_29 no-ec-included.tsv"
+MISSING_ECLAB_MPTS_SERIES_BUG = DIR_FAILING / "2024-01-17 15_13_45 ec-included-mpt-missing/2024-01-17 15_13_45 ec-included-mpt-missing.tsv"
+
+
+@pytest.mark.external
+class TestRegressions:
+    """Test patched way and the old way of dataset parsing."""
+
+    def test_parse_ecms_measurement(self):
+        """Test parsing EC-MS dataset without specifying a technique."""
+        m = Measurement.read(OK_ECMS_DATASET)
+        assert isinstance(m, ECMSMeasurement)
+
+    def test_parse_ms_measurement(self):
+        """Test parsing MS dataset without specifying a technique."""
+        m = Measurement.read(OK_MS_DATASET)
+        assert isinstance(m, MSMeasurement)
+
+    def test_parse_ms_measurement_read_as_ecms_regression(self):
+        """Test parsing MS dataset the old way.
+
+        The dataset used to be created with ECMSMeasurement class by default.
+        That was failing, because an essential series 't' was missing.
+
+        """
+        with pytest.raises(SeriesNotFoundError):
+            m = Measurement.read(OK_MS_DATASET, technique="EC-MS")
+
+    def test_parse_with_missing_zilien_pot_data(self):
+        """Test patched parsing a buggy MS dataset with empty "pot" part."""
+        m = Measurement.read(MISSING_POT_SERIES_BUG)
+        assert isinstance(m, MSMeasurement)
+
+    def test_parse_with_missing_zilien_pot_data_regression(self):
+        """Test parsing a buggy MS dataset with empty "pot" part the old way.
+
+        The dataset used to be created with ECMSMeasurement class by default.
+        That was failing, because of the internal bug in Zilien, which caused
+        including empty "pot" series.
+
+        """
+        with pytest.raises(KeyError):
+            m = Measurement.read(MISSING_POT_SERIES_BUG, technique="EC-MS")
+
+    def test_parse_with_missing_biologic_data(self):
+        """Test patched parsing a buggy EC-MS dataset with missing EC-lab part."""
+
+        # silence the warning message for tests
+        sys.stderr.write = lambda _: _
+
+        m = Measurement.read(MISSING_ECLAB_MPTS_SERIES_BUG)
+        assert isinstance(m, MSMeasurement)
+
+    def test_parse_with_missing_biologic_data_regression(self):
+        """Test parsing a buggy EC-MS dataset with missing EC-lab part the old way.
+
+        The dataset used to be created with ECMSMeasurement class by default.
+        That was failing, because all the "EC-lab" series were missing, when no
+        .mpt files were found after Zilien measurement ended.
+
+        """
+        # silence the warning message for tests
+        sys.stderr.write = lambda _: _
+
+        with pytest.raises(ValueError):
+            m = Measurement.read(MISSING_ECLAB_MPTS_SERIES_BUG, technique="EC-MS")

--- a/tests/unit/test_zilien_reader.py
+++ b/tests/unit/test_zilien_reader.py
@@ -4,9 +4,12 @@ from unittest.mock import patch
 import numpy as np
 import pytest
 
-from ixdat.techniques import ECMeasurement, MSMeasurement, ECMSMeasurement
-from ixdat.readers.zilien import ZilienTSVReader, to_mass, parse_metadata_line
 from ixdat.data_series import TimeSeries, ValueSeries
+from ixdat.exceptions import TechniqueError
+from ixdat.readers.zilien import (
+    ZilienTSVReader, determine_class, to_mass, to_snake_case, parse_metadata_line
+)
+from ixdat.techniques import ECMeasurement, MSMeasurement, ECMSMeasurement
 
 
 DATA_DIR = Path(__file__).parent.parent.parent / "submodules" / "ixdat-large-test-files"
@@ -82,8 +85,13 @@ class TestZilienTSVReader:
         ),
     )
     def test_zilien_dataset_part(self, series_header, column_headers, expected_aliases):
-        """Test forming of Zilien part of a dataset."""
+        """Test forming of Zilien part of a dataset.
 
+        The headers are parametrized, because some headers do produce an alias
+        (C4M26 -> M26) and some do not. The data stays the same, because the
+        values in the columns don't have an effect on the parsing.
+
+        """
         reader = ZilienTSVReader()
         reader._timestamp = 123456
         reader._metadata = {
@@ -157,8 +165,13 @@ class TestZilienTSVReader:
         # fmt: on
     )
     def test_biologic_dataset_part(self, data, lines_count, expected_series_length):
-        """Test forming of Biologic part of a dataset."""
+        """Test forming of Biologic part of a dataset.
 
+        The data change, because the "experiment_number" and the "technique_number"
+        columns are used to split the data chuck into more chunks. The headers
+        stay the same, because nothing else is produces from them.
+
+        """
         reader = ZilienTSVReader()
         reader._timestamp = 123456
         reader._metadata = {
@@ -181,6 +194,62 @@ class TestZilienTSVReader:
 
         for i, count in enumerate(expected_series_length):
             assert series[i].data.size == count
+
+    @pytest.mark.parametrize(
+        "metadata, series_headers, column_headers, expected",
+        (
+            (  # good case with EC-lab data
+                {"pot_pot_count": 3},
+                ["pot", "", "", "", "Iongauge value", "", "EC-lab", "", ""],
+                [
+                    "Time [s]", "Voltage [V]", "Current [mA]", "Cycle [n]", "Time [s]", "Pressure [mbar]",
+                    "time/s", "experiment_number", "technique_number", "Ewe/V"
+                ],
+                "EC-MS"
+            ),
+            (  # bug case without EC-lab data
+                {"pot_pot_count": 3},
+                ["pot", "", "", "", "Iongauge value", "", "EC-lab"],
+                [
+                    "Time [s]", "Voltage [V]", "Current [mA]", "Cycle [n]", "Time [s]", "Pressure [mbar]",
+                ],
+                "MS"
+            ),
+            (  # bug case without pot data
+                {},
+                ["pot", "", "", "", "Iongauge value", ""],
+                [
+                    "Time [s]", "Voltage [V]", "Current [mA]", "Cycle [n]", "Time [s]", "Pressure [mbar]",
+                ],
+                "MS"
+            ),
+            (  # good case without EC measurement run
+                {},
+                ["Iongauge value", ""],
+                ["Time [s]", "Pressure [mbar]"],
+                "MS"
+            ),
+            (  # random and unexpected case
+                {"pot_pot_count": 3},
+                ["Iongauge value", ""],
+                ["Time [s]", "Pressure [mbar]"],
+                "MS"
+            ),
+            (  # random and unexpected case
+                {},
+                ["Iongauge value", "", "EC-lab", ""],
+                ["Time [s]", "Pressure [mbar]", "time/s", "Ewe/V"],
+                "MS"
+            ),
+        )
+    )
+    def test_get_technique(self, metadata, series_headers, column_headers, expected):
+        reader = ZilienTSVReader()
+        reader._metadata = metadata
+        reader._series_headers = series_headers
+        reader._column_headers = column_headers
+
+        assert reader._get_technique() == expected
 
     @pytest.mark.parametrize(
         "klass, expected_aliases, expected_series",
@@ -301,6 +370,22 @@ class TestZilienTSVReaderUtils:
     @pytest.mark.parametrize(
         "data, expected",
         (
+            ("", ""),
+            ("a", "a"),
+            ("A", "a"),
+            (" ", "_"),
+            ("_", "_"),
+            ("A String to-convert", "a_string_to-convert"),
+            ("TRAILING  SPACE  ", "trailing__space__"),
+        )
+    )
+    def test_to_snake_case(self, data, expected):
+        """Test converting a string to snakecase."""
+        assert to_snake_case(data) == expected
+
+    @pytest.mark.parametrize(
+        "data, expected",
+        (
             ("not-a-match", None),
             ("C0M2", "2"),
             ("C2M15", "15"),
@@ -310,6 +395,26 @@ class TestZilienTSVReaderUtils:
     def test_to_mass(self, data, expected):
         """Test conversion to mass."""
         assert to_mass(data) == expected
+
+    @pytest.mark.parametrize(
+        "data, expected",
+        (
+            ("EC-MS", ECMSMeasurement),
+            ("EC", ECMeasurement),
+            ("MS", MSMeasurement),
+        ),
+    )
+    def test_determine_class(self, data, expected):
+        """Test determining a class type."""
+        assert determine_class(data) == expected
+
+    @pytest.mark.parametrize(
+        "data", ("ec-ms", "ec", "ms", "read the exception message finally"),
+    )
+    def test_determine_class_error(self, data):
+        """Test an exception while determining a class type."""
+        with pytest.raises(TechniqueError):
+            determine_class(data)
 
     @pytest.mark.parametrize(
         "data, expected",


### PR DESCRIPTION
A patch for parsing of Zilien dataset. It is possible to read a measurement without specifying a `technique="MS"` kwargs. When a measurement is MS, it will be instantiated as MS. When it is EC-MS, it will be instantiated as EC-MS. Both by using `Measurement.read("my_dataset.tsv")`.

Directly fixing this issue:
- https://github.com/ixdat/ixdat/issues/95

And making these cases not happen:
- https://github.com/ixdat/ixdat/issues/107
- https://github.com/ixdat/ixdat/issues/114

The #107 is happening when .mpt files are not generated, thus "EC-lab" series are missing in the dataset, but the series header is still there. Normally, you want to read it as EC-MS measurement, but since there are no EC data, it is read just as an MS measurement and it gives a warning in a terminal.

The #114 is an internal Zilien bug that causes including empty "potential" series in a dataset even when no EC measurement was running. So there is an extra branch for this case and the dataset is normally parsed as MS measurement.

Whether a dataset is MS or EC-MS is determined after parsing metadata and headers, and `technique` is initialized. I changed a default value of `cls` in `ZilienTSVReader.read()` method from `ECMSMeasurement` to `None`. There is a `Measurement` type provided by default from `Measurement.read()`, but that is not very useful. So when `cls` is `Measurement` or `None` then the real `cls` is determined with the `technique` value.