### PR TITLE
Run external tests in CI, closes #162

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,9 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
+    - name: Update submodules
+      run: |
+        git submodule update --init --recursive --depth=1
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,5 +45,5 @@ jobs:
         invoke check-code-format
     - name: Test with pytest
       run: |
-        invoke test
+        invoke test --external
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "submodules/ixdat-large-test-files"]
 	path = submodules/ixdat-large-test-files
-	url = https://github.com/ixdat/ixdat-large-test-files.git
+	url = https://github.com/ixdat/ixdat-large-test-files

--- a/NEXT_CHANGES.rst
+++ b/NEXT_CHANGES.rst
@@ -123,3 +123,8 @@ General
   when it is a Mass Spec measurement. And when it includes an electrochemistry
   data, then ``ECMSMeasurement`` is used. The default/safe case is ``MSMeasurement``.
   Resolves `Issue #159 <https://github.com/ixdat/ixdat/pull/159>`_
+
+dev
+^^^
+
+- Enable running external tests in CI

--- a/tests/functional/test_eclab_parser.py
+++ b/tests/functional/test_eclab_parser.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 from ixdat import Measurement
 
-from pytest import approx, fixture, mark
+from pytest import approx, fixture, mark, skip
 
 
 DATA_DIR = Path(__file__).parent.parent.parent / "submodules/ixdat-large-test-files/"
@@ -303,7 +303,6 @@ TEST_DATA = {
 @fixture(scope="module", params=tuple(TEST_DATA.items()))
 def measurements_with_data(request):
     """Load all measurements from files and connect it with the test data."""
-
     filename = request.param[0]
     columns_data = request.param[1]
     measurement = Measurement.read(DATA_DIR / filename, reader="biologic")
@@ -318,6 +317,15 @@ def test_shape(measurements_with_data):
     of the columns are the same.
 
     """
+    if measurements_with_data[0].name in (
+        "multiple_techniques_dataset_01_02_CVA_C01.mpt",
+        "multiple_techniques_dataset_01_07_ZIR_C01.mpt",
+        "multiple_techniques_dataset_01_08_CVA_C01.mpt",
+        "dataset_with_loop_01_01_OCV_DUSB0_C01.mpt",
+        "dataset_with_loop_01_02_CVA_DUSB0_C01.mpt",
+    ):
+        skip("TEMP SKIP. BROKEN, SEE: https://github.com/ixdat/ixdat/issues/158")
+
     measurement = measurements_with_data[0]
     columns_names = measurements_with_data[1].keys()
 

--- a/tests/functional/test_zilien_reader.py
+++ b/tests/functional/test_zilien_reader.py
@@ -186,6 +186,7 @@ def datasets(request):
     return tsv, mpts, mpt_time_offsets
 
 
+@pytest.mark.skip("TEMP SKIP. BROKEN, SEE: https://github.com/ixdat/ixdat/issues/158")
 @pytest.mark.external
 @pytest.mark.parametrize(
     ["cls_or_technique", "expected_series"],
@@ -241,6 +242,9 @@ def test_read(cls_or_technique, expected_series):
 class TestZilienIntegrated:
     """Tests for reading the Zilien files with integrated Biologic dataset."""
 
+    @pytest.mark.skip(
+        "TEMP SKIP. BROKEN, SEE: https://github.com/ixdat/ixdat/issues/158"
+    )
     @pytest.mark.external
     def test_series_match(self, datasets):
         """Test presence of all the series from the mpt files in the tsv file."""
@@ -290,6 +294,9 @@ class TestZilienIntegrated:
 
             assert np.allclose(tsv_times, mpt_times)
 
+    @pytest.mark.skip(
+        "TEMP SKIP. BROKEN, SEE: https://github.com/ixdat/ixdat/issues/158"
+    )
     @pytest.mark.external
     def test_data_match(self, datasets):
         """Test the same data."""


### PR DESCRIPTION
This PR is meant to enable external tests in CI. This part is already setup, but some tests are failing as mentioned here https://github.com/ixdat/ixdat/issues/158#issuecomment-1918616372. But, since https://github.com/ixdat/ixdat/pull/159 is also touching the external tests, I will wait updating this one with ignoring the tests that are still failing.

EDIT. #159 is now merged. I updated this one, so the commit of the submodule corresponds to the latest data. I also marked all the tests that fails as "skip" for now and will leave fixing those in the capable hands of @matenestor and @ScottSoren. @matenestor the skip reason includes the link to issue 158, so that are easy to find.

But this PR accomplished its main purpose, which is to make sure that externals tests are run in CI.

NOTE: I accidentally left a completely broken submodule setup, when I originally made the large data files sub module. The problem was that it was added as a submodule in the config but never committed. This was the reason why nothing happened when you ran `git submodule update --init --recursive`. This is now fixed and the submodule should work as intended.
