### PR TITLE
Enable multicomp gas calibration calculator

### DIFF
--- a/NEXT_CHANGES.rst
+++ b/NEXT_CHANGES.rst
@@ -167,6 +167,7 @@ is implemented as a plugin. At present, this is in **src/ixdat/plugins/siq_plugi
   Constructor methods:
   - ``gas_flux_calibration``, formerly ``MSMeasurement.siq_gas_flux_calibration``.
   - ``gas_flux_calibration_curve``, formerly ``MSMeasurement.siq_gas_flux_calibration_curve``.
+  - ``multicomp_gas_flux_calibration``, formerly ``MSMeasurement.siq_multicomp_gas_flux_calibration``
   - ``ecms_calibration``, formerly ``ECMSMeasurement.siq_ecms_calibration``
   - ``ecms_calibration_curve``, formerly ``ECMSMeasurement.siq_ecms_calibration_curve``
   Useage:

--- a/src/ixdat/plugins/siq_plugin.py
+++ b/src/ixdat/plugins/siq_plugin.py
@@ -172,7 +172,7 @@ class SIQ_Plugin:
             )
 
             @classmethod
-            def siq_multicomp_gas_flux_calibration(
+            def multicomp_gas_flux_calibration(
                 cls,
                 measurement,
                 mol_list,
@@ -253,9 +253,9 @@ class SIQ_Plugin:
 
                 delta_signal_list = []
                 for mass in mass_list:
-                    S = self.grab_signal(mass, tspan=tspan)[1].mean()
+                    S = measurement.grab_signal(mass, tspan=tspan)[1].mean()
                     if tspan_bg:
-                        S_bg = self.grab_signal(mass, tspan=tspan_bg)[1].mean()
+                        S_bg = measurement.grab_signal(mass, tspan=tspan_bg)[1].mean()
                     else:
                         S_bg = 0
                     delta_S = S - S_bg
@@ -285,7 +285,7 @@ class SIQ_Plugin:
                                 mass=mass,
                                 F=F,
                                 F_type="capillary",
-                                date=self.yyMdd,
+                                date=measurement.yyMdd,
                             )
                             cal_list.append(cal)
 


### PR DESCRIPTION
Updating the tutorial to work with ixdat 0.3.0, I noticed that the multicomp_gas_flux_calibration had not been updated fully to work as calculator classmethod. Fixed it and added it to NEXT_CHANGES as well. Should be an easy PR.