### PR TITLE
Fix multical to work without passing tspan_bg

### DIFF
--- a/src/ixdat/techniques/ms.py
+++ b/src/ixdat/techniques/ms.py
@@ -792,7 +792,10 @@ class MSMeasurement(Measurement):
         delta_signal_list = []
         for mass in mass_list:
             S = self.grab_signal(mass, tspan=tspan)[1].mean()
-            S_bg = self.grab_signal(mass, tspan=tspan_bg)[1].mean()
+            if tspan_bg:
+                S_bg = self.grab_signal(mass, tspan=tspan_bg)[1].mean()
+            else:
+                S_bg = 0
             delta_S = S - S_bg
             delta_signal_list.append(delta_S)
         delta_signal_vec = np.array(delta_signal_list)


### PR DESCRIPTION
@ScottSoren I just made the tiny change in multical to not subtract the entire measurement if no tspan_bg is passed. Decided to pull request this now since multical seems to be working fine (our issues seem to be caused by something else).
I didnt add anything to next changes. let me know if I should.