### PR TITLE
--- ixdat 0.2.10 --- (bugfix)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,4 +1,17 @@
 
+
+ixdat 0.2.10 (2024-04-15)
+========================
+
+debugging
+---------
+- Fixed bug in 0.2.9 on exporter initiation that had caused a crash on initation of some Spectrum
+  and SpectroMeasurement objects due to removed `delim` argument.
+
+- Fixed bug in 0.2.9 on spectrum reading that had caused a crash when making SpectrumSeries objects
+  from auxiliary files representing simple Spectrum objects.
+
+
 ixdat 0.2.9 (2024-04-12)
 ========================
 

--- a/src/ixdat/__init__.py
+++ b/src/ixdat/__init__.py
@@ -1,6 +1,7 @@
 """initialize ixdat, giving top-level access to a few of the important structures
 """
-__version__ = "0.2.9"
+
+__version__ = "0.2.10"
 __title__ = "ixdat"
 __description__ = "The in-situ experimental data tool"
 __url__ = "https://ixdat.readthedocs.io"

--- a/src/ixdat/exporters/ms_exporter.py
+++ b/src/ixdat/exporters/ms_exporter.py
@@ -8,8 +8,8 @@ class MSExporter(CSVExporter):
 
 
 class MSSpectroExporter(MSExporter):
-    def __init__(self, measurement, delim=","):
-        super().__init__(measurement, delim=delim)
+    def __init__(self, measurement):
+        super().__init__(measurement)
         # self.spectra_exporter = SpectrumSeriesExporter(measurement.spectrum_series)
         # FIXME: Have to do a property because this __int__ gets called before the
         #    measurement's __init__ is finished...

--- a/src/ixdat/exporters/sec_exporter.py
+++ b/src/ixdat/exporters/sec_exporter.py
@@ -4,8 +4,8 @@ from . import ECExporter, SpectrumExporter, SpectrumSeriesExporter
 class SECExporter(ECExporter):
     """Adds to CSVExporter the export of the Field with the SEC spectra"""
 
-    def __init__(self, measurement, delim=","):
-        super().__init__(measurement, delim=delim)
+    def __init__(self, measurement):
+        super().__init__(measurement)
         # FIXME: The lines below don't work because this __init__ gets called before
         #   the measurement's __init__ is finished.
         # self.reference_exporter = SpectrumExporter(measurement.reference_spectrum)

--- a/src/ixdat/exporters/spectrum_exporter.py
+++ b/src/ixdat/exporters/spectrum_exporter.py
@@ -5,17 +5,16 @@ from collections import OrderedDict
 class SpectrumExporter:
     """An ixdat CSV exporter for spectra. Uses pandas."""
 
-    def __init__(self, spectrum, delim=","):
+    delim = ","
+    """The separator for the .csv file. Has to be single-char due to pandas"""
+
+    def __init__(self, spectrum):
         """Initiate the SpectrumExporter.
 
         Args:
             spectrum (Spectrum): The spectrum to export by default
-            delim (char): The separator for the .csv file. Note that this cannot be
-                the ",\t" used by ixdat's main exporter since pandas only accepts single
-                character delimiters.
         """
         self.spectrum = spectrum
-        self.delim = delim
 
     def export(self, path_to_file, spectrum=None):
         """Export spectrum to path_to_file.
@@ -62,17 +61,16 @@ class SpectrumExporter:
 class SpectrumSeriesExporter:
     """An exporter for ixdat spectrum series."""
 
-    def __init__(self, spectrum_series, delim=","):
+    delim = ","
+    """The separator for the .csv file. Has to be single-char due to pandas"""
+
+    def __init__(self, spectrum_series):
         """Initiate the SpectrumSeriesExporter.
 
         Args:
             spectrum_series (SpectrumSeries): The spectrum to export by default
-            delim (char): The separator for the .csv file. (Note that this cannot be
-                the "," previously used by ixdat's main exporter since pandas only
-                accepts single character delimiters.)
         """
         self.spectrum_series = spectrum_series
-        self.delim = delim
 
     def export(self, path_to_file=None, spectrum_series=None, spectra_as_rows=True):
         """Export spectrum series to path_to_file.

--- a/src/ixdat/measurements.py
+++ b/src/ixdat/measurements.py
@@ -232,7 +232,8 @@ class Measurement(Saveable):
                 "Consider passing the `technique` argument into the read() function.\n"
                 "The available techniques are:\n"
                 f"  {list(TECHNIQUE_CLASSES.keys())}"  # again intended
-            ) from None  # to silence the top exception, because it is in the `e`
+            )  # adding `from None` here would avoid repeating the message in `e`...
+            # ...but it can be useful to have the full traceback!
 
         return measurement
 


### PR DESCRIPTION
@matenestor , I spoke too soon when I said that the merge was trivial. I caught a few bugs. The CI tests passed but the external tests did not pass, and neither did the demo scripts for msrh_sec or opus_ftir. The main bug was a simple one due to incomplete removal of the redundant `delim` argument from exporter initiation. The other bug was a bit more difficult, having to do with how ixdat determines the class of the object from a file representing a spectrum that ixdat exported.
Now external tests, as well as all the demo scripts, pass! The changes are directly in CHANGES.rst, thus the failed test when CI checks NEXT_CHANGES.rst

Unfortunately, I already released 0.2.9, so this requires a quick additional release, 0.2.10. Hope to gain your quick approval!