### PR TITLE
Unskip biologic tests

### DIFF
--- a/tests/functional/test_eclab_parser.py
+++ b/tests/functional/test_eclab_parser.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 from ixdat import Measurement
 
-from pytest import approx, fixture, mark, skip
+from pytest import approx, fixture, mark
 
 
 DATA_DIR = Path(__file__).parent.parent.parent / "submodules/ixdat-large-test-files/"
@@ -43,7 +43,7 @@ TEST_DATA = {
         "I Range": ("", (41, 41)),
         "Rcmp/Ohm": ("Ohm", (0.0000000e000, 0.0000000e000)),
         "P/W": ("W", (-4.0162254e-007, 1.0149774e-005)),
-        "Ns": ("", (0, 0)),  # this is automatically added by ixdat as a ConstantValue
+        "Ns=0": ("", (0, 0)),  # this is automatically added by ixdat as a ConstantValue
     },
     "biologic_multiple_techniques_dataset/multiple_techniques_dataset_01_03_CP_C01.mpt": {  # noqa: E501
         "mode": ("", (1, 1)),
@@ -213,8 +213,8 @@ TEST_DATA = {
         "Im(Y)/Ohm-1": ("Ohm-1", None),
         "|Y|/Ohm-1": ("Ohm-1", None),
         "Phase(Y)/deg": ("deg", None),
-        "cycle number": ("", None),  # added by Ixdat
-        "Ns": ("", None),  # added by Ixdat
+        "cycle number=0": ("", None),  # added by Ixdat
+        "Ns=0": ("", None),  # added by Ixdat
     },
     "biologic_multiple_techniques_dataset/multiple_techniques_dataset_01_08_CVA_C01.mpt": {  # noqa: E501
         "mode": ("", (2, 2)),
@@ -232,7 +232,7 @@ TEST_DATA = {
         "I Range": ("", (41, 41)),
         "Rcmp/Ohm": ("Ohm", (0.0000000e000, 0.0000000e000)),
         "P/W": ("W", (9.5904383e-008, 2.4153431e-007)),
-        "Ns": ("", (0, 0)),  # added by Ixdat
+        "Ns=0": ("", (0, 0)),  # added by Ixdat
     },
     # DATASET WITH A LOOP
     "biologic_dataset_with_loop/dataset_with_loop_01_01_OCV_DUSB0_C01.mpt": {  # noqa: E501
@@ -244,8 +244,8 @@ TEST_DATA = {
         "Ewe-Ece/V": ("V", (-1.9979715e-001, -1.9840407e-001)),
         "loop_number": ("", (0, 0)),  # added by Ixdat
         "raw_current=0": ("", (0, 0)),  # added by Ixdat
-        "cycle number": ("", (0, 0)),  # added by Ixdat
-        "Ns": ("", (0, 0)),  # added by Ixdat
+        "cycle number=0": ("", (0, 0)),  # added by Ixdat
+        "Ns=0": ("", (0, 0)),  # added by Ixdat
     },
     "biologic_dataset_with_loop/dataset_with_loop_01_02_CVA_DUSB0_C01.mpt": {  # noqa: E501
         "mode": ("", (2, 2)),
@@ -265,7 +265,7 @@ TEST_DATA = {
         "P/W": ("W", (3.1451185e-007, 5.5134848e-007)),
         "Ewe-Ece/V": ("V", (-1.9443744e-001, -2.1177679e-001)),
         "loop_number": ("", (0, 1)),  # added by Ixdat
-        "Ns": ("", (0, 0)),  # added by Ixdat
+        "Ns=0": ("", (0, 0)),  # added by Ixdat
     },
     "biologic_dataset_with_loop/dataset_with_loop_01_03_CP_DUSB0_C01.mpt": {  # noqa: E501
         "mode": ("", (1, 1)),
@@ -317,15 +317,6 @@ def test_shape(measurements_with_data):
     of the columns are the same.
 
     """
-    if measurements_with_data[0].name in (
-        "multiple_techniques_dataset_01_02_CVA_C01.mpt",
-        "multiple_techniques_dataset_01_07_ZIR_C01.mpt",
-        "multiple_techniques_dataset_01_08_CVA_C01.mpt",
-        "dataset_with_loop_01_01_OCV_DUSB0_C01.mpt",
-        "dataset_with_loop_01_02_CVA_DUSB0_C01.mpt",
-    ):
-        skip("TEMP SKIP. BROKEN, SEE: https://github.com/ixdat/ixdat/issues/158")
-
     measurement = measurements_with_data[0]
     columns_names = measurements_with_data[1].keys()
 

--- a/tests/functional/test_zilien_reader.py
+++ b/tests/functional/test_zilien_reader.py
@@ -186,7 +186,6 @@ def datasets(request):
     return tsv, mpts, mpt_time_offsets
 
 
-@pytest.mark.skip("TEMP SKIP. BROKEN, SEE: https://github.com/ixdat/ixdat/issues/158")
 @pytest.mark.external
 @pytest.mark.parametrize(
     ["cls_or_technique", "expected_series"],
@@ -206,10 +205,15 @@ def test_read(cls_or_technique, expected_series):
     if isinstance(cls_or_technique, str):
         expected_measurement_class = TECHNIQUE_NAME_TO_CLASS[cls_or_technique]
         measurement = Measurement.read(
-            PATH_TO_DATAFILE, reader="zilien", technique=cls_or_technique
+            PATH_TO_DATAFILE,
+            reader="zilien",
+            technique=cls_or_technique,
+            include_mass_scans=False,
         )
     else:
-        measurement = cls_or_technique.read(PATH_TO_DATAFILE, reader="zilien")
+        measurement = cls_or_technique.read(
+            PATH_TO_DATAFILE, reader="zilien", include_mass_scans=False
+        )
         if cls_or_technique is Measurement:
             expected_measurement_class = ECMSMeasurement
         else:

--- a/tests/functional/test_zilien_reader.py
+++ b/tests/functional/test_zilien_reader.py
@@ -315,7 +315,9 @@ class TestZilienIntegrated:
             # essential series is not in the parsed dataset.
             # This suffix is removed by Zilien when integrating .mpt files,
             # so use the actual name without the suffix to check.
-            if (name := mpt_name).endswith("=0"):
+            if mpt_name.endswith("=0"):
                 name = all_mpts.reverse_aliases[mpt_name][0]
+            else:
+                name = mpt_name
 
             assert np.allclose(all_mpts[name].data, tsv[name].data)


### PR DESCRIPTION
Fixes for failing tests for reading biologic files and checking dataset integration consistency. This is a patch after #134 which now creates `cycle number` and `Ns` series with `=0` suffix when they are missing in an .mpt file. (This triggered a change in Zilien code as well :smile: ).