### PR TITLE
Nordic Electrochemistry tdms

### DIFF
--- a/NEXT_CHANGES.rst
+++ b/NEXT_CHANGES.rst
@@ -12,5 +12,11 @@ links to relevant Issues, Discussions, and PR's on github with the following for
 
 `PR #XX <https://github.com/ixdat/ixdat/pull/XX>`_
 
-For ixdat 0.3.0
+For ixdat 0.2.9
 ===============
+
+readers
+^^^^^^^
+
+- The ``NordicTDMSReader`` (reader="nordic") has been added for reading the .tdms files
+  produced by Nordic potentiostat. So far it just reads current, potential, and impedance.

--- a/development_scripts/reader_demonstrators/demo_nordic_tdms_reader.py
+++ b/development_scripts/reader_demonstrators/demo_nordic_tdms_reader.py
@@ -4,8 +4,14 @@ from ixdat import Measurement
 
 data_dir = Path.home() / "Dropbox/ixdat_resources/test_data/nordic_tdms/24B07_0_Pt"
 
-c1 = Measurement.read_set(data_dir / "CV_101448_ 1.tdms", reader="nordic", suffix=".tdms")
+c1 = Measurement.read(data_dir / "CV_101448_ 1.tdms", reader="nordic")
+
+c1.plot()
 
 meas = Measurement.read_set(data_dir, reader="nordic", suffix=".tdms")
 
 meas.plot()
+
+cv = meas.as_cv()
+cv.redefine_cycle(start_potential=0.4, redox=True)
+cv[15:30].plot_cycles()

--- a/development_scripts/reader_demonstrators/demo_nordic_tdms_reader.py
+++ b/development_scripts/reader_demonstrators/demo_nordic_tdms_reader.py
@@ -1,0 +1,11 @@
+from pathlib import Path
+from ixdat import Measurement
+
+
+data_dir = Path.home() / "Dropbox/ixdat_resources/test_data/nordic_tdms/24B07_0_Pt"
+
+c1 = Measurement.read_set(data_dir / "CV_101448_ 1.tdms", reader="nordic", suffix=".tdms")
+
+meas = Measurement.read_set(data_dir, reader="nordic", suffix=".tdms")
+
+meas.plot()

--- a/src/ixdat/__init__.py
+++ b/src/ixdat/__init__.py
@@ -1,6 +1,6 @@
 """initialize ixdat, giving top-level access to a few of the important structures
 """
-__version__ = "0.2.9.dev2"
+__version__ = "0.2.9.dev3"
 __title__ = "ixdat"
 __description__ = "The in-situ experimental data tool"
 __url__ = "https://ixdat.readthedocs.io"

--- a/src/ixdat/readers/__init__.py
+++ b/src/ixdat/readers/__init__.py
@@ -15,6 +15,7 @@ from .biologic import BiologicReader
 from .autolab import NovaASCIIReader
 from .ivium import IviumDatasetReader
 from .chi import CHInstrumentsTXTReader
+from .nordic import NordicTDMSReader
 
 # mass spectrometers
 from .pfeiffer import PVMassSpecReader
@@ -55,6 +56,7 @@ READER_CLASSES = {
     "msrh_sec": MsrhSECReader,
     "msrh_sec_decay": MsrhSECDecayReader,
     "qexafs": QexafsDATReader,
+    "nordic": NordicTDMSReader,
 }
 
 

--- a/src/ixdat/readers/nordic.py
+++ b/src/ixdat/readers/nordic.py
@@ -1,12 +1,27 @@
 from ..exceptions import ReadError
 from ..techniques import ECMeasurement
+from ..data_series import DataSeries, TimeSeries, ValueSeries
+
 
 class NordicTDMSReader:
+    """Reader for the .tdms files produced by Nordic Electrochemistry potentiostat"""
 
     def __init__(self):
-        self.tdms_file = None
-    def read(self, path_to_file, *, cls=ECMeasurement, **kwargs):
+        self.tdms_file = None  # The raw TdmsFile as imported by npTDMS package
 
+    def read(self, path_to_file, *, cls=ECMeasurement, **kwargs):
+        """Read the .tdms file and return the resulting measurement object
+
+        Requires that the npTDMS package has been installed.
+        See: https://nptdms.readthedocs.io/en/stable/quickstart.html
+
+        Args:
+            path_to_file (Path or str): Path to the .tdms file to read
+            cls (Measurement subclass): the class to return an object of. Defaults to
+                ECMeasurement
+            kwargs: Additional key-word arguments are included in the dictionary used
+                to initiate the measurement by cls.from_dict().
+        """
         try:
             from nptdms import TdmsFile
         except ImportError as e:
@@ -17,8 +32,34 @@ class NordicTDMSReader:
                 f"\noriginal error: \n{e}"
             )
 
-        self.tdms_file = TdmsFile.read(path_to_file)
-        name = self.tdms_file.properties["name"]
-        tstamp = self.tdms_file.properties["dateTime"].astype('datetime64[s]').astype('int')
+        tdms_file = TdmsFile.read(path_to_file)
+        self.tdms_file = tdms_file
 
+        name = tdms_file.properties["name"]
+        tstamp = tdms_file.properties["dateTime"].astype("datetime64[s]").astype("int")
 
+        t = tdms_file["EC"]["Time"][:]  # time in [s]
+        V = tdms_file["EC"]["E"][:]  # raw potential in [V]
+        i = tdms_file["EC"]["i"][:] * 1e3  # raw current in [mA]
+
+        Z = tdms_file["EC"]["Z_E"][:]
+        phase = tdms_file["EC"]["Phase_E"][:]
+
+        tseries = TimeSeries(name="Time", unit_name="s", data=t, tstamp=tstamp)
+        Vseries = ValueSeries(name="E", unit_name="V", data=V, tseries=tseries)
+        Iseries = ValueSeries(name="i", unit_name="mA", data=i, tseries=tseries)
+        Zseries = DataSeries(name="Z_E", unit_name="Ohm", data=Z)
+        pseries = DataSeries(name="phase_E", unit_name=None, data=phase)
+
+        aliases = {"t": ["Time"], "raw_potential": ["E"], "raw_current": ["i"]}
+
+        obj_as_dict = dict(
+            name=name,
+            technique="EC",
+            tstamp=tstamp,
+            series_list=[tseries, Vseries, Iseries, Zseries, pseries],
+            aliases=aliases,
+            reader=self,
+        )
+        obj_as_dict.update(kwargs)
+        return cls.from_dict(obj_as_dict)

--- a/src/ixdat/readers/nordic.py
+++ b/src/ixdat/readers/nordic.py
@@ -1,0 +1,24 @@
+from ..exceptions import ReadError
+from ..techniques import ECMeasurement
+
+class NordicTDMSReader:
+
+    def __init__(self):
+        self.tdms_file = None
+    def read(self, path_to_file, *, cls=ECMeasurement, **kwargs):
+
+        try:
+            from nptdms import TdmsFile
+        except ImportError as e:
+            raise ReadError(
+                "To read Nordic Electrochemistry .tdms files, ixdat uses "
+                "the npTDMS package. Please install npTDMS and try again.\n"
+                "see: https://nptdms.readthedocs.io/en/stable/quickstart.html "
+                f"\noriginal error: \n{e}"
+            )
+
+        self.tdms_file = TdmsFile.read(path_to_file)
+        name = self.tdms_file.properties["name"]
+        tstamp = self.tdms_file.properties["dateTime"].astype('datetime64[s]').astype('int')
+
+


### PR DESCRIPTION
A reader for the .tdms files made by the labview-based EC4-DAQ software by Nordic Electrochemistry for their potentiostats.
It makes use of the [npTDMS package](https://nptdms.readthedocs.io/en/stable/).

(If #166 is merged first, this branch should be rebased and merged to main.)