### PR TITLE
Add `CalculatorPack` (grouping of calculators/calibrators into "packs")

### DIFF
--- a/NEXT_CHANGES.rst
+++ b/NEXT_CHANGES.rst
@@ -10,3 +10,11 @@ links to relevant Issues, Discussions, and PR's on github with the following for
 
 `Issue #XX <https://github.com/ixdat/ixdat/issues/XX>`_
 `PR #XX <https://github.com/ixdat/ixdat/pull/XX>`_
+
+For ixdat 0.3.1
+===============
+
+calculators
+^^^^^^^^^^^
+
+- The ``CalculatorPack`` has been added in `PR #196 <https://github.com/ixdat/ixdat/pull/196>`_, adressing `Issue #184 <https:github.com/ixdat/ixdat/issues/184>`_, to allow capturing multiple calculators from a measurement, saving them to JSON, and re-attaching them to other measurements for convenient, reproducible, and portable reuse of calibration workflows.

--- a/NEXT_CHANGES.rst
+++ b/NEXT_CHANGES.rst
@@ -17,4 +17,4 @@ For ixdat 0.3.1
 calculators
 ^^^^^^^^^^^
 
-- The ``CalculatorPack`` has been added in `PR #196 <https://github.com/ixdat/ixdat/pull/196>`_, adressing `Issue #184 <https:github.com/ixdat/ixdat/issues/184>`_, to allow capturing multiple calculators from a measurement, saving them to JSON, and re-attaching them to other measurements for convenient, reproducible, and portable reuse of calibration workflows.
+- The ``CalculatorPack`` has been added in `PR #196 <https://github.com/ixdat/ixdat/pull/196>`_, addressing `Issue #184 <https://github.com/ixdat/ixdat/issues/184>`_, to allow capturing multiple calculators from a measurement, saving them to file, and re-attaching them to other measurements for convenient, reproducible, and portable reuse of calibration workflows. The file format is YAML (``pyyaml`` required) or JSON, auto-detected from the file extension.

--- a/development_scripts/demo_calculator_pack.py
+++ b/development_scripts/demo_calculator_pack.py
@@ -1,0 +1,98 @@
+"""
+1) Read an EC measurement (Biologic .mpt)
+2) Add and apply ECCalibration (compute 'potential' and 'current')
+3) Pack calculators to file (exclude Indexer)
+4) Read pack back
+5) Read another measurement (can be same file for demo)
+6) Attach pack to target and APPLY again
+"""
+
+from __future__ import annotations
+from pathlib import Path
+
+from ixdat import Measurement
+from ixdat.calculators.ec_calculators import ECCalibration
+from ixdat.calculators.packs import CalculatorPack
+
+# --- CONFIG -------------------------------------------------------------------
+TEST_FILE = Path(__file__).parent / "../test_data/biologic/Pt_poly_cv.mpt"
+PACK_PATH = Path(__file__).parent / "demo_pack.ixpack.json"
+
+
+def compute_ec_series(meas: Measurement):
+    """Trigger calculation of EC-calibrated series to prove calibration is applied."""
+    pot = meas["potential"].data
+    cur = meas["current"].data
+    print(f"\tpotential: len={len(pot)}, min={pot.min():.3g}, max={pot.max():.3g}")
+    print(f"\tcurrent:   len={len(cur)}, min={cur.min():.3g}, max={cur.max():.3g}")
+
+
+def main():
+    # 1) Read a real EC measurement
+    print("\n[1] Reading source measurement...")
+    src = Measurement.read(TEST_FILE, reader="biologic")
+    print(
+        "\ttechnique:",
+        getattr(src, "technique", None) or getattr(src, "techniques", None),
+    )
+    print("\tseries:", [s.name for s in src.series_list][:6], "...")
+    print("\n[2] EC series before calibration...")
+    compute_ec_series(src)
+
+    # 2) Add only ECCalibration (EC-only file)
+    print("\n[3] Adding ECCalibration...")
+    ec_cal = ECCalibration(name="ec", A_el=0.196, RE_vs_RHE=0.2, R_Ohm=0.0)
+    src.add_calculator(ec_cal)
+
+    print("\tCalculators now on src:")
+    cal_list = (
+        src.calculators.values()
+        if isinstance(src.calculators, dict)
+        else src.calculators
+    )
+    for c in cal_list:
+        print("\t-", c)
+
+    # 3) APPLY EC calibration by computing series
+    print("\n[4] Computing calibrated EC series on src:")
+    compute_ec_series(src)
+
+    # 4) Build a CalculatorPack and write to file (exclude Indexer by default)
+    print("\n[5] Building CalculatorPack (excluding Indexer) and writing to file...")
+    pack = CalculatorPack.from_measurement(
+        src,
+        name="demo_pack",
+        notes="EC-only demo",
+        exclude=["Indexer", "ixdat.calculators.indexer.Indexer"],
+    )
+    print(pack.summary())
+
+    pack.to_file(str(PACK_PATH))
+    print("\tWrote:", PACK_PATH.resolve())
+
+    # 5) Read the pack back
+    print("\n[6] Reading pack back from file...")
+    pack2 = CalculatorPack.read(path=str(PACK_PATH))
+    print(pack2.summary())
+
+    # 6) Read target measurement (reuse same file for demo) and attach pack
+    print("\n[7] Reading target measurement...")
+    tgt = Measurement.read(TEST_FILE, reader="biologic")
+
+    print("\tAttaching pack to target...")
+    attached = pack2.attach_to(
+        tgt,
+        on_conflict="replace",
+    )
+    print("\tAttached calculators:")
+    for c in attached:
+        print("\t-", c)
+
+    print("\n[8] Computing calibrated EC series on target:")
+    compute_ec_series(tgt)
+
+    print("\nDone")
+
+
+if __name__ == "__main__":
+    main()

--- a/development_scripts/demo_calculator_pack.py
+++ b/development_scripts/demo_calculator_pack.py
@@ -63,7 +63,7 @@ def main():
         src,
         name="demo_pack",
         notes="EC-only demo",
-        #include = ["Indexer"],
+        # include = ["Indexer"],
     )
     print(pack.summary())
 
@@ -90,6 +90,11 @@ def main():
 
     print("\n[8] Computing calibrated EC series on target:")
     compute_ec_series(tgt)
+
+    # 7) Clean up
+    if PACK_PATH.exists():
+        PACK_PATH.unlink()
+        print(f"\n[9] Deleted temprory pack file: {PACK_PATH.name}")
 
     print("\nDone")
 

--- a/development_scripts/demo_calculator_pack.py
+++ b/development_scripts/demo_calculator_pack.py
@@ -16,7 +16,7 @@ from ixdat.calculators.packs import CalculatorPack
 
 # --- CONFIG -------------------------------------------------------------------
 TEST_FILE = Path(__file__).parent / "../test_data/biologic/Pt_poly_cv.mpt"
-PACK_PATH = Path(__file__).parent / "demo_pack.ixpack.json"
+PACK_PATH = Path(__file__).parent / "demo_pack.ixpack.yaml"
 
 
 def compute_ec_series(meas: Measurement):

--- a/development_scripts/demo_calculator_pack.py
+++ b/development_scripts/demo_calculator_pack.py
@@ -63,7 +63,7 @@ def main():
         src,
         name="demo_pack",
         notes="EC-only demo",
-        exclude=["Indexer", "ixdat.calculators.indexer.Indexer"],
+        #include = ["Indexer"],
     )
     print(pack.summary())
 

--- a/development_scripts/demo_calculator_pack.py
+++ b/development_scripts/demo_calculator_pack.py
@@ -67,7 +67,7 @@ def main():
     )
     print(pack.summary())
 
-    pack.to_file(str(PACK_PATH))
+    pack.export(str(PACK_PATH))
     print("\tWrote:", PACK_PATH.resolve())
 
     # 5) Read the pack back

--- a/src/ixdat/calculators/packs.py
+++ b/src/ixdat/calculators/packs.py
@@ -412,10 +412,11 @@ class CalculatorPack(Saveable):
         Validate the internal structure and per-calculator integrity hashes.
 
         Parameters:
-            strict: If True, treat any discrepancy as an error; otherwise aggregate warnings.
+            strict: If True, treat any discrepancy as an error;
+            otherwise aggregate warnings.
 
         Returns:
-            (ok, messages) ok=True if everything looks good (or if not strict and only warnings).
+            (ok, messages): ok=True if everything looks good
         """
         msgs: List[str] = []
         ok = True

--- a/src/ixdat/calculators/packs.py
+++ b/src/ixdat/calculators/packs.py
@@ -310,10 +310,8 @@ class CalculatorPack(Saveable):
         """
         Serialize the pack (including calculators) to a JSON-serializable dict.
 
-        Returns
-        -------
-        dict
-            The full, self-describing pack.
+        Returns:
+            dict: The full, self-describing pack.
         """
         items = self._ensure_items()
         data: JsonDict = {
@@ -333,11 +331,6 @@ class CalculatorPack(Saveable):
     def from_json(cls, data: JsonDict) -> "CalculatorPack":
         """
         Construct a pack from a JSON dictionary (inverse of `to_json`).
-
-        Notes
-        -----
-        - Calculators are *not* materialized here; only their JSON entries are stored.
-          Use `.calculators()` to materialize later.
         """
         if data.get("type") != "ixdat.CalculatorPack":
             raise ValueError(f"Unexpected type: {data.get('type')}")
@@ -356,10 +349,8 @@ class CalculatorPack(Saveable):
         """
         Write the pack to a JSON file.
 
-        Parameters
-        ----------
-        path
-            Output file path (e.g., 'my_setup.ixpack.json').
+        Parameters:
+            path: Output file path (e.g., 'my_setup.ixpack.json').
         """
         data = self.to_json()
         with open(path, "w", encoding="utf-8") as f:
@@ -368,42 +359,24 @@ class CalculatorPack(Saveable):
     @classmethod
     def read(
         cls,
-        path: Optional[str] = None,
-        id: Optional[str] = None,  # noqa: A002 - parity with Saveable.read
+        path: str,
     ) -> "CalculatorPack":
         """
-        Read a pack either from a file (`path`) or from the database (`id`).
+        Read a pack from a file (`path`)
 
-        Exactly one of `path` or `id` must be provided.
-
-        Returns
-        -------
-        CalculatorPack
+        Returns:
+            CalculatorPack
         """
-        if bool(path) == bool(id):
-            raise ValueError("Provide exactly one of 'path' or 'id'")
-
-        if path:
-            with open(path, "r", encoding="utf-8") as f:
-                data = json.load(f)
-            return cls.from_json(data)
-
-        # Database path: delegate to Saveable.read to get an instance that already
-        # has the `json` column populated. Then parse its json payload.
-        obj = super().read(id)  # type: ignore[misc]
-        if not getattr(obj, "json", None):
-            raise ValueError(f"Database record {id!r} has no json payload")
-        data = json.loads(obj.json)  # type: ignore[arg-type]
+        with open(path, "r", encoding="utf-8") as f:
+            data = json.load(f)
         return cls.from_json(data)
 
     def calculators(self) -> List[Any]:
         """
         Materialize and return the list of calculator objects contained in the pack.
 
-        Returns
-        -------
-        list
-            List of calculator instances reconstructed from their stored payloads.
+        Returns:
+            list: List of calculator instances reconstructed from their stored payloads.
         """
         if self._calculators:
             return list(self._calculators)
@@ -438,15 +411,11 @@ class CalculatorPack(Saveable):
         """
         Validate the internal structure and per-calculator integrity hashes.
 
-        Parameters
-        ----------
-        strict
-            If True, treat any discrepancy as an error; otherwise aggregate warnings.
+        Parameters:
+            strict: If True, treat any discrepancy as an error; otherwise aggregate warnings.
 
-        Returns
-        -------
-        (ok, messages)
-            ok=True if everything looks good (or if not strict and only warnings).
+        Returns:
+            (ok, messages) ok=True if everything looks good (or if not strict and only warnings).
         """
         msgs: List[str] = []
         ok = True

--- a/src/ixdat/calculators/packs.py
+++ b/src/ixdat/calculators/packs.py
@@ -1,0 +1,589 @@
+# CalculatorPack class
+# @Author: Frederik Lizak Johansen
+# @Created: 18/08/2025
+
+from __future__ import annotations
+
+import json
+import hashlib
+import importlib
+from datetime import datetime, timezone
+from typing import Any, Callable, Dict, Iterable, List, Optional, Sequence, Tuple, Union
+
+from ixdat.db import Saveable
+from ixdat.calculators.indexer import Indexer
+
+
+JsonDict = Dict[str, Any]
+Selector = Union[Iterable[str], Callable[[Any], bool], None]
+
+
+def _now_utc_iso() -> str:
+    """Return current UTC timestamp as ISO 8601 string with 'Z'."""
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _json_canonical(obj: Any) -> str:
+    """Canonical JSON representation (sorted keys, no whitespace)."""
+    return json.dumps(obj, sort_keys=True, separators=(",", ":"))
+
+
+def _sha256_of_jsonable(obj: Any) -> str:
+    """SHA256 hex digest of a JSON-serializable object (canonicalized)."""
+    s = _json_canonical(obj).encode("utf-8")
+    return hashlib.sha256(s).hexdigest()
+
+
+def _import_from_class_path(class_path: str) -> type:
+    """Import and return a class given its 'module.ClassName' path."""
+    mod_name, cls_name = class_path.rsplit(".", 1)
+    module = importlib.import_module(mod_name)
+    return getattr(module, cls_name)
+
+
+def _matches_selector(obj: Any, selector: Selector) -> bool:
+    """
+    Return True if `obj` matches the selector.
+    """
+    if selector is None:
+        return True
+
+    if callable(selector):
+        return bool(selector(obj))
+
+    # Normalize selector to a set of strings
+    if isinstance(selector, str):
+        names = {selector}
+    elif isinstance(selector, (set, list, tuple)):
+        names = set(selector)
+    else:
+        # Fallback: try to coerce to set with one string representation
+        names = {str(selector)}
+
+    cls = obj.__class__
+    class_name = cls.__name__
+    class_path = f"{cls.__module__}.{class_name}"
+    return (class_name in names) or (class_path in names)
+
+
+def _ixdat_version() -> Optional[str]:
+    """Best-effort retrieval of ixdat version string; returns None if unavailable."""
+    try:
+        from .. import __version__
+
+        return __version__
+    except Exception:
+        return None
+
+
+class CalculatorPack(Saveable):
+    """
+    A container that serializes multiple calculators together so they can be
+    saved/loaded and re-applied to another Measurement in a single operation.
+
+    Overview:
+    - Captures a set of calculators (MS, EC, backgrounds, siq, ...)
+      with minimal metadata and per-calculator payloads.
+    - Supports:
+        `CalculatorPack.from_measurement(...)` to capture calculators
+        `pack.to_file(path)` and `CalculatorPack.read(path=...)` for file I/O
+        `pack.calculators()` for lazy materialization
+        `pack.attach_to(measurement, ...)` convenience to add all calculators
+
+    Storage:
+    - File format: JSON (`.ixpack.json` recommended)
+    - Database: inherits Saveable; `json` column stores `to_json()` blob
+
+    Integrity:
+    - Each calculator payload is hashed (SHA256) for integrity verification
+
+    """
+
+    # for `Saveable`
+    table_name = "calculator_pack"
+    column_attrs = {"name", "schema_version", "ixdat_version", "created_utc", "json"}
+    SCHEMA_VERSION = "1.0"  # Keep track of versioning for the pack
+
+    def __init__(
+        self,
+        *,
+        name: Optional[str] = None,
+        calculators: Optional[Sequence[Any]] = None,
+        metadata: Optional[JsonDict] = None,
+    ):
+        """
+        Create an empty pack or with a given sequence of calculator objects.
+
+        Parameters:
+            name: Human-readable name for the pack.
+            calculators: Sequence of calculator instances to include.
+            If omitted, the pack starts empty and calculators can be
+            loaded later via `from_json`.
+            metadata: Arbitrary metadata stored under `metadata` in the JSON.
+        """
+        super().__init__()
+        self.name: str = name or "CalculatorPack()"
+        self.schema_version: str = self.SCHEMA_VERSION
+        self.ixdat_version: Optional[str] = _ixdat_version()
+        self.created_utc: str = (
+            _now_utc_iso()
+        )  # Centralized; can be used anywhere on earth
+        self._metadata: JsonDict = metadata or {}
+
+        # Internal storage:
+        self._calculators: List[Any] = list(calculators) if calculators else []
+        self._items: Optional[List[JsonDict]] = None  # filled by from_json or to_json
+
+        # Backing JSON for Saveable (db column). Keep it None until first to_json()
+        self.json: Optional[str] = None
+
+    @staticmethod
+    def _serialize_calculator(cal: Any) -> dict:
+        """
+        Serialize a calculator to a JSON-safe dict.
+
+        Preference order:
+          1) Calculator.as_dict()  (ixdat-native format used by Calculator.export())
+          2) lightweight __dict__ snapshot (filtered)
+        """
+        try:
+            from ..measurement_base import (
+                Calculator as _BaseCalc,
+            )  # local import to avoid import cycle errors
+
+            if isinstance(cal, _BaseCalc) and hasattr(cal, "as_dict"):
+                payload = cal.as_dict()
+                # Assuming for sake of future implementation.
+                # Ensure we don't persist a heavy/circular measurement reference:
+                payload.pop("measurement", None)
+                return {
+                    "__format__": "ixdat.calculator.as_dict",
+                    "payload": payload,
+                    "calculator_type": getattr(cal, "calculator_type", None),
+                    "technique": getattr(cal, "technique", None),
+                }
+        except Exception:
+            pass
+
+        # Fallback: filtered __dict__
+        safe: dict[str, Any] = {"__format__": "light.dict"}
+        for k, v in vars(cal).items():
+            if k == "measurement":
+                continue  # don't persist the measurement object
+            if isinstance(v, (int, float, str, list, dict, type(None))):
+                safe[k] = v
+        return safe
+
+    @staticmethod
+    def _deserialize_calculator(cls: type, payload: dict) -> Any:
+        """
+        Recreate calculator instance from stored payload.
+
+        Preference order:
+          1) Calculator.from_dict() if we stored 'as_dict' format
+          2) lightweight __dict__
+        """
+        fmt = payload.get("__format__")
+        if fmt == "ixdat.calculator.as_dict":
+            # Try the native method first
+            calc_payload = dict(payload.get("payload") or {})
+            # from_dict expects calculator metadata in the dict:
+            if "calculator_type" not in calc_payload and payload.get("calculator_type"):
+                calc_payload["calculator_type"] = payload["calculator_type"]
+            if "technique" not in calc_payload and payload.get("technique"):
+                calc_payload["technique"] = payload["technique"]
+            try:
+                from ..measurement_base import (
+                    Calculator as _BaseCalc,
+                )  # avoid circular import, by loading locally
+
+                if issubclass(cls, _BaseCalc) and hasattr(cls, "from_dict"):
+                    return cls.from_dict(calc_payload)
+            except Exception:
+                pass
+
+        # Fallback: blank instance + shallow dict update
+        cal = object.__new__(cls)
+        try:
+            # Strip helper key if present
+            payload = dict(payload)
+            payload.pop("__format__", None)
+            cal.__dict__.update(payload)
+        except Exception:
+            pass
+        return cal
+
+    @classmethod
+    def from_measurement(
+        cls,
+        measurement: Any,
+        *,
+        include: Selector = None,
+        exclude: Selector = None,
+        name: Optional[str] = None,
+        notes: Optional[str] = None,
+        extra_metadata: Optional[JsonDict] = None,
+    ) -> "CalculatorPack":
+        """
+        Capture calculators from a Measurement into a pack.
+
+        Parameters:
+            measurement: Source Measurement providing `.calculators`.
+            include: Selector to include some calculators.
+            exclude: Selector to exclude some calculators.
+            name: Optional name for the created pack.
+            notes: Optional human-readable note stored in metadata.history.notes.
+            extra_metadata: Extra metadata merged into the pack metadata.
+
+        Returns:
+            CalculatorPack
+        """
+        # Collect calculators
+        if hasattr(measurement, "calculators"):
+            if isinstance(measurement.calculators, dict):
+                calculators = list(measurement.calculators.values())
+            else:
+                calculators = list(measurement.calculators)
+
+        else:
+            raise AttributeError("Measurement has no 'calculators' attribute")
+
+        # Do not include Indexes
+        calculators = [c for c in calculators if not isinstance(c, Indexer)]
+
+        # Apply include/exclude filters
+        if include is not None:
+            calculators = [c for c in calculators if _matches_selector(c, include)]
+        if exclude is not None:
+            calculators = [c for c in calculators if not _matches_selector(c, exclude)]
+
+        # Build metadata
+        meta: JsonDict = {
+            "history": {
+                "source_measurement_uuid": getattr(measurement, "uuid", None),
+                "source_measurement_name": getattr(measurement, "name", None),
+                "notes": notes,
+            }
+        }
+        if extra_metadata:
+            meta.update(extra_metadata)
+
+        return cls(
+            name=name
+            or f"CalculatorPack({getattr(measurement, 'name', 'measurement')})",
+            calculators=calculators,
+            metadata=meta,
+        )
+
+    def _ensure_items(self) -> List[JsonDict]:
+        """
+        Ensure internal `_items` list exists,
+        synthesizing it from calculators if needed.
+        """
+        if self._items is not None:
+            return self._items
+
+        items: List[JsonDict] = []
+        for cal in self._calculators:
+            cls = cal.__class__
+            class_path = f"{cls.__module__}.{cls.__name__}"
+
+            payload = self._serialize_calculator(cal)
+
+            item: JsonDict = {
+                "class_path": class_path,
+                "payload": payload,
+                "hash": _sha256_of_jsonable(payload),
+            }
+
+            # Optional metadata
+            cal_ver = getattr(cal, "version", None)
+            if cal_ver:
+                item["calculator_version"] = str(cal_ver)
+
+            items.append(item)
+
+        self._items = items
+        return items
+
+    def to_json(self) -> JsonDict:
+        """
+        Serialize the pack (including calculators) to a JSON-serializable dict.
+
+        Returns
+        -------
+        dict
+            The full, self-describing pack.
+        """
+        items = self._ensure_items()
+        data: JsonDict = {
+            "type": "ixdat.CalculatorPack",
+            "name": self.name,
+            "schema_version": self.schema_version,
+            "ixdat_version": self.ixdat_version,
+            "created_utc": self.created_utc,
+            "metadata": self._metadata,
+            "calculators": items,
+        }
+        # Also keep a string form for Saveable db column
+        self.json = json.dumps(data, indent=2)
+        return data
+
+    @classmethod
+    def from_json(cls, data: JsonDict) -> "CalculatorPack":
+        """
+        Construct a pack from a JSON dictionary (inverse of `to_json`).
+
+        Notes
+        -----
+        - Calculators are *not* materialized here; only their JSON entries are stored.
+          Use `.calculators()` to materialize later.
+        """
+        if data.get("type") != "ixdat.CalculatorPack":
+            raise ValueError(f"Unexpected type: {data.get('type')}")
+
+        pack = cls(name=data.get("name"))
+        pack.schema_version = str(data.get("schema_version") or cls.SCHEMA_VERSION)
+        pack.ixdat_version = data.get("ixdat_version")
+        pack.created_utc = data.get("created_utc") or _now_utc_iso()
+        pack._metadata = data.get("metadata", {})
+        pack._items = list(data.get("calculators") or [])
+        # Keep canonical db json string if caller wants to save to DB
+        pack.json = json.dumps(data, indent=2)
+        return pack
+
+    def to_file(self, path: str) -> None:
+        """
+        Write the pack to a JSON file.
+
+        Parameters
+        ----------
+        path
+            Output file path (e.g., 'my_setup.ixpack.json').
+        """
+        data = self.to_json()
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(data, f, indent=2)
+
+    @classmethod
+    def read(
+        cls,
+        path: Optional[str] = None,
+        id: Optional[str] = None,  # noqa: A002 - parity with Saveable.read
+    ) -> "CalculatorPack":
+        """
+        Read a pack either from a file (`path`) or from the database (`id`).
+
+        Exactly one of `path` or `id` must be provided.
+
+        Returns
+        -------
+        CalculatorPack
+        """
+        if bool(path) == bool(id):
+            raise ValueError("Provide exactly one of 'path' or 'id'")
+
+        if path:
+            with open(path, "r", encoding="utf-8") as f:
+                data = json.load(f)
+            return cls.from_json(data)
+
+        # Database path: delegate to Saveable.read to get an instance that already
+        # has the `json` column populated. Then parse its json payload.
+        obj = super().read(id)  # type: ignore[misc]
+        if not getattr(obj, "json", None):
+            raise ValueError(f"Database record {id!r} has no json payload")
+        data = json.loads(obj.json)  # type: ignore[arg-type]
+        return cls.from_json(data)
+
+    def calculators(self) -> List[Any]:
+        """
+        Materialize and return the list of calculator objects contained in the pack.
+
+        Returns
+        -------
+        list
+            List of calculator instances reconstructed from their stored payloads.
+        """
+        if self._calculators:
+            return list(self._calculators)
+
+        if not self._items:
+            return []
+
+        calculators: List[Any] = []
+        for item in self._items:
+            class_path = item["class_path"]
+            payload = item["payload"]
+
+            # Integrity check (best-effort)
+            h_expected = item.get("hash")
+            h_actual = _sha256_of_jsonable(payload)
+            if h_expected and h_expected != h_actual:
+                raise ValueError(
+                    f"Integrity check failed for {class_path}: hash mismatch"
+                )
+
+            CalCls = _import_from_class_path(class_path)
+
+            # Always use CalculatorPack’s deserializer
+            cal = self._deserialize_calculator(CalCls, payload)
+            calculators.append(cal)
+
+        self._calculators = calculators
+
+        return list(self._calculators)
+
+    def validate(self, *, strict: bool = True) -> Tuple[bool, List[str]]:
+        """
+        Validate the internal structure and per-calculator integrity hashes.
+
+        Parameters
+        ----------
+        strict
+            If True, treat any discrepancy as an error; otherwise aggregate warnings.
+
+        Returns
+        -------
+        (ok, messages)
+            ok=True if everything looks good (or if not strict and only warnings).
+        """
+        msgs: List[str] = []
+        ok = True
+
+        if self.schema_version != self.SCHEMA_VERSION:
+            ok = False
+            msgs.append(
+                f"Schema version mismatch: pack={self.schema_version}, "
+                f"supported={self.SCHEMA_VERSION}"
+            )
+
+        if not self._items:
+            msgs.append("Pack contains no calculator entries")
+            return (ok and not strict, msgs)
+
+        for item in self._items:
+            cp = item.get("class_path")
+            payload = item.get("payload")
+            if not cp or not isinstance(cp, str):
+                ok = False
+                msgs.append("Entry missing valid 'class_path'")
+                if strict:
+                    continue
+            if not isinstance(payload, dict):
+                ok = False
+                msgs.append(f"{cp}: payload is not a dict")
+                if strict:
+                    continue
+            h_expected = item.get("hash")
+            if h_expected:
+                h_actual = _sha256_of_jsonable(payload)
+                if h_expected != h_actual:
+                    ok = False
+                    msgs.append(f"{cp}: integrity hash mismatch")
+
+        if strict and not ok:
+            return (False, msgs)
+        return (ok, msgs)
+
+    def attach_to(
+        self,
+        measurement: Any,
+        *,
+        on_conflict: str = "replace",
+    ) -> List[Any]:
+        """
+        Attach all calculators in the pack to a Measurement.
+
+        Parameters:
+            measurement: Target Measurement (must provide `.add_calculator(calculator)`).
+            on_conflict:
+                "replace" (default): replace existing calculator of same class+name
+                "skip": keep existing one, skip new
+                "duplicate": add new one and allow duplicates (caller handles names)
+        Returns:
+            list: The list of calculators actually attached to the measurement.
+        """
+        attached: List[Any] = []
+        calculators = self.calculators()
+
+        # Acquire current calculators on measurement (for conflict handling)
+        existing: List[Any]
+        if hasattr(measurement, "calculators"):
+            if isinstance(measurement.calculators, dict):
+                existing = list(measurement.calculators.values())
+            else:
+                existing = list(measurement.calculators)
+        else:
+            existing = []
+
+        def _same_kind(a: Any, b: Any) -> bool:
+            return a.__class__ is b.__class__ and getattr(a, "name", None) == getattr(
+                b, "name", None
+            )
+
+        for cal in calculators:
+            # Conflict resolution
+            conflict = next((c for c in existing if _same_kind(c, cal)), None)
+            if conflict:
+                if on_conflict == "replace":
+                    # remove then add (if API supports remove)
+                    if hasattr(measurement, "remove_calculator"):
+                        try:
+                            measurement.remove_calculator(conflict)
+                        except Exception:
+                            pass
+                    # fall through to add
+                elif on_conflict == "skip":
+                    continue
+                elif on_conflict == "duplicate":
+                    # Let both exist; optionally rename to avoid ambiguity
+                    if getattr(cal, "name", None) and hasattr(cal, "name"):
+                        cal.name = f"{cal.name} (2)"
+                else:
+                    raise ValueError(f"Unknown on_conflict policy: {on_conflict}")
+
+            # Attach
+            if not hasattr(measurement, "add_calculator") or not callable(
+                measurement.add_calculator
+            ):
+                raise AttributeError("Measurement lacks add_calculator(calculator)")
+
+            measurement.add_calculator(cal)
+            attached.append(cal)
+            existing.append(cal)
+
+        return attached
+
+    def summary(self) -> str:
+        """Human-readable one-line-per-entry summary of the pack contents."""
+        parts: List[str] = [
+            f"CalculatorPack(name={self.name!r}, schema={self.schema_version},"
+            f"ixdat={self.ixdat_version}, created={self.created_utc})"
+        ]
+        items = self._items or []
+        if not items and self._calculators:
+            # Synthesize items to summarize
+            _ = self._ensure_items()
+            items = self._items or []
+
+        for i, item in enumerate(items, 1):
+            cp = item.get("class_path", "?")
+            ver = item.get("calculator_version")
+            suffix = []
+            if ver:
+                suffix.append(f"ver={ver}")
+            parts.append(
+                f"  {i:02d}. {cp}" + (f" ({', '.join(suffix)})" if suffix else "")
+            )
+        return "\n".join(parts)
+
+    def __str__(self) -> str:
+        return self.summary()
+
+    def __repr__(self) -> str:
+        repr_name = (
+            f"<CalculatorPack name={self.name!r} "
+            f"items={len(self._items or self._calculators)}>"
+        )
+        return repr_name

--- a/src/ixdat/calculators/packs.py
+++ b/src/ixdat/calculators/packs.py
@@ -160,8 +160,10 @@ class CalculatorPack(Saveable):
             include: Optional filter to include some calculators.
                 - None (default): include all calculators
                 - Iterable[str]: match by class name or full module.ClassName path
-                - Callable[[Calculator], bool]: predicate returning True for calculators to keep
-            exclude: Optional filter applied after `include` with the same accepted forms.
+                - Callable[[Calculator], bool]: predicate returning
+                  True for calculators to keep
+            exclude: Optional filter applied after `include`,
+                     with the same accepted forms.
             name: Optional name for the created pack.
             notes: Optional human-readable note stored in metadata.history.notes.
             extra_metadata: Extra metadata merged into the pack metadata.

--- a/src/ixdat/calculators/packs.py
+++ b/src/ixdat/calculators/packs.py
@@ -248,14 +248,26 @@ class CalculatorPack(Saveable):
         else:
             raise AttributeError("Measurement has no 'calculators' attribute")
 
-        # Do not include Indexes
-        calculators = [c for c in calculators if not isinstance(c, Indexer)]
+        # Exclude Indexer by default
+        base = [c for c in calculators if not isinstance(c, Indexer)]
 
-        # Apply include/exclude filters
-        if include is not None:
-            calculators = [c for c in calculators if _matches_selector(c, include)]
+        # Exclude first
         if exclude is not None:
-            calculators = [c for c in calculators if not _matches_selector(c, exclude)]
+            base = [c for c in base if not _matches_selector(c, exclude)]
+
+        # Include (also include Indexer again if requested)
+        if include is not None:
+            must_have = [c for c in calculators if _matches_selector(c, include)]
+            seen = set()
+            calculators = []
+            for c in base + must_have:
+                oid = id(c)
+                if oid in seen:
+                    continue
+                seen.add(oid)
+                calculators.append(c)
+        else:
+            calculators = base
 
         # Build metadata
         meta: JsonDict = {

--- a/src/ixdat/calculators/packs.py
+++ b/src/ixdat/calculators/packs.py
@@ -222,8 +222,13 @@ class CalculatorPack(Saveable):
 
     def _ensure_items(self) -> List[JsonDict]:
         """
-        Ensure internal `_items` list exists,
-        synthesizing it from calculators if needed.
+        Ensure `_items` exists by synthesizing it from calculators when needed.
+
+        Each entry contains:
+          - class_path: module.ClassName of the calculator
+          - payload: calculator.as_dict(exclude=["measurement"])
+          - hash: SHA256 over the payload
+          - optional: calculator_version
         """
         if self._items is not None:
             return self._items
@@ -255,10 +260,8 @@ class CalculatorPack(Saveable):
 
     def to_json(self) -> JsonDict:
         """
-        Serialize the pack (including calculators) to a JSON-serializable dict.
-
-        Returns:
-            dict: The full, self-describing pack.
+        Serialize the pack container (metadata + calculators’ payloads) to a dict.
+        Calculator payloads come from each calculator’s own `as_dict()`.
         """
         items = self._ensure_items()
         data: JsonDict = {
@@ -277,7 +280,8 @@ class CalculatorPack(Saveable):
     @classmethod
     def from_json(cls, data: JsonDict) -> "CalculatorPack":
         """
-        Construct a pack from a JSON dictionary (inverse of `to_json`).
+        Rebuild the pack container from a dict made by `to_json()`.
+        Calculator instances are materialized lazily via `.calculators()`.
         """
         if data.get("type") != "ixdat.CalculatorPack":
             raise ValueError(f"Unexpected type: {data.get('type')}")

--- a/src/ixdat/calculators/packs.py
+++ b/src/ixdat/calculators/packs.py
@@ -10,6 +10,14 @@ import importlib
 from datetime import datetime, timezone
 from typing import Any, Callable, Dict, Iterable, List, Optional, Sequence, Tuple, Union
 
+try:
+    import yaml as _yaml
+
+    _YAML_AVAILABLE = True
+except ImportError:
+    _yaml = None  # type: ignore[assignment]
+    _YAML_AVAILABLE = False
+
 from ixdat.db import Saveable
 from ixdat.calculators.indexer import Indexer
 
@@ -298,14 +306,28 @@ class CalculatorPack(Saveable):
 
     def export(self, path: str) -> None:
         """
-        Write the pack to a JSON file.
+        Write the pack to a file.
+
+        Format is determined by file extension:
+        - ``.yaml`` / ``.yml``: YAML (requires pyyaml; allows inline comments)
+        - anything else (e.g. ``.json``): JSON
 
         Parameters:
-            path: Output file path (e.g., 'my_setup.ixpack.json').
+            path: Output file path (e.g., 'my_setup.ixpack.yaml').
         """
         data = self.to_json()
-        with open(path, "w", encoding="utf-8") as f:
-            json.dump(data, f, indent=2)
+        path = str(path)
+        if path.endswith((".yaml", ".yml")):
+            if not _YAML_AVAILABLE:
+                raise ImportError(
+                    "pyyaml is required for YAML export. Install with: pip install pyyaml"
+                )
+            assert _yaml is not None
+            with open(path, "w", encoding="utf-8") as f:
+                _yaml.dump(data, f, allow_unicode=True, sort_keys=False, default_flow_style=False)
+        else:
+            with open(path, "w", encoding="utf-8") as f:
+                json.dump(data, f, indent=2)
 
     @classmethod
     def read(
@@ -313,15 +335,28 @@ class CalculatorPack(Saveable):
         path: str,
     ) -> "CalculatorPack":
         """
-        Read a pack from a file (`path`)
+        Read a pack from a file.
+
+        Format is auto-detected from the file extension (``.yaml``/``.yml`` → YAML,
+        everything else → JSON).
 
         Returns:
             CalculatorPack
         """
+        path = str(path)
         with open(path, "r", encoding="utf-8") as f:
-            data = json.load(f)
+            if path.endswith((".yaml", ".yml")):
+                if not _YAML_AVAILABLE:
+                    raise ImportError(
+                        "pyyaml is required to read YAML files. Install with: pip install pyyaml"
+                    )
+                assert _yaml is not None
+                data = _yaml.safe_load(f)
+            else:
+                data = json.load(f)
         return cls.from_json(data)
 
+    @property
     def calculators(self) -> List[Any]:
         """
         Materialize and return the list of calculator objects contained in the pack.
@@ -424,7 +459,7 @@ class CalculatorPack(Saveable):
             list: The list of calculators actually attached to the measurement.
         """
         attached: List[Any] = []
-        calculators = self.calculators()
+        calculators = self.calculators
 
         # Acquire current calculators on measurement (for conflict handling)
         existing: List[Any]

--- a/src/ixdat/calculators/packs.py
+++ b/src/ixdat/calculators/packs.py
@@ -15,7 +15,11 @@ from ixdat.calculators.indexer import Indexer
 
 
 JsonDict = Dict[str, Any]
-Selector = Union[Iterable[str], Callable[[Any], bool], None]
+# Local, private selector type used only within CalculatorPack:
+# - Iterable[str]: class names or fully-qualified class paths
+# - Callable[[Any], bool]: predicate on a calculator
+# - None: no filtering
+_Selector = Union[Iterable[str], Callable[[Any], bool], None]
 
 
 def _now_utc_iso() -> str:
@@ -41,7 +45,7 @@ def _import_from_class_path(class_path: str) -> type:
     return getattr(module, cls_name)
 
 
-def _matches_selector(obj: Any, selector: Selector) -> bool:
+def _matches_selector(obj: Any, selector: _Selector) -> bool:
     """
     Return True if `obj` matches the selector.
     """
@@ -142,8 +146,8 @@ class CalculatorPack(Saveable):
         cls,
         measurement: Any,
         *,
-        include: Selector = None,
-        exclude: Selector = None,
+        include: _Selector = None,
+        exclude: _Selector = None,
         name: Optional[str] = None,
         notes: Optional[str] = None,
         extra_metadata: Optional[JsonDict] = None,
@@ -153,8 +157,11 @@ class CalculatorPack(Saveable):
 
         Parameters:
             measurement: Source Measurement providing `.calculators`.
-            include: Selector to include some calculators.
-            exclude: Selector to exclude some calculators.
+            include: Optional filter to include some calculators.
+                - None (default): include all calculators
+                - Iterable[str]: match by class name or full module.ClassName path
+                - Callable[[Calculator], bool]: predicate returning True for calculators to keep
+            exclude: Optional filter applied after `include` with the same accepted forms.
             name: Optional name for the created pack.
             notes: Optional human-readable note stored in metadata.history.notes.
             extra_metadata: Extra metadata merged into the pack metadata.

--- a/src/ixdat/calculators/packs.py
+++ b/src/ixdat/calculators/packs.py
@@ -137,82 +137,6 @@ class CalculatorPack(Saveable):
         # Backing JSON for Saveable (db column). Keep it None until first to_json()
         self.json: Optional[str] = None
 
-    @staticmethod
-    def _serialize_calculator(cal: Any) -> dict:
-        """
-        Serialize a calculator to a JSON-safe dict.
-
-        Preference order:
-          1) Calculator.as_dict()  (ixdat-native format used by Calculator.export())
-          2) lightweight __dict__ snapshot (filtered)
-        """
-        try:
-            from ..measurement_base import (
-                Calculator as _BaseCalc,
-            )  # local import to avoid import cycle errors
-
-            if isinstance(cal, _BaseCalc) and hasattr(cal, "as_dict"):
-                payload = cal.as_dict()
-                # Assuming for sake of future implementation.
-                # Ensure we don't persist a heavy/circular measurement reference:
-                payload.pop("measurement", None)
-                return {
-                    "__format__": "ixdat.calculator.as_dict",
-                    "payload": payload,
-                    "calculator_type": getattr(cal, "calculator_type", None),
-                    "technique": getattr(cal, "technique", None),
-                }
-        except Exception:
-            pass
-
-        # Fallback: filtered __dict__
-        safe: dict[str, Any] = {"__format__": "light.dict"}
-        for k, v in vars(cal).items():
-            if k == "measurement":
-                continue  # don't persist the measurement object
-            if isinstance(v, (int, float, str, list, dict, type(None))):
-                safe[k] = v
-        return safe
-
-    @staticmethod
-    def _deserialize_calculator(cls: type, payload: dict) -> Any:
-        """
-        Recreate calculator instance from stored payload.
-
-        Preference order:
-          1) Calculator.from_dict() if we stored 'as_dict' format
-          2) lightweight __dict__
-        """
-        fmt = payload.get("__format__")
-        if fmt == "ixdat.calculator.as_dict":
-            # Try the native method first
-            calc_payload = dict(payload.get("payload") or {})
-            # from_dict expects calculator metadata in the dict:
-            if "calculator_type" not in calc_payload and payload.get("calculator_type"):
-                calc_payload["calculator_type"] = payload["calculator_type"]
-            if "technique" not in calc_payload and payload.get("technique"):
-                calc_payload["technique"] = payload["technique"]
-            try:
-                from ..measurement_base import (
-                    Calculator as _BaseCalc,
-                )  # avoid circular import, by loading locally
-
-                if issubclass(cls, _BaseCalc) and hasattr(cls, "from_dict"):
-                    return cls.from_dict(calc_payload)
-            except Exception:
-                pass
-
-        # Fallback: blank instance + shallow dict update
-        cal = object.__new__(cls)
-        try:
-            # Strip helper key if present
-            payload = dict(payload)
-            payload.pop("__format__", None)
-            cal.__dict__.update(payload)
-        except Exception:
-            pass
-        return cal
-
     @classmethod
     def from_measurement(
         cls,
@@ -300,7 +224,9 @@ class CalculatorPack(Saveable):
             cls = cal.__class__
             class_path = f"{cls.__module__}.{cls.__name__}"
 
-            payload = self._serialize_calculator(cal)
+            payload = cal.as_dict(
+                exclude=["measurement"]
+            )  # exclude to avoid heavy/cyclic payload
 
             item: JsonDict = {
                 "class_path": class_path,
@@ -410,9 +336,7 @@ class CalculatorPack(Saveable):
                 )
 
             CalCls = _import_from_class_path(class_path)
-
-            # Always use CalculatorPack’s deserializer
-            cal = self._deserialize_calculator(CalCls, payload)
+            cal = CalCls.from_dict(payload)
             calculators.append(cal)
 
         self._calculators = calculators

--- a/src/ixdat/calculators/packs.py
+++ b/src/ixdat/calculators/packs.py
@@ -454,7 +454,11 @@ class CalculatorPack(Saveable):
             on_conflict:
                 "replace" (default): replace existing calculator of same class+name
                 "skip": keep existing one, skip new
-                "duplicate": add new one and allow duplicates (caller handles names)
+                "duplicate": add new one alongside the existing one (caller handles
+                    names). Note: this bypasses ``Measurement.consolidate_calculators``
+                    and its ``__add__``-based merging. For merge behaviour (e.g. two
+                    ``ECCalibration`` objects with complementary fields), call
+                    ``measurement.add_calculator()`` directly instead.
         Returns:
             list: The list of calculators actually attached to the measurement.
         """

--- a/src/ixdat/calculators/packs.py
+++ b/src/ixdat/calculators/packs.py
@@ -86,7 +86,7 @@ class CalculatorPack(Saveable):
       with minimal metadata and per-calculator payloads.
     - Supports:
         `CalculatorPack.from_measurement(...)` to capture calculators
-        `pack.to_file(path)` and `CalculatorPack.read(path=...)` for file I/O
+        `pack.export(path)` and `CalculatorPack.read(path=...)` for file I/O
         `pack.calculators()` for lazy materialization
         `pack.attach_to(measurement, ...)` convenience to add all calculators
 
@@ -357,7 +357,7 @@ class CalculatorPack(Saveable):
         pack.json = json.dumps(data, indent=2)
         return pack
 
-    def to_file(self, path: str) -> None:
+    def export(self, path: str) -> None:
         """
         Write the pack to a JSON file.
 

--- a/src/ixdat/calculators/packs.py
+++ b/src/ixdat/calculators/packs.py
@@ -320,11 +320,18 @@ class CalculatorPack(Saveable):
         if path.endswith((".yaml", ".yml")):
             if not _YAML_AVAILABLE:
                 raise ImportError(
-                    "pyyaml is required for YAML export. Install with: pip install pyyaml"
+                    "pyyaml is required for YAML export. "
+                    "Install with: pip install pyyaml"
                 )
             assert _yaml is not None
             with open(path, "w", encoding="utf-8") as f:
-                _yaml.dump(data, f, allow_unicode=True, sort_keys=False, default_flow_style=False)
+                _yaml.dump(
+                    data,
+                    f,
+                    allow_unicode=True,
+                    sort_keys=False,
+                    default_flow_style=False,
+                )
         else:
             with open(path, "w", encoding="utf-8") as f:
                 json.dump(data, f, indent=2)
@@ -348,7 +355,8 @@ class CalculatorPack(Saveable):
             if path.endswith((".yaml", ".yml")):
                 if not _YAML_AVAILABLE:
                     raise ImportError(
-                        "pyyaml is required to read YAML files. Install with: pip install pyyaml"
+                        "pyyaml is required to read YAML files. "
+                        "Install with: pip install pyyaml"
                     )
                 assert _yaml is not None
                 data = _yaml.safe_load(f)

--- a/src/ixdat/measurement_base.py
+++ b/src/ixdat/measurement_base.py
@@ -30,7 +30,7 @@ from .exceptions import BuildError, SeriesNotFoundError, TechniqueError, ReadErr
 from .tools import tstamp_to_string, deprecate
 
 
-from typing import Any, Callable, Iterable, Optional, Union, TYPE_CHECKING
+from typing import Any, Callable, Iterable, Optional, Union, List, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from .calculators.packs import (
@@ -1507,7 +1507,7 @@ class Measurement(Saveable):
         pack: Union["CalculatorPack", str],
         *,
         on_conflict: str = "replace",
-    ) -> list[Any]:
+    ) -> List[Any]:
         """
         Attach all calculators contained in a CalculatorPack to this Measurement.
 
@@ -1530,7 +1530,7 @@ class Measurement(Saveable):
 
         Returns
         -------
-        list[Calculator]
+        List[Calculator]
             The calculators that were actually attached.
         """
         from .calculators.packs import CalculatorPack

--- a/src/ixdat/measurement_base.py
+++ b/src/ixdat/measurement_base.py
@@ -30,6 +30,16 @@ from .exceptions import BuildError, SeriesNotFoundError, TechniqueError, ReadErr
 from .tools import tstamp_to_string, deprecate
 
 
+from typing import Any, Callable, Iterable, Optional, Union, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .calculators.packs import (
+        CalculatorPack,
+    )  # for type checking only, later local imports
+
+Selector = Union[Iterable[str], Callable[[Any], bool], None]
+
+
 class Measurement(Saveable):
     """The Measurement class"""
 
@@ -174,7 +184,7 @@ class Measurement(Saveable):
                     out.append("┣━ " + str(value_series))
 
         calc_out = []
-        for (n, (name, calculator)) in enumerate(self.calculators.items()):
+        for n, (name, calculator) in enumerate(self.calculators.items()):
             if n == len(self.calculators) - 1:
                 calc_out.append("┗━ " + str(calculator))
             else:
@@ -1525,6 +1535,121 @@ class Calculator(Saveable):
             " measurement causes the first to be ignored."
         )
         return other
+
+    def save_calculators_pack(
+        self,
+        *,
+        name: Optional[str] = None,
+        path: Optional[str] = None,
+        include: Selector = None,
+        exclude: Selector = None,
+        notes: Optional[str] = None,
+        extra_metadata: Optional[dict] = None,
+        save_to_db: bool = False,
+    ) -> "CalculatorPack":
+        """
+        Create a CalculatorPack from this Measurement's calculators and (optionally)
+        write it to disk and/or save it to the ixdat database.
+
+        Parameters
+        ----------
+        name
+            Optional human-readable name for the pack. Defaults to
+            "CalculatorPack(<measurement.name>)".
+        path
+            Optional output filepath (e.g. "my_setup.ixpack.json"). If provided,
+            the pack is serialized to JSON at this location.
+        include
+            Selector to include calculators (iter of class names / class paths,
+            or a predicate `fn(cal) -> bool`). If None, include all.
+        exclude
+            Selector to exclude calculators (applied after `include`).
+        notes
+            Optional free-text notes stored in pack metadata (provenance).
+        extra_metadata
+            Optional dict merged into pack metadata.
+        save_to_db
+            If True, also persist the pack via `CalculatorPack.save()`.
+
+        Returns
+        -------
+        CalculatorPack
+            The constructed pack (saved to file/DB if requested).
+        """
+        from .calculators.packs import CalculatorPack
+        pack = CalculatorPack.from_measurement(
+            self,
+            include=include,
+            exclude=exclude,
+            name=name,
+            notes=notes,
+            extra_metadata=extra_metadata,
+        )
+
+        if path:
+            pack.to_file(path)
+
+        if save_to_db:
+            pack.save()
+
+        return pack
+
+    def apply_calculators_pack(
+        self,
+        pack: Union["CalculatorPack", str],
+        *,
+        on_conflict: str = "replace",
+        missing_plugins: str = "warn",
+        preflight: bool = True,
+    ) -> list[Any]:
+        """
+        Attach all calculators contained in a CalculatorPack to this Measurement.
+
+        Parameters
+        ----------
+        pack
+            A CalculatorPack instance, a filesystem path to a JSON pack
+            (e.g. "my_setup.ixpack.json"), or a database id (string).
+            - If `str` ends with ".json" or ".ixpack.json": treated as file path.
+            - Else: treated as a database id for `CalculatorPack.read(id=...)`.
+        on_conflict
+            Policy when a calculator with same class+name already exists:
+            "replace" (default), "skip", or "duplicate".
+        missing_plugins
+            Behavior if a required plugin is not installed: "warn" (default),
+            "skip", or "fail".
+        preflight
+            If True, perform light compatibility checks and raise
+            QuantificationError with an actionable message if unmet.
+
+        Returns
+        -------
+        list[Calculator]
+            The calculators that were actually attached.
+        """
+        from .calculators.packs import CalculatorPack
+        # Normalize `pack` to a CalculatorPack instance
+        if isinstance(pack, CalculatorPack):
+            the_pack = pack
+        elif isinstance(pack, str):
+            # Heuristic: file vs DB id
+            lower = pack.lower()
+            if lower.endswith(".json") or lower.endswith(".ixpack.json"):
+                the_pack = CalculatorPack.read(path=pack)
+            else:
+                the_pack = CalculatorPack.read(id=pack)
+        else:
+            raise TypeError(
+                "pack must be a CalculatorPack instance, a file path, or a database id (str)"
+            )
+
+        # Delegate to the pack's attach method
+        return the_pack.attach_to(
+            self,
+            on_conflict=on_conflict,
+            missing_plugins=missing_plugins,
+            preflight=preflight,
+        )
 
 
 def get_combined_technique(technique_1, technique_2):


### PR DESCRIPTION
This PR introduces a new CalculatorPack feature, trying to address Issue #184 and following up on the original comment by @AnnaWiniwarter in #182.

### Why it would be useful

From what I gather from the discussions, in some workflows, a measurement is analyzed using several calculators at once (e.g. an ECCalibration together with an MSCalibration). Currently, if we want to apply the same calibrations to another dataset, each calculator has to be recreated or copied separately.

`CalculatorPack` lets users capture all relevant calculators from a measurement in one step and re-apply them elsewhere, making it more **convenient** to reproduce results, while also making it more **portable** (packs are plain JSON files that can be versioned, shared, or stored with raw data), and possibly **extendable** in the future.

### Overview
`CalculatorPack` is a container for a set of calculators (EC, MS, SIQ, ...) extracted from a `Measurement`. It allows them to be:

- captured from a measurement,
- serialized to JSON or database, 
- saved/loaded from files (.ixpack.json), and
- re-attached to another measurement, with optional conflict resolution.

This makes it possible to “carry over” calibration and quantification workflows between datasets.

### Changes:

1. ixdat/calculators/packs.py _(new file)_

    - Defines `CalculatorPack` with helpers for serialization, integrity checking, file/DB I/O, and re-attachment. 
    - Skips Indexer calculators (they are always created by measurements).
    - Uses the Calculators native `as_dict()`/`from_dict()` if available. Else uses lightweight serialization.

2. ixdat/measurement_base.py _(updated)_

    - Adds integration helpers to create a pack from a measurement (`save_calculators_pack`) and apply one back (`apply_calculators_pack`).

3. development_scripts/demo_calculator_pack.py _(new demo)_

    - Demonstration of capturing EC calibrations, saving/loading packs, and re-attaching them to new measurements. **note: due to missing test data on my side, I have not been able to test multiple calculator types**.

### Still Missing / To Discuss

1. Plugin handling:

    - Some calculators (e.g. `siqCalculator`) depend on external packages (`spectro_inlets_quantification`). Currently `CalculatorPack` has no way to handle this robustly.

    - An approach might be a central plugin registry where calculator classes (or their `calculator_type`) can declare the external module and optional activation function.

    - Question: would you prefer this registry approach, or to extend each calculator with something like a `requires_plugin` attribute?

2. Broader testing:

    - Unit tests are still missing for edge cases (conflict resolution, _missing plugins_, integrity failures).
    - Only a demo script exists so far.
    
    
Closes #184 