### PR TITLE
Add ASIMOV support for Spectrum payloads

### DIFF
--- a/NEXT_CHANGES.rst
+++ b/NEXT_CHANGES.rst
@@ -33,6 +33,13 @@ readers
   from the payload.
   `PR #198 <https://github.com/ixdat/ixdat/pull/198>`_
 
+- The ``AsimovReader`` (reader="asimov") now uses ASIMOV's native project-file and
+  project-file-bundle ixdat payload endpoints, supports ``Spectrum.read`` and
+  ``SpectrumSeries`` payloads, and gives clearer errors when the requested ixdat class
+  does not match the payload ``object_type``. Nested ixdat objects in ASIMOV payloads
+  must declare ``object_type`` so ixdat can reconstruct them generically.
+  `Issue #206 <https://github.com/ixdat/ixdat/issues/206>`_
+
 - The ``BrukerNMRReader`` (reader="bruker") has been added for reading Bruker
   TopSpin 1D NMR experiment folders. It uses the optional ``nmrglue`` package
   to parse the ``acqus`` parameter file and the processed real spectrum from

--- a/development_scripts/reader_demonstrators/inspect_asimov_payloads.py
+++ b/development_scripts/reader_demonstrators/inspect_asimov_payloads.py
@@ -1,0 +1,124 @@
+"""Inspect current Asimov payload structure without printing full data arrays.
+
+Usage:
+    python development_scripts/reader_demonstrators/inspect_asimov_payloads.py ID [ID ...]
+
+Set ASIMOV_ACCESS_TOKEN for non-interactive use, or let AsimovReader use the
+normal Keycloak login flow.
+"""
+
+import argparse
+from collections import Counter
+
+from ixdat.readers.asimov import AsimovReader
+
+
+def _shape(value):
+    """Return the nested list shape if value looks like array data."""
+    shape = []
+    cursor = value
+    while isinstance(cursor, list):
+        shape.append(len(cursor))
+        cursor = cursor[0] if cursor else None
+    return tuple(shape)
+
+
+def _short(value):
+    """Return a compact scalar/list summary suitable for terminal inspection."""
+    if isinstance(value, list):
+        return f"list shape={_shape(value)}"
+    if isinstance(value, dict):
+        return f"dict keys={sorted(value)}"
+    return repr(value)
+
+
+def _print_series(entry, indent):
+    prefix = " " * indent
+    print(
+        f"{prefix}- {entry.get('series_type', 'series')}: "
+        f"{entry.get('name')!r} [{entry.get('unit_name')!r}]"
+    )
+    if "key" in entry:
+        print(f"{prefix}  key={entry['key']!r}")
+    if "data" in entry:
+        print(f"{prefix}  data={_short(entry['data'])}")
+    for ref_key in ("tseries_key", "axes_keys"):
+        if ref_key in entry:
+            print(f"{prefix}  {ref_key}={entry[ref_key]!r}")
+    if entry.get("axes_series"):
+        print(f"{prefix}  axes_series:")
+        for axis in entry["axes_series"]:
+            _print_series(axis, indent + 4)
+
+
+def _print_object(dct, indent=0, label="payload"):
+    prefix = " " * indent
+    object_type = dct.get("object_type", "<missing>")
+    technique = dct.get("technique", "<missing>")
+    print(f"{prefix}{label}: object_type={object_type!r}, technique={technique!r}")
+    for key in ("name", "sample_name", "tstamp", "duration", "durations", "continuous"):
+        if key in dct:
+            print(f"{prefix}  {key}={_short(dct[key])}")
+    if isinstance(dct.get("metadata"), dict):
+        print(f"{prefix}  metadata keys={sorted(dct['metadata'])}")
+    if dct.get("series_list"):
+        counts = Counter(s.get("series_type", "series") for s in dct["series_list"])
+        print(f"{prefix}  series_list len={len(dct['series_list'])} types={dict(counts)}")
+        for series in dct["series_list"][:6]:
+            _print_series(series, indent + 4)
+        if len(dct["series_list"]) > 6:
+            print(f"{prefix}    ... {len(dct['series_list']) - 6} more series")
+    if isinstance(dct.get("field"), dict):
+        print(f"{prefix}  field:")
+        _print_series(dct["field"], indent + 4)
+    nested = [
+        (key, value)
+        for key, value in dct.items()
+        if isinstance(value, dict) and "object_type" in value
+    ]
+    for key, value in nested:
+        _print_object(value, indent + 2, label=key)
+
+
+def _get_payload(reader, asimov_id, force_login=False):
+    headers = reader._build_auth_headers(force_login=force_login)
+    envelope = reader._get_ixdat_payload_envelope(asimov_id, headers=headers)
+    payload = envelope.get("payload_json")
+    if not payload and envelope.get("payload_uri"):
+        payload = reader._load_payload_uri(envelope["payload_uri"], headers=headers)
+    return envelope, payload
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("asimov_ids", nargs="+")
+    parser.add_argument("--force-login", action="store_true")
+    args = parser.parse_args()
+
+    reader = AsimovReader()
+    for asimov_id in args.asimov_ids:
+        envelope, payload = _get_payload(
+            reader,
+            asimov_id,
+            force_login=args.force_login,
+        )
+        print("=" * 88)
+        print(
+            f"project_file_id={envelope.get('project_file_id')} "
+            f"bundle_id={envelope.get('bundle_id')} "
+            f"filename={envelope.get('filename')!r} "
+            f"name={envelope.get('name')!r}"
+        )
+        print(
+            f"created_at={envelope.get('created_at')} "
+            f"parser={envelope.get('parser_name')!r} "
+            f"ixdat={envelope.get('ixdat_version')!r}"
+        )
+        if payload:
+            _print_object(payload)
+        else:
+            print("payload: <missing>")
+
+
+if __name__ == "__main__":
+    main()

--- a/development_scripts/reader_demonstrators/inspect_asimov_payloads.py
+++ b/development_scripts/reader_demonstrators/inspect_asimov_payloads.py
@@ -1,7 +1,7 @@
 """Inspect current Asimov payload structure without printing full data arrays.
 
 Usage:
-    python development_scripts/reader_demonstrators/inspect_asimov_payloads.py ID [ID ...]
+    python inspect_asimov_payloads.py ID [ID ...]
 
 Set ASIMOV_ACCESS_TOKEN for non-interactive use, or let AsimovReader use the
 normal Keycloak login flow.
@@ -63,7 +63,9 @@ def _print_object(dct, indent=0, label="payload"):
         print(f"{prefix}  metadata keys={sorted(dct['metadata'])}")
     if dct.get("series_list"):
         counts = Counter(s.get("series_type", "series") for s in dct["series_list"])
-        print(f"{prefix}  series_list len={len(dct['series_list'])} types={dict(counts)}")
+        print(
+            f"{prefix}  series_list len={len(dct['series_list'])} types={dict(counts)}"
+        )
         for series in dct["series_list"][:6]:
             _print_series(series, indent + 4)
         if len(dct["series_list"]) > 6:

--- a/src/ixdat/readers/__init__.py
+++ b/src/ixdat/readers/__init__.py
@@ -86,4 +86,5 @@ SPECTRUM_READER_CLASSES = {
     "qexafs": QexafsDATReader,
     "opus_ftir": OpusFTIRReader,
     "bruker": BrukerNMRReader,
+    "asimov": AsimovReader,
 }

--- a/src/ixdat/readers/asimov.py
+++ b/src/ixdat/readers/asimov.py
@@ -1,4 +1,4 @@
-"""Reader for ixdat measurements stored in Asimov dataset versions."""
+"""Reader for ixdat objects stored as parsed Asimov project-file payloads."""
 
 import os
 from dataclasses import dataclass, fields
@@ -8,7 +8,7 @@ import numpy as np
 import requests
 
 from ..auth import KeycloakDeviceTokenProvider
-from ..data_series import DataSeries, TimeSeries, ValueSeries, Field
+from ..data_series import DataSeries, SERIES_CLASSES
 from ..measurement_base import Measurement
 from ..spectra import Spectrum, SpectrumSeries
 from ..tools import request_with_retries
@@ -111,9 +111,9 @@ ASIMOV_CONFIG = AsimovConfig.from_env()
 
 
 class AsimovReader:
-    """Read a remote dataset version from Asimov into an ixdat object.
+    """Read a remote project file or bundle parse result into an ixdat object.
 
-    Typical use only needs the dataset id: ``Measurement.read(<id>,
+    Typical use only needs the project file or bundle id: ``Measurement.read(<id>,
     reader="asimov")``. The first read opens a browser tab where you log
     in once; later reads reuse a cached token.
 
@@ -159,8 +159,7 @@ class AsimovReader:
                 read_timeout=self.config.read_timeout,
             )
 
-        self.dataset = None
-        self.dataset_version = None
+        self.payload_envelope = None
         self._session = requests.Session()
         self._session.trust_env = False
 
@@ -168,73 +167,131 @@ class AsimovReader:
         self,
         id,
         cls=None,
-        version=None,
-        version_id=None,
         force_login=False,
         **kwargs,
     ):
-        """Read a dataset version from Asimov as an ixdat object.
+        """Read an ixdat payload from Asimov.
 
         Args:
-            id (str): Asimov dataset id (UUID string).
+            id (str): Asimov project-file or project-file-bundle id (UUID string).
             cls (class, optional): Class to instantiate (Measurement, Spectrum, etc.).
                 If None, auto-detected from the payload's object_type field.
-            version (int, optional): Version number to select.
-            version_id (str, optional): Dataset-version UUID to select.
             force_login (bool): Force fresh Keycloak device login.
             kwargs: Extra key/value pairs merged into the object dict.
         """
-        dataset_id = str(id)
+        asimov_id = str(id)
         headers = self._build_auth_headers(force_login=force_login)
 
-        dataset = self._get_json(f"datasets/{dataset_id}", headers=headers)
-        versions = self._get_json(
-            "dataset-versions",
-            headers=headers,
-            params={"dataset_id": dataset_id},
+        payload_envelope = self._get_ixdat_payload_envelope(
+            asimov_id, headers=headers
         )
-        dataset_version = self._select_dataset_version(
-            versions, version=version, version_id=version_id
-        )
-
-        payload = dataset_version.get("payload_json")
-        if not payload and dataset_version.get("payload_uri"):
+        payload = payload_envelope.get("payload_json")
+        if not payload and payload_envelope.get("payload_uri"):
             payload = self._load_payload_uri(
-                dataset_version["payload_uri"], headers=headers
+                payload_envelope["payload_uri"], headers=headers
             )
         if not payload:
             raise ValueError(
-                f"Dataset version {dataset_version.get('id')} has no "
+                f"Asimov parsed payload response for {asimov_id} has no "
                 "payload_json or payload_uri."
             )
 
-        self.dataset = dataset
-        self.dataset_version = dataset_version
+        self.payload_envelope = payload_envelope
 
-        # Inject Asimov provenance (dataset versioning) into metadata
+        # Inject Asimov provenance from the native project-file/bundle envelope.
         meta = dict(payload.get("metadata") or {})
         meta["asimov"] = {
-            "dataset_id": dataset.get("id"),
-            "dataset_kind": dataset.get("kind"),
-            "dataset_label": dataset.get("label"),
-            "dataset_version_id": dataset_version.get("id"),
-            "dataset_version": dataset_version.get("version"),
-            "dataset_version_created_at": dataset_version.get("created_at"),
-            "parser_name": dataset_version.get("parser_name"),
-            "ixdat_version": dataset_version.get("ixdat_version"),
+            "project_file_id": payload_envelope.get("project_file_id"),
+            "bundle_id": payload_envelope.get("bundle_id"),
+            "filename": payload_envelope.get("filename"),
+            "name": payload_envelope.get("name"),
+            "parser_name": payload_envelope.get("parser_name"),
+            "created_at": payload_envelope.get("created_at"),
+            "ixdat_version": payload_envelope.get("ixdat_version"),
         }
 
         d = {**payload, "metadata": meta}
         if not d.get("name"):
-            d["name"] = dataset.get("label") or str(dataset.get("id"))
+            d["name"] = (
+                payload_envelope.get("filename")
+                or payload_envelope.get("name")
+                or payload_envelope.get("project_file_id")
+                or payload_envelope.get("bundle_id")
+                or asimov_id
+            )
 
-        if cls is None:
-            object_type = d.get("object_type", "measurement")
-            cls = OBJECT_TYPE_CLASSES.get(object_type, Measurement)
+        object_type = d.get("object_type", "measurement")
+        self._check_requested_class_matches_object_type(
+            requested_class=cls, object_type=object_type, asimov_id=asimov_id
+        )
 
-        return cls.from_dict(self._build_kwargs(d, reader=self, **kwargs))
+        return self._build_object(d, cls=cls, reader=self, **kwargs)
 
-    def _build_kwargs(self, dct, **kwargs):
+    @staticmethod
+    def _check_requested_class_matches_object_type(
+        requested_class, object_type, asimov_id
+    ):
+        """Raise a clear error when a read entrypoint asks for the wrong object family."""
+        if requested_class is None:
+            return
+
+        if object_type == "measurement":
+            expected_cls = Measurement
+            recommended_read = "Measurement.read"
+            compatible = issubclass(requested_class, Measurement)
+        elif object_type == "spectrum":
+            expected_cls = Spectrum
+            recommended_read = "Spectrum.read"
+            compatible = issubclass(requested_class, Spectrum) and not issubclass(
+                requested_class, SpectrumSeries
+            )
+        elif object_type == "spectrum_series":
+            expected_cls = SpectrumSeries
+            recommended_read = "Spectrum.read or SpectrumSeries.read"
+            compatible = issubclass(requested_class, Spectrum)
+        else:
+            raise ValueError(
+                f"Asimov payload {asimov_id} has unsupported object_type={object_type!r}. "
+                f"Supported object types are {sorted(OBJECT_TYPE_CLASSES)}."
+            )
+
+        if compatible:
+            return
+
+        raise ValueError(
+            f"Asimov payload {asimov_id} contains a {expected_cls.__name__} payload "
+            f"(object_type={object_type!r}), but {requested_class.__name__}.read(..., "
+            "reader='asimov') requested an incompatible ixdat object type. "
+            f"Use {recommended_read}(..., reader='asimov') for this payload instead."
+        )
+
+    def _get_ixdat_payload_envelope(self, asimov_id, headers):
+        """Return the native Asimov ixdat-payload envelope for a file or bundle."""
+        try:
+            return self._get_json(
+                f"project-files/{asimov_id}/ixdat-payload", headers=headers
+            )
+        except RuntimeError as exc:
+            if not self._is_http_status(exc, 404):
+                raise
+
+        try:
+            return self._get_json(
+                f"project-file-bundles/{asimov_id}/ixdat-payload", headers=headers
+            )
+        except RuntimeError as exc:
+            if self._is_http_status(exc, 404):
+                raise ValueError(
+                    f"No Asimov project file or project file bundle with id={asimov_id}."
+                ) from exc
+            raise
+
+    @staticmethod
+    def _is_http_status(exc, status_code):
+        """Return True if a request RuntimeError mentions an HTTP status code."""
+        return f"HTTP {status_code}" in str(exc)
+
+    def _build_kwargs(self, dct, object_class=None, **kwargs):
         """Translate an Asimov payload into kwargs for cls.from_dict().
         Measurements need an absolute tstamp; Spectrum / SpectrumSeries
         accept tstamp=None natively, so we don't enforce it for them.
@@ -284,7 +341,89 @@ class AsimovReader:
                 obj["durations"] = dct.get("durations")
                 obj["continuous"] = dct.get("continuous", False)
 
+        for key, value in dct.items():
+            # A nested dict with object_type is a complete ixdat object payload,
+            # such as a reference_spectrum or spectrum_series inside a Measurement.
+            # Build it recursively without caring what the attribute is called.
+            if (
+                key not in obj
+                and isinstance(value, dict)
+                and "object_type" in value
+            ):
+                obj[key] = self._build_object(value, reader=self)
+            # Some ixdat attributes are lists of child objects, for example
+            # component_measurements. Hydrate only the list entries that declare
+            # object_type and leave ordinary scalar/list metadata untouched.
+            elif (
+                key not in obj
+                and isinstance(value, list)
+                and any(
+                    isinstance(v, dict) and "object_type" in v
+                    for v in value
+                )
+            ):
+                obj[key] = [
+                    self._build_object(v, reader=self)
+                    if isinstance(v, dict) and "object_type" in v
+                    else v
+                    for v in value
+                ]
+            # If a nested dict has the shape of an ixdat object but omits
+            # object_type, the payload is ambiguous. ASIMOV should add object_type
+            # rather than ixdat guessing from field names or data shape.
+            elif (
+                key not in obj
+                and isinstance(value, dict)
+                and "object_type" not in value
+                and ("series_list" in value or "field" in value)
+            ):
+                raise ValueError(
+                    f"Asimov payload field {key!r} is missing 'object_type'. "
+                    "Nested ixdat objects must declare object_type so ixdat can "
+                    "reconstruct them without key-specific reader logic."
+                )
+            else:
+                # Everything else is ordinary payload metadata or an unsupported
+                # auxiliary shape. It is ignored here unless ixdat declares it as a
+                # serializable constructor field in the block below.
+                pass
+
+        for key in self._get_serializable_attrs(dct, object_class):
+            if key not in obj and key in dct:
+                obj[key] = dct[key]
+
         return obj
+
+    @staticmethod
+    def _get_serializable_attrs(dct, object_class=None):
+        """Return ixdat-declared constructor fields relevant to a payload."""
+        if object_class is None:
+            return set()
+        serializable_attrs = set(object_class.get_all_column_attrs())
+
+        technique = dct.get("technique")
+        if technique:
+            from ..techniques import TECHNIQUE_CLASSES
+
+            technique_class = TECHNIQUE_CLASSES.get(technique)
+            if technique_class and issubclass(technique_class, object_class):
+                serializable_attrs.update(technique_class.get_all_column_attrs())
+
+        return serializable_attrs
+
+    def _build_object(self, dct, cls=None, **kwargs):
+        """Build an ixdat Measurement, Spectrum, or SpectrumSeries from a payload."""
+        object_type = dct.get("object_type", "measurement")
+        if cls is None:
+            cls = OBJECT_TYPE_CLASSES.get(object_type)
+            if cls is None:
+                raise ValueError(
+                    f"Asimov payload has unsupported object_type={object_type!r}. "
+                    f"Supported object types are {sorted(OBJECT_TYPE_CLASSES)}."
+                )
+        if cls is Spectrum and object_type == "spectrum_series":
+            cls = SpectrumSeries
+        return cls.from_dict(self._build_kwargs(dct, object_class=cls, **kwargs))
 
     @staticmethod
     def _build_series(dct, key_map=None):
@@ -294,72 +433,36 @@ class AsimovReader:
         the entry comes from a Measurement's series_list.
         """
         kind = dct.get("series_type", "series")
-        name = dct["name"]
-        unit_name = dct["unit_name"]
-        data = np.asarray(dct["data"])
-
-        if kind == "tseries":
-            if dct.get("tstamp") is None:
-                raise ValueError(
-                    f"Asimov tseries '{name}' is missing 'tstamp'. ixdat requires "
-                    "an absolute timestamp on every TimeSeries."
-                )
-            return TimeSeries(
-                name=name, unit_name=unit_name, data=data, tstamp=dct["tstamp"]
+        series_cls = SERIES_CLASSES.get(kind)
+        if series_cls is None:
+            raise ValueError(
+                f"Asimov series '{dct.get('name')}' has unsupported "
+                f"series_type={kind!r}. Supported series types are "
+                f"{sorted(SERIES_CLASSES)}."
             )
-        if kind in ("vseries", "constantvalue"):
-            ts = None
-            if key_map and "tseries_key" in dct:
-                ts = key_map.get(dct["tseries_key"])
-            return ValueSeries(name=name, unit_name=unit_name, data=data, tseries=ts)
-        if kind == "field":
-            # axes_keys references axes already built from the shared series_list;
-            # axes_series is the inline form where axes are embedded in the payload
-            # directly (standalone Spectrum / SpectrumSeries with no series_list).
-            if "axes_keys" in dct and key_map:
-                axes = [key_map[k] for k in dct["axes_keys"]]
-            else:
-                # No key_map means axes are not in a shared series_list, so they
-                # must be embedded inline under axes_series.
-                axes = [
-                    AsimovReader._build_series(a, key_map)
-                    for a in dct.get("axes_series", [])
-                ]
-            return Field(name=name, unit_name=unit_name, data=data, axes_series=axes)
+        serializable_attrs = set(series_cls.get_all_column_attrs())
+        series_dict = {
+            key: value for key, value in dct.items() if key in serializable_attrs
+        }
+        series_dict["series_type"] = kind
+        series_dict["data"] = np.asarray(series_dict["data"])
 
-        return DataSeries(name=name, unit_name=unit_name, data=data)
+        if kind == "tseries" and dct.get("tstamp") is None:
+            raise ValueError(
+                f"Asimov tseries '{dct.get('name')}' is missing 'tstamp'. "
+                "ixdat requires an absolute timestamp on every TimeSeries."
+            )
+        if "tseries_key" in dct and key_map:
+            series_dict["tseries"] = key_map[dct["tseries_key"]]
+        if "axes_keys" in dct and key_map:
+            series_dict["axes_series"] = [key_map[k] for k in dct["axes_keys"]]
+        elif "axes_series" in dct:
+            series_dict["axes_series"] = [
+                AsimovReader._build_series(axis, key_map)
+                for axis in dct["axes_series"]
+            ]
 
-    def _select_dataset_version(self, versions, version=None, version_id=None):
-        """Return the dataset version dict to load.
-
-        A dataset in Asimov can have multiple versions: each time data is
-        re-processed or re-uploaded, a new version is created while older
-        ones are kept for provenance (so you can always trace back to exactly
-        what data was used in a given analysis). In practice you almost always
-        want the latest version, which is the default when neither ``version``
-        nor ``version_id`` is given.
-
-        Args:
-            versions (list): List of version dicts returned by the API.
-            version (int, optional): Version number to select (1-based).
-            version_id (str, optional): Exact version UUID to select.
-        """
-        if not isinstance(versions, list) or not versions:
-            raise ValueError("No dataset versions returned from Asimov API.")
-        if version_id is not None:
-            for v in versions:
-                if v.get("id") == version_id:
-                    return v
-            raise ValueError(f"No dataset version with id={version_id}.")
-        if version is not None:
-            for v in versions:
-                if v.get("version") == version:
-                    return v
-            raise ValueError(f"No dataset version with version={version}.")
-        # Asimov returns created_at as an ISO 8601 string (e.g. "2024-06-01T12:00:00Z").
-        # Lexicographic sorting of ISO 8601 strings is equivalent to chronological
-        # sorting, so reverse=True gives the most recently created version first.
-        return sorted(versions, key=lambda v: v.get("created_at", ""), reverse=True)[0]
+        return DataSeries.from_dict(series_dict)
 
     def _build_auth_headers(self, force_login=False):
         """Return the HTTP Authorization header dict for an API request.
@@ -380,7 +483,7 @@ class AsimovReader:
     def _load_payload_uri(self, payload_uri, headers):
         """Fetch and return a payload stored at a URI rather than inline.
 
-        Large datasets are sometimes stored outside the main API response
+        Large payloads are sometimes stored outside the main API response
         and referenced by a URI. This method resolves relative URIs against
         the base URL and downloads the payload JSON.
         """

--- a/src/ixdat/readers/asimov.py
+++ b/src/ixdat/readers/asimov.py
@@ -182,9 +182,7 @@ class AsimovReader:
         asimov_id = str(id)
         headers = self._build_auth_headers(force_login=force_login)
 
-        payload_envelope = self._get_ixdat_payload_envelope(
-            asimov_id, headers=headers
-        )
+        payload_envelope = self._get_ixdat_payload_envelope(asimov_id, headers=headers)
         payload = payload_envelope.get("payload_json")
         if not payload and payload_envelope.get("payload_uri"):
             payload = self._load_payload_uri(
@@ -231,7 +229,7 @@ class AsimovReader:
     def _check_requested_class_matches_object_type(
         requested_class, object_type, asimov_id
     ):
-        """Raise a clear error when a read entrypoint asks for the wrong object family."""
+        """Raise a clear error for the wrong read entrypoint."""
         if requested_class is None:
             return
 
@@ -251,7 +249,8 @@ class AsimovReader:
             compatible = issubclass(requested_class, Spectrum)
         else:
             raise ValueError(
-                f"Asimov payload {asimov_id} has unsupported object_type={object_type!r}. "
+                f"Asimov payload {asimov_id} has unsupported "
+                f"object_type={object_type!r}. "
                 f"Supported object types are {sorted(OBJECT_TYPE_CLASSES)}."
             )
 
@@ -345,11 +344,7 @@ class AsimovReader:
             # A nested dict with object_type is a complete ixdat object payload,
             # such as a reference_spectrum or spectrum_series inside a Measurement.
             # Build it recursively without caring what the attribute is called.
-            if (
-                key not in obj
-                and isinstance(value, dict)
-                and "object_type" in value
-            ):
+            if key not in obj and isinstance(value, dict) and "object_type" in value:
                 obj[key] = self._build_object(value, reader=self)
             # Some ixdat attributes are lists of child objects, for example
             # component_measurements. Hydrate only the list entries that declare
@@ -357,10 +352,7 @@ class AsimovReader:
             elif (
                 key not in obj
                 and isinstance(value, list)
-                and any(
-                    isinstance(v, dict) and "object_type" in v
-                    for v in value
-                )
+                and any(isinstance(v, dict) and "object_type" in v for v in value)
             ):
                 obj[key] = [
                     self._build_object(v, reader=self)
@@ -458,8 +450,7 @@ class AsimovReader:
             series_dict["axes_series"] = [key_map[k] for k in dct["axes_keys"]]
         elif "axes_series" in dct:
             series_dict["axes_series"] = [
-                AsimovReader._build_series(axis, key_map)
-                for axis in dct["axes_series"]
+                AsimovReader._build_series(axis, key_map) for axis in dct["axes_series"]
             ]
 
         return DataSeries.from_dict(series_dict)

--- a/src/ixdat/spectra.py
+++ b/src/ixdat/spectra.py
@@ -98,6 +98,21 @@ class Spectrum(Saveable):
         self.export = self.exporter.export
 
     @classmethod
+    def from_dict(cls, obj_as_dict):
+        """Return a spectrum object of the right technique class.
+
+        This mirrors :meth:`Measurement.from_dict`: a serialized spectrum carries
+        its technique, and that is enough to reconstruct the registered
+        technique-specific subclass, including its plotter/exporter behavior.
+        """
+        from .techniques import TECHNIQUE_CLASSES
+
+        technique_class = TECHNIQUE_CLASSES.get(obj_as_dict.get("technique"))
+        if technique_class and issubclass(technique_class, cls):
+            return technique_class(**obj_as_dict)
+        return cls(**obj_as_dict)
+
+    @classmethod
     def read(cls, path_to_file, reader, **kwargs):
         """Return a Measurement object from parsing a file with the specified reader
 

--- a/tests/unit/test_asimov_reader.py
+++ b/tests/unit/test_asimov_reader.py
@@ -1,3 +1,5 @@
+import json
+
 import numpy as np
 import pytest
 import requests
@@ -6,6 +8,8 @@ from ixdat.data_series import TimeSeries, ValueSeries
 from ixdat.measurement_base import Measurement
 from ixdat.readers.asimov import AsimovConfig, AsimovReader
 from ixdat.spectra import Spectrum, SpectrumSeries
+from ixdat.techniques.spectroelectrochemistry import ECOpticalMeasurement
+from ixdat.techniques.nmr import NMRSpectrum
 
 
 class FakeSession:
@@ -22,14 +26,52 @@ class FakeSession:
         return self.response
 
 
+class FakeQueuedSession:
+    """requests.Session stand-in that returns queued responses in order."""
+
+    def __init__(self, responses):
+        self.responses = list(responses)
+        self.requests = []
+        self.adapters = {}
+        self.trust_env = False
+
+    def mount(self, prefix, adapter):
+        self.adapters[prefix] = adapter
+
+    def request(self, *args, **kwargs):
+        self.requests.append((args, kwargs))
+        return self.responses.pop(0)
+
+
 def make_response(status_code, body, reason=""):
     response = requests.Response()
     response.status_code = status_code
     response.reason = reason
-    response.url = "https://asimov.example.test/api/datasets/dataset-id"
+    response.url = "https://asimov.example.test/api/project-files/file-id/ixdat-payload"
     response._content = body.encode()
     response.headers["content-type"] = "application/json"
     return response
+
+
+def make_json_response(body):
+    response = requests.Response()
+    response.status_code = 200
+    response.url = "https://asimov.example.test/api"
+    response._content = json.dumps(body).encode()
+    response.headers["content-type"] = "application/json"
+    return response
+
+
+def make_payload_envelope(payload, **overrides):
+    envelope = {
+        "project_file_id": "dataset-id",
+        "filename": "remote.dat",
+        "parser_name": "parser",
+        "created_at": "2026-06-19T12:00:00Z",
+        "payload_json": payload,
+    }
+    envelope.update(overrides)
+    return envelope
 
 
 def test_asimov_reader_explains_unauthorized_client():
@@ -43,7 +85,10 @@ def test_asimov_reader_explains_unauthorized_client():
     reader._session = FakeSession(response)
 
     with pytest.raises(RuntimeError) as exception:
-        reader._get_json("datasets/dataset-id", headers={"Authorization": "Bearer t"})
+        reader._get_json(
+            "project-files/file-id/ixdat-payload",
+            headers={"Authorization": "Bearer t"},
+        )
 
     message = str(exception.value)
     assert "Unauthorized client" in message
@@ -141,6 +186,372 @@ def test_parse_spectrum_payload():
     np.testing.assert_allclose(spectrum.y, y)
 
 
+def test_spectrum_read_uses_asimov_reader_registration(monkeypatch):
+    x = np.linspace(0, 10, 50)
+    y = np.sin(x)
+    payload = {
+        "object_type": "spectrum",
+        "name": "remote-spectrum",
+        "technique": "XPS",
+        "tstamp": 456.0,
+        "field": {
+            "series_type": "field",
+            "name": "intensity",
+            "unit_name": "counts",
+            "data": y.tolist(),
+            "axes_series": [
+                {
+                    "series_type": "series",
+                    "name": "energy",
+                    "unit_name": "eV",
+                    "data": x.tolist(),
+                }
+            ],
+        },
+    }
+    session = FakeQueuedSession(
+        [
+            make_json_response(
+                make_payload_envelope(payload, filename="remote-spectrum.dat")
+            )
+        ]
+    )
+    monkeypatch.setenv("ASIMOV_ACCESS_TOKEN", "dummy")
+    monkeypatch.setattr("ixdat.readers.asimov.requests.Session", lambda: session)
+
+    spectrum = Spectrum.read("dataset-id", reader="asimov")
+
+    assert isinstance(spectrum, Spectrum)
+    assert spectrum.name == "remote-spectrum"
+    np.testing.assert_allclose(spectrum.x, x)
+    np.testing.assert_allclose(spectrum.y, y)
+    assert spectrum.metadata["asimov"]["project_file_id"] == "dataset-id"
+    assert "dataset_id" not in spectrum.metadata["asimov"]
+    assert "version" not in spectrum.metadata["asimov"]
+    assert "project-files/dataset-id/ixdat-payload" in session.requests[0][1]["url"]
+    assert "dataset-versions" not in session.requests[0][1]["url"]
+
+
+def test_asimov_reader_falls_back_to_bundle_payload_endpoint(monkeypatch):
+    payload = {
+        "object_type": "measurement",
+        "name": "bundle-measurement",
+        "technique": "simple",
+        "tstamp": 123.0,
+        "series_list": [
+            {
+                "key": "s0",
+                "series_type": "tseries",
+                "name": "time/s",
+                "unit_name": "s",
+                "data": [0.0, 1.0],
+                "tstamp": 123.0,
+            }
+        ],
+    }
+    session = FakeQueuedSession(
+        [
+            make_response(404, '{"detail": "Not found"}', reason="Not Found"),
+            make_json_response(
+                make_payload_envelope(
+                    payload,
+                    project_file_id=None,
+                    bundle_id="bundle-id",
+                    name="bundle",
+                    filename=None,
+                )
+            ),
+        ]
+    )
+    monkeypatch.setenv("ASIMOV_ACCESS_TOKEN", "dummy")
+    monkeypatch.setattr("ixdat.readers.asimov.requests.Session", lambda: session)
+
+    measurement = Measurement.read("bundle-id", reader="asimov")
+
+    assert isinstance(measurement, Measurement)
+    assert measurement.metadata["asimov"]["bundle_id"] == "bundle-id"
+    assert "project-files/bundle-id/ixdat-payload" in session.requests[0][1]["url"]
+    assert "project-file-bundles/bundle-id/ixdat-payload" in session.requests[1][1]["url"]
+
+
+def test_spectrum_read_explains_measurement_payload_mismatch(monkeypatch):
+    payload = {
+        "object_type": "measurement",
+        "name": "remote-measurement",
+        "technique": "simple",
+        "tstamp": 123.0,
+        "series_list": [
+            {
+                "key": "s0",
+                "series_type": "tseries",
+                "name": "time/s",
+                "unit_name": "s",
+                "data": [0.0, 1.0],
+                "tstamp": 123.0,
+            },
+            {
+                "key": "s1",
+                "series_type": "vseries",
+                "name": "I/mA",
+                "unit_name": "mA",
+                "data": [1.0, 2.0],
+                "tseries_key": "s0",
+            },
+        ],
+    }
+    session = FakeQueuedSession(
+        [
+            make_json_response(make_payload_envelope(payload))
+        ]
+    )
+    monkeypatch.setenv("ASIMOV_ACCESS_TOKEN", "dummy")
+    monkeypatch.setattr("ixdat.readers.asimov.requests.Session", lambda: session)
+
+    with pytest.raises(ValueError) as exception:
+        Spectrum.read("dataset-id", reader="asimov")
+
+    message = str(exception.value)
+    assert "contains a Measurement payload" in message
+    assert "incompatible ixdat object type" in message
+    assert "Measurement.read" in message
+
+
+def test_measurement_read_explains_spectrum_payload_mismatch(monkeypatch):
+    x = np.linspace(0, 10, 50)
+    y = np.sin(x)
+    payload = {
+        "object_type": "spectrum",
+        "name": "remote-spectrum",
+        "technique": "XPS",
+        "field": {
+            "series_type": "field",
+            "name": "intensity",
+            "unit_name": "counts",
+            "data": y.tolist(),
+            "axes_series": [
+                {
+                    "series_type": "series",
+                    "name": "energy",
+                    "unit_name": "eV",
+                    "data": x.tolist(),
+                }
+            ],
+        },
+    }
+    session = FakeQueuedSession(
+        [
+            make_json_response(
+                make_payload_envelope(payload, filename="remote-spectrum.dat")
+            )
+        ]
+    )
+    monkeypatch.setenv("ASIMOV_ACCESS_TOKEN", "dummy")
+    monkeypatch.setattr("ixdat.readers.asimov.requests.Session", lambda: session)
+
+    with pytest.raises(ValueError) as exception:
+        Measurement.read("dataset-id", reader="asimov")
+
+    message = str(exception.value)
+    assert "contains a Spectrum payload" in message
+    assert "incompatible ixdat object type" in message
+    assert "Spectrum.read" in message
+
+
+def test_spectrum_series_read_explains_spectrum_payload_mismatch(monkeypatch):
+    x = np.linspace(0, 10, 50)
+    y = np.sin(x)
+    payload = {
+        "object_type": "spectrum",
+        "name": "remote-spectrum",
+        "technique": "XPS",
+        "field": {
+            "series_type": "field",
+            "name": "intensity",
+            "unit_name": "counts",
+            "data": y.tolist(),
+            "axes_series": [
+                {
+                    "series_type": "series",
+                    "name": "energy",
+                    "unit_name": "eV",
+                    "data": x.tolist(),
+                }
+            ],
+        },
+    }
+    session = FakeQueuedSession(
+        [
+            make_json_response(
+                make_payload_envelope(payload, filename="remote-spectrum.dat")
+            )
+        ]
+    )
+    monkeypatch.setenv("ASIMOV_ACCESS_TOKEN", "dummy")
+    monkeypatch.setattr("ixdat.readers.asimov.requests.Session", lambda: session)
+
+    with pytest.raises(ValueError) as exception:
+        SpectrumSeries.read("dataset-id", reader="asimov")
+
+    message = str(exception.value)
+    assert "contains a Spectrum payload" in message
+    assert "incompatible ixdat object type" in message
+    assert "Spectrum.read" in message
+
+
+def test_asimov_nmr_spectrum_uses_nmr_subclass_and_plotter(monkeypatch):
+    x = np.linspace(15, -5, 50)
+    y = np.sin(x)
+    payload = {
+        "object_type": "spectrum",
+        "name": "remote-nmr",
+        "technique": "NMR",
+        "tstamp": 456.0,
+        "field": {
+            "series_type": "field",
+            "name": "intensity",
+            "unit_name": None,
+            "data": y.tolist(),
+            "axes_series": [
+                {
+                    "series_type": "series",
+                    "name": "chemical shift",
+                    "unit_name": "ppm",
+                    "data": x.tolist(),
+                }
+            ],
+        },
+    }
+    session = FakeQueuedSession(
+        [
+            make_json_response(make_payload_envelope(payload, filename="nmr.dat"))
+        ]
+    )
+    monkeypatch.setenv("ASIMOV_ACCESS_TOKEN", "dummy")
+    monkeypatch.setattr("ixdat.readers.asimov.requests.Session", lambda: session)
+
+    spectrum = Spectrum.read("dataset-id", reader="asimov")
+
+    assert isinstance(spectrum, NMRSpectrum)
+    assert spectrum.plotter.__class__.__name__ == "NMRPlotter"
+    np.testing.assert_allclose(spectrum.x, x)
+    np.testing.assert_allclose(spectrum.y, y)
+
+
+def test_asimov_nmr_spectrum_can_be_read_from_nmr_class(monkeypatch):
+    x = np.linspace(15, -5, 50)
+    y = np.sin(x)
+    payload = {
+        "object_type": "spectrum",
+        "name": "remote-nmr",
+        "technique": "NMR",
+        "tstamp": 456.0,
+        "field": {
+            "series_type": "field",
+            "name": "intensity",
+            "unit_name": None,
+            "data": y.tolist(),
+            "axes_series": [
+                {
+                    "series_type": "series",
+                    "name": "chemical shift",
+                    "unit_name": "ppm",
+                    "data": x.tolist(),
+                }
+            ],
+        },
+    }
+    session = FakeQueuedSession(
+        [
+            make_json_response(make_payload_envelope(payload, filename="nmr.dat"))
+        ]
+    )
+    monkeypatch.setenv("ASIMOV_ACCESS_TOKEN", "dummy")
+    monkeypatch.setattr("ixdat.readers.asimov.requests.Session", lambda: session)
+
+    spectrum = NMRSpectrum.read("dataset-id", reader="asimov")
+
+    assert isinstance(spectrum, NMRSpectrum)
+    assert spectrum.plotter.__class__.__name__ == "NMRPlotter"
+    np.testing.assert_allclose(spectrum.x, x)
+    np.testing.assert_allclose(spectrum.y, y)
+
+
+def test_spectrum_from_dict_dispatches_by_technique():
+    x = np.linspace(15, -5, 50)
+    y = np.sin(x)
+    spectrum = Spectrum.from_dict(
+        {
+            "name": "nmr",
+            "technique": "NMR",
+            "field": _reader()._build_series(
+                {
+                    "series_type": "field",
+                    "name": "intensity",
+                    "unit_name": None,
+                    "data": y.tolist(),
+                    "axes_series": [
+                        {
+                            "series_type": "series",
+                            "name": "chemical shift",
+                            "unit_name": "ppm",
+                            "data": x.tolist(),
+                        }
+                    ],
+                }
+            ),
+        }
+    )
+
+    assert isinstance(spectrum, NMRSpectrum)
+    assert spectrum.plotter.__class__.__name__ == "NMRPlotter"
+    np.testing.assert_allclose(spectrum.x, x)
+
+
+def test_asimov_spectrum_read_can_return_spectrum_series(monkeypatch):
+    x = np.linspace(0, 10, 50)
+    spectra = np.stack([np.sin(x), np.cos(x)])
+    payload = {
+        "object_type": "spectrum_series",
+        "name": "remote-series",
+        "technique": "spectra",
+        "tstamp": 100.0,
+        "field": {
+            "series_type": "field",
+            "name": "intensity",
+            "unit_name": "counts",
+            "data": spectra.tolist(),
+            "axes_series": [
+                {
+                    "series_type": "tseries",
+                    "name": "Spectrum Time",
+                    "unit_name": "s",
+                    "data": [0.0, 1.0],
+                    "tstamp": 100.0,
+                },
+                {
+                    "series_type": "series",
+                    "name": "energy",
+                    "unit_name": "eV",
+                    "data": x.tolist(),
+                },
+            ],
+        },
+    }
+    session = FakeQueuedSession(
+        [
+            make_json_response(make_payload_envelope(payload, filename="series.dat"))
+        ]
+    )
+    monkeypatch.setenv("ASIMOV_ACCESS_TOKEN", "dummy")
+    monkeypatch.setattr("ixdat.readers.asimov.requests.Session", lambda: session)
+
+    spectrum_series = Spectrum.read("dataset-id", reader="asimov")
+
+    assert isinstance(spectrum_series, SpectrumSeries)
+    np.testing.assert_allclose(spectrum_series.x, x)
+    np.testing.assert_allclose(spectrum_series.y, spectra)
+
+
 def test_parse_spectrum_series_payload():
     x = np.linspace(0, 10, 50)
     spectra = np.stack([np.sin(x + i) for i in range(3)])
@@ -178,6 +589,361 @@ def test_parse_spectrum_series_payload():
     np.testing.assert_allclose(series.x, x)
     assert series.y.shape == (3, 50)
     np.testing.assert_allclose(series.y[0], np.sin(x))
+
+
+def test_build_kwargs_hydrates_generic_nested_ixdat_objects():
+    x = np.linspace(0, 10, 5)
+    y = np.sin(x)
+    payload = {
+        "object_type": "measurement",
+        "name": "demo",
+        "technique": "simple",
+        "tstamp": 1.0,
+        "series_list": [
+            {
+                "key": "s0",
+                "series_type": "tseries",
+                "name": "time/s",
+                "unit_name": "s",
+                "data": [0.0, 1.0],
+                "tstamp": 1.0,
+            }
+        ],
+        "calibration_spectrum": {
+            "object_type": "spectrum",
+            "name": "calibration",
+            "technique": "spectrum",
+            "field": {
+                "series_type": "field",
+                "name": "intensity",
+                "unit_name": "counts",
+                "data": y.tolist(),
+                "axes_series": [
+                    {
+                        "series_type": "series",
+                        "name": "energy",
+                        "unit_name": "eV",
+                        "data": x.tolist(),
+                    }
+                ],
+            },
+        },
+    }
+
+    obj = _reader()._build_kwargs(payload)
+
+    assert isinstance(obj["calibration_spectrum"], Spectrum)
+    np.testing.assert_allclose(obj["calibration_spectrum"].x, x)
+    np.testing.assert_allclose(obj["calibration_spectrum"].y, y)
+
+
+def test_build_kwargs_hydrates_generic_nested_ixdat_object_lists():
+    payload = {
+        "object_type": "measurement",
+        "name": "combined",
+        "technique": "simple",
+        "tstamp": 1.0,
+        "series_list": [
+            {
+                "key": "s0",
+                "series_type": "tseries",
+                "name": "time/s",
+                "unit_name": "s",
+                "data": [0.0, 1.0],
+                "tstamp": 1.0,
+            }
+        ],
+        "component_measurements": [
+            {
+                "object_type": "measurement",
+                "name": "part",
+                "technique": "simple",
+                "tstamp": 1.0,
+                "series_list": [
+                    {
+                        "key": "s0",
+                        "series_type": "tseries",
+                        "name": "time/s",
+                        "unit_name": "s",
+                        "data": [0.0],
+                        "tstamp": 1.0,
+                    }
+                ],
+            }
+        ],
+    }
+
+    obj = _reader()._build_kwargs(payload)
+
+    assert len(obj["component_measurements"]) == 1
+    assert isinstance(obj["component_measurements"][0], Measurement)
+    assert obj["component_measurements"][0].name == "part"
+
+
+def test_build_object_supports_ixdat_container_object_types():
+    reader = _reader()
+    measurement = reader._build_object(
+        {
+            "object_type": "measurement",
+            "name": "demo-measurement",
+            "technique": "simple",
+            "tstamp": 1.0,
+            "series_list": [
+                {
+                    "key": "s0",
+                    "series_type": "tseries",
+                    "name": "time/s",
+                    "unit_name": "s",
+                    "data": [0.0, 1.0],
+                    "tstamp": 1.0,
+                }
+            ],
+        }
+    )
+    assert isinstance(measurement, Measurement)
+
+    spectrum = reader._build_object(
+        {
+            "object_type": "spectrum",
+            "name": "demo-spectrum",
+            "technique": "spectrum",
+            "field": {
+                "series_type": "field",
+                "name": "intensity",
+                "unit_name": "counts",
+                "data": [1.0, 2.0],
+                "axes_series": [
+                    {
+                        "series_type": "series",
+                        "name": "energy",
+                        "unit_name": "eV",
+                        "data": [0.0, 1.0],
+                    }
+                ],
+            },
+        }
+    )
+    assert isinstance(spectrum, Spectrum)
+
+    spectrum_series = reader._build_object(
+        {
+            "object_type": "spectrum_series",
+            "name": "demo-series",
+            "technique": "spectra",
+            "field": {
+                "series_type": "field",
+                "name": "intensity",
+                "unit_name": "counts",
+                "data": [[1.0, 2.0], [3.0, 4.0]],
+                "axes_series": [
+                    {
+                        "series_type": "tseries",
+                        "name": "Spectrum Time",
+                        "unit_name": "s",
+                        "data": [0.0, 1.0],
+                        "tstamp": 1.0,
+                    },
+                    {
+                        "series_type": "series",
+                        "name": "energy",
+                        "unit_name": "eV",
+                        "data": [0.0, 1.0],
+                    },
+                ],
+            },
+        },
+        cls=Spectrum,
+    )
+    assert isinstance(spectrum_series, SpectrumSeries)
+
+
+def test_build_object_rejects_unknown_container_object_type():
+    with pytest.raises(ValueError) as exception:
+        _reader()._build_object(
+            {
+                "object_type": "future_container",
+                "name": "demo",
+                "technique": "simple",
+            }
+        )
+
+    assert "unsupported object_type='future_container'" in str(exception.value)
+    assert "measurement" in str(exception.value)
+    assert "spectrum" in str(exception.value)
+    assert "spectrum_series" in str(exception.value)
+
+
+def test_parse_spectro_measurement_with_nested_spectrum_objects():
+    x = np.linspace(400, 700, 4)
+    spectra = np.stack([np.sin(x), np.cos(x)])
+    payload = {
+        "object_type": "measurement",
+        "name": "sec-demo",
+        "technique": "EC-Optical",
+        "tstamp": 100.0,
+        "series_list": [
+            {
+                "key": "s0",
+                "series_type": "tseries",
+                "name": "time/s",
+                "unit_name": "s",
+                "data": [0.0, 1.0],
+                "tstamp": 100.0,
+            },
+            {
+                "key": "s1",
+                "series_type": "vseries",
+                "name": "Ewe/V",
+                "unit_name": "V",
+                "data": [0.1, 0.2],
+                "tseries_key": "s0",
+            },
+        ],
+        "spectrum_series": {
+            "object_type": "spectrum_series",
+            "name": "uv-vis",
+            "technique": "spectra",
+            "tstamp": 100.0,
+            "metadata": {"spectrometer": "demo"},
+            "field": {
+                "series_type": "field",
+                "name": "absorbance",
+                "unit_name": "a.u.",
+                "data": spectra.tolist(),
+                "axes_series": [
+                    {
+                        "series_type": "tseries",
+                        "name": "Spectrum Time",
+                        "unit_name": "s",
+                        "data": [0.0, 1.0],
+                        "tstamp": 100.0,
+                    },
+                    {
+                        "series_type": "series",
+                        "name": "wavelength",
+                        "unit_name": "nm",
+                        "data": x.tolist(),
+                    },
+                ],
+            },
+            "durations": [0.5, 0.5],
+            "continuous": True,
+        },
+        "reference_spectrum": {
+            "object_type": "spectrum",
+            "name": "reference",
+            "technique": "spectrum",
+            "tstamp": 99.0,
+            "metadata": {"dark_corrected": True},
+            "field": {
+                "series_type": "field",
+                "name": "reference intensity",
+                "unit_name": "counts",
+                "data": [1.0, 2.0, 3.0, 4.0],
+                "axes_series": [
+                    {
+                        "series_type": "series",
+                        "name": "wavelength",
+                        "unit_name": "nm",
+                        "data": x.tolist(),
+                    }
+                ],
+            },
+        },
+    }
+
+    measurement = Measurement.from_dict(_reader()._build_kwargs(payload))
+
+    assert isinstance(measurement.spectrum_series, SpectrumSeries)
+    assert measurement.spectrum_series.metadata == {"spectrometer": "demo"}
+    assert measurement.spectrum_series.continuous is True
+    np.testing.assert_allclose(measurement.spectrum_series.durations, [0.5, 0.5])
+    np.testing.assert_allclose(measurement.spectrum_series.x, x)
+    np.testing.assert_allclose(measurement.spectrum_series.y, spectra)
+
+    assert isinstance(measurement.reference_spectrum, Spectrum)
+    assert measurement.reference_spectrum.metadata == {"dark_corrected": True}
+    np.testing.assert_allclose(measurement.reference_spectrum.x, x)
+    np.testing.assert_allclose(measurement.reference_spectrum.y, [1.0, 2.0, 3.0, 4.0])
+
+
+def test_nested_ixdat_object_without_object_type_fails_clearly():
+    payload = {
+        "object_type": "measurement",
+        "name": "sec-demo",
+        "technique": "EC-Optical",
+        "tstamp": 100.0,
+        "series_list": [
+            {
+                "key": "s0",
+                "series_type": "tseries",
+                "name": "time/s",
+                "unit_name": "s",
+                "data": [0.0, 1.0],
+                "tstamp": 100.0,
+            }
+        ],
+        "reference_spectrum": {
+            "name": "reference",
+            "technique": "spectrum",
+            "field": {
+                "series_type": "field",
+                "name": "reference intensity",
+                "unit_name": "counts",
+                "data": [1.0, 2.0],
+                "axes_series": [
+                    {
+                        "series_type": "series",
+                        "name": "wavelength",
+                        "unit_name": "nm",
+                        "data": [400.0, 500.0],
+                    }
+                ],
+            },
+        },
+    }
+
+    with pytest.raises(ValueError) as exception:
+        _reader()._build_kwargs(payload)
+
+    message = str(exception.value)
+    assert "reference_spectrum" in message
+    assert "missing 'object_type'" in message
+
+
+def test_parse_ec_optical_measurement_preserves_linker_ids():
+    payload = {
+        "object_type": "measurement",
+        "name": "sec-demo",
+        "technique": "EC-Optical",
+        "tstamp": 100.0,
+        "series_list": [
+            {
+                "key": "s0",
+                "series_type": "tseries",
+                "name": "time/s",
+                "unit_name": "s",
+                "data": [0.0, 1.0],
+                "tstamp": 100.0,
+            },
+            {
+                "key": "s1",
+                "series_type": "vseries",
+                "name": "Ewe/V",
+                "unit_name": "V",
+                "data": [0.1, 0.2],
+                "tseries_key": "s0",
+            },
+        ],
+        "spectrum_id": 12,
+        "ref_id": 13,
+    }
+
+    measurement = _reader()._build_object(payload)
+
+    assert isinstance(measurement, ECOpticalMeasurement)
+    assert measurement._spectrum_series.id == 12
+    assert measurement._reference_spectrum.id == 13
 
 
 def test_appended_measurement_same_named_tseries_resolved_by_key():
@@ -239,6 +1005,22 @@ def test_appended_measurement_same_named_tseries_resolved_by_key():
     # tstamp=101.0, so its data is offset by (101.0 - 1.0) = 100 s.
     meas = Measurement.from_dict(obj)
     np.testing.assert_allclose(meas["time/s"].data, [0.0, 1.0, 200.0, 201.0])
+
+
+def test_series_payload_ignores_non_ixdat_constructor_metadata():
+    series = _reader()._build_series(
+        {
+            "series_type": "tseries",
+            "class": "TimeSeries",
+            "name": "time/s",
+            "unit_name": "s",
+            "data": [0.0, 1.0],
+            "tstamp": 1.0,
+        }
+    )
+
+    assert isinstance(series, TimeSeries)
+    np.testing.assert_allclose(series.data, [0.0, 1.0])
 
 
 def test_field_axis_reuses_top_level_tseries_via_axes_keys():

--- a/tests/unit/test_asimov_reader.py
+++ b/tests/unit/test_asimov_reader.py
@@ -271,7 +271,9 @@ def test_asimov_reader_falls_back_to_bundle_payload_endpoint(monkeypatch):
     assert isinstance(measurement, Measurement)
     assert measurement.metadata["asimov"]["bundle_id"] == "bundle-id"
     assert "project-files/bundle-id/ixdat-payload" in session.requests[0][1]["url"]
-    assert "project-file-bundles/bundle-id/ixdat-payload" in session.requests[1][1]["url"]
+    assert (
+        "project-file-bundles/bundle-id/ixdat-payload" in session.requests[1][1]["url"]
+    )
 
 
 def test_spectrum_read_explains_measurement_payload_mismatch(monkeypatch):
@@ -299,11 +301,7 @@ def test_spectrum_read_explains_measurement_payload_mismatch(monkeypatch):
             },
         ],
     }
-    session = FakeQueuedSession(
-        [
-            make_json_response(make_payload_envelope(payload))
-        ]
-    )
+    session = FakeQueuedSession([make_json_response(make_payload_envelope(payload))])
     monkeypatch.setenv("ASIMOV_ACCESS_TOKEN", "dummy")
     monkeypatch.setattr("ixdat.readers.asimov.requests.Session", lambda: session)
 
@@ -422,9 +420,7 @@ def test_asimov_nmr_spectrum_uses_nmr_subclass_and_plotter(monkeypatch):
         },
     }
     session = FakeQueuedSession(
-        [
-            make_json_response(make_payload_envelope(payload, filename="nmr.dat"))
-        ]
+        [make_json_response(make_payload_envelope(payload, filename="nmr.dat"))]
     )
     monkeypatch.setenv("ASIMOV_ACCESS_TOKEN", "dummy")
     monkeypatch.setattr("ixdat.readers.asimov.requests.Session", lambda: session)
@@ -461,9 +457,7 @@ def test_asimov_nmr_spectrum_can_be_read_from_nmr_class(monkeypatch):
         },
     }
     session = FakeQueuedSession(
-        [
-            make_json_response(make_payload_envelope(payload, filename="nmr.dat"))
-        ]
+        [make_json_response(make_payload_envelope(payload, filename="nmr.dat"))]
     )
     monkeypatch.setenv("ASIMOV_ACCESS_TOKEN", "dummy")
     monkeypatch.setattr("ixdat.readers.asimov.requests.Session", lambda: session)
@@ -538,9 +532,7 @@ def test_asimov_spectrum_read_can_return_spectrum_series(monkeypatch):
         },
     }
     session = FakeQueuedSession(
-        [
-            make_json_response(make_payload_envelope(payload, filename="series.dat"))
-        ]
+        [make_json_response(make_payload_envelope(payload, filename="series.dat"))]
     )
     monkeypatch.setenv("ASIMOV_ACCESS_TOKEN", "dummy")
     monkeypatch.setattr("ixdat.readers.asimov.requests.Session", lambda: session)


### PR DESCRIPTION
# Support Spectrum and SpectrumSeries payloads in ASIMOV reader

This PR addresses ixdat issue #206: ASIMOV should be able to return both Measurement-class and Spectrum-class data through the normal ixdat read API.

The important user-facing goal is that these calls should all work when the ASIMOV payload contains the matching ixdat object, including registered subclasses of either class:

```python
Measurement.read(asimov_id, reader="asimov")
Spectrum.read(asimov_id, reader="asimov")
```

There are three parts to making that work cleanly.

First, ixdat needed the same reconstruction behavior for `Spectrum` that it already had for `Measurement`. `Measurement.from_dict()` already looks at the payload technique and returns the registered technique-specific class. Spectrum did not do that before, so a technique-specific Spectrum payload could be reconstructed as plain `Spectrum` instead of the registered subclass. This PR adds `Spectrum.from_dict()` so spectrum payloads get the correct subclass, plotter, and behavior.

Second, ASIMOV has migrated from dataset/dataset-version payload storage to project-file and bundle payload storage. The reader therefore had to stop using the legacy compatibility routes and start using the native ixdat-payload endpoints.

Third, ASIMOVReader should not need a new special case every time we add a new technique, spectrum subtype, or reader. The reader now builds ixdat's core container objects generically from `object_type`, delegates technique dispatch to ixdat's own `from_dict()` methods, and delegates series class selection to ixdat's `DataSeries.from_dict()`.

## What Changed

### `Spectrum.from_dict()` now mirrors `Measurement.from_dict()`

File: `src/ixdat/spectra.py`

Minimal excerpt:

```python
@classmethod
def from_dict(cls, obj_as_dict):
    from .techniques import TECHNIQUE_CLASSES

    technique_class = TECHNIQUE_CLASSES.get(obj_as_dict.get("technique"))
    if technique_class and issubclass(technique_class, cls):
        return technique_class(**obj_as_dict)
    return cls(**obj_as_dict)
```

Why this matters:

ASIMOV can now send a spectrum payload with `"technique": "NMR"` and ixdat can rebuild it as `NMRSpectrum`, not just `Spectrum`. That is important because the subclass carries technique-specific plotting behavior.

### ASIMOV is registered as a Spectrum reader

File: `src/ixdat/readers/__init__.py`

Minimal excerpt:

```python
SPECTRUM_READER_CLASSES = {
    ...
    "bruker": BrukerNMRReader,
    "asimov": AsimovReader,
}
```

Why this matters:

`Spectrum.read(..., reader="asimov")` looks in `SPECTRUM_READER_CLASSES`. Without this registration, the Measurement path could work while the Spectrum path could not even find the ASIMOV reader.

### ASIMOVReader uses the native project-file and bundle payload endpoints

File: `src/ixdat/readers/asimov.py`

Minimal excerpt:

```python
payload_envelope = self._get_ixdat_payload_envelope(
    asimov_id, headers=headers
)
```

```python
def _get_ixdat_payload_envelope(self, asimov_id, headers):
    try:
        return self._get_json(
            f"project-files/{asimov_id}/ixdat-payload", headers=headers
        )
    except RuntimeError as exc:
        if not self._is_http_status(exc, 404):
            raise

    try:
        return self._get_json(
            f"project-file-bundles/{asimov_id}/ixdat-payload", headers=headers
        )
    ...
```

Why this matters:

The old ASIMOV compatibility routes returned a legacy dataset-version envelope with synthetic `dataset_id` and `version` fields. The new native endpoints return the clean ixdat payload envelope for a project file or bundle. ixdat should read that native envelope directly.

### ASIMOV provenance now uses project-file and bundle fields

File: `src/ixdat/readers/asimov.py`

Minimal excerpt:

```python
meta = dict(payload.get("metadata") or {})
meta["asimov"] = {
    "project_file_id": payload_envelope.get("project_file_id"),
    "bundle_id": payload_envelope.get("bundle_id"),
    "filename": payload_envelope.get("filename"),
    "name": payload_envelope.get("name"),
    "parser_name": payload_envelope.get("parser_name"),
    "created_at": payload_envelope.get("created_at"),
    "ixdat_version": payload_envelope.get("ixdat_version"),
}
```

Why this matters:

Users still need provenance, but it should describe the current ASIMOV storage model. The metadata should not preserve legacy dataset-version concepts that are only present in compatibility shims.

### The reader catches wrong read entrypoints early

File: `src/ixdat/readers/asimov.py`

Minimal excerpt:

```python
object_type = d.get("object_type", "measurement")
self._check_requested_class_matches_object_type(
    requested_class=cls, object_type=object_type, asimov_id=asimov_id
)
```

```python
if object_type == "measurement":
    compatible = issubclass(requested_class, Measurement)
elif object_type == "spectrum":
    compatible = issubclass(requested_class, Spectrum) and not issubclass(
        requested_class, SpectrumSeries
    )
elif object_type == "spectrum_series":
    compatible = issubclass(requested_class, Spectrum)
```

Why this matters:

If the user calls `Spectrum.read(..., reader="asimov")` on a Measurement payload, the useful answer is "this is a Measurement payload; use `Measurement.read()`". Without this check, the user would get a confusing constructor error such as `unexpected keyword argument 'series_list'`.

### Container objects are built from `object_type`

File: `src/ixdat/readers/asimov.py`

Minimal excerpt:

```python
OBJECT_TYPE_CLASSES = {
    "measurement": Measurement,
    "spectrum": Spectrum,
    "spectrum_series": SpectrumSeries,
}
```

```python
def _build_object(self, dct, cls=None, **kwargs):
    object_type = dct.get("object_type", "measurement")
    if cls is None:
        cls = OBJECT_TYPE_CLASSES.get(object_type)
        ...
    if cls is Spectrum and object_type == "spectrum_series":
        cls = SpectrumSeries
    return cls.from_dict(self._build_kwargs(dct, object_class=cls, **kwargs))
```

Why this matters:

ASIMOVReader should not know about every technique. It only needs to know the core ixdat container family: Measurement, Spectrum, or SpectrumSeries. The technique-specific class is then selected by `from_dict()`.

### Nested ixdat objects are hydrated generically

File: `src/ixdat/readers/asimov.py`

Minimal excerpt:

```python
if key not in obj and isinstance(value, dict) and "object_type" in value:
    obj[key] = self._build_object(value, reader=self)
elif (
    key not in obj
    and isinstance(value, list)
    and any(isinstance(v, dict) and "object_type" in v for v in value)
):
    obj[key] = [
        self._build_object(v, reader=self)
        if isinstance(v, dict) and "object_type" in v
        else v
        for v in value
    ]
```

Payload shape:

```python
{
    "object_type": "measurement",
    "technique": "EC-Optical",
    "spectrum_series": {"object_type": "spectrum_series", ...},
    "reference_spectrum": {"object_type": "spectrum", ...},
}
```

Why this matters:

This avoids special-casing names like `reference_spectrum`. The rule is simple:
if a nested value is an ixdat object, ASIMOV marks it with `object_type`, and ixdat rebuilds it recursively.

### Nested ixdat objects must declare `object_type`

File: `src/ixdat/readers/asimov.py`

Minimal excerpt:

```python
elif (
    key not in obj
    and isinstance(value, dict)
    and "object_type" not in value
    and ("series_list" in value or "field" in value)
):
    raise ValueError(
        f"Asimov payload field {key!r} is missing 'object_type'. "
        "Nested ixdat objects must declare object_type so ixdat can "
        "reconstruct them without key-specific reader logic."
    )
```

Bad payload:

```python
"reference_spectrum": {
    "name": "reference",
    "technique": "spectrum",
    "field": {...},
}
```

Good payload:

```python
"reference_spectrum": {
    "object_type": "spectrum",
    "name": "reference",
    "technique": "spectrum",
    "field": {...},
}
```

Why this matters:

The reader should not guess object type from a key name or from array shape. That would make future payloads fragile. The payload itself should say what each nested ixdat object is.

### Technique-specific linker fields are preserved when ixdat declares them

File: `src/ixdat/readers/asimov.py`

Minimal excerpt:

```python
for key in self._get_serializable_attrs(dct, object_class):
    if key not in obj and key in dct:
        obj[key] = dct[key]
```

```python
serializable_attrs = set(object_class.get_all_column_attrs())
...
if technique_class and issubclass(technique_class, object_class):
    serializable_attrs.update(technique_class.get_all_column_attrs())
```

Why this matters:

Some technique classes can be built either from embedded child objects or saved object IDs. For EC-Optical data, `ref_id` and `spectrum_id` are meaningful ixdat constructor fields. The reader passes those through only when ixdat declares them, instead of passing arbitrary ASIMOV metadata into constructors.

### DataSeries construction uses ixdat's series registry

File: `src/ixdat/readers/asimov.py`

Minimal excerpt:

```python
kind = dct.get("series_type", "series")
series_cls = SERIES_CLASSES.get(kind)
...
return DataSeries.from_dict(series_dict)
```

```python
if "tseries_key" in dct and key_map:
    series_dict["tseries"] = key_map[dct["tseries_key"]]
if "axes_keys" in dct and key_map:
    series_dict["axes_series"] = [key_map[k] for k in dct["axes_keys"]]
```

Why this matters:

ASIMOVReader still resolves ASIMOV-specific references like `tseries_key` and `axes_keys`, but ixdat itself chooses the DataSeries subclass. This means a new registered ixdat series type does not require a new ASIMOVReader special case.

### ASIMOV-only series metadata is filtered out

File: `src/ixdat/readers/asimov.py`

Minimal excerpt:

```python
serializable_attrs = set(series_cls.get_all_column_attrs())
series_dict = {
    key: value for key, value in dct.items() if key in serializable_attrs
}
```

Payload shape:

```python
{
    "series_type": "tseries",
    "class": "TimeSeries",
    "name": "time/s",
    "unit_name": "s",
    "data": [0.0, 1.0],
    "tstamp": 1.0,
}
```

Why this matters:

Real ASIMOV series payloads can contain helper metadata such as `"class"`. Python constructors reject unknown keyword arguments, so the reader only passes fields that ixdat declares as constructor data.

## Development Helper

### `development_scripts/reader_demonstrators/inspect_asimov_payloads.py`

Added a small inspection script for looking at ASIMOV payload envelopes and payload structure without dumping full numerical arrays.

Minimal excerpt:

```python
def _get_payload(reader, asimov_id, force_login=False):
    headers = reader._build_auth_headers(force_login=force_login)
    envelope = reader._get_ixdat_payload_envelope(asimov_id, headers=headers)
    payload = envelope.get("payload_json")
    if not payload and envelope.get("payload_uri"):
        payload = reader._load_payload_uri(envelope["payload_uri"], headers=headers)
    return envelope, payload
```

Why this matters:

While developing this PR, ASIMOV payloads differed across techniques and changed as the ASIMOV-side migration progressed. The helper makes it easy to inspect payload shape without printing huge arrays.

## Tests

The tests were expanded to cover the behavior described above: native ASIMOV endpoints, Measurement/Spectrum mismatch errors, Spectrum and SpectrumSeries payloads, NMR subclass dispatch, nested ixdat objects, missing nested `object_type`, linker IDs such as `ref_id`, and ASIMOV-only series metadata.