### PR TITLE
Add relational schema generation and SQLite storage backend

### DIFF
--- a/NEXT_CHANGES.rst
+++ b/NEXT_CHANGES.rst
@@ -104,7 +104,9 @@ database
   primary key, and ordered many-to-many relationships (e.g. a measurement's data
   series) map to linker tables. Numerical data is stored in numpy-format blob
   columns which are only queried when the data is actually accessed, keeping
-  ixdat's laziness intact.
+  ixdat's laziness intact. A complete object graph is saved in one transaction,
+  frequently queried columns are indexed, and an internal schema version enables
+  validation and safe additive migration of existing database files.
 
 - ``Saveable.load(name)`` has been added as the by-name counterpart to
   ``Saveable.get(id)``: e.g. ``Measurement.load("my measurement")`` returns the

--- a/NEXT_CHANGES.rst
+++ b/NEXT_CHANGES.rst
@@ -99,14 +99,29 @@ database
   ``Saveable`` class already defines (``table_name``, ``column_attrs``,
   ``extra_column_attrs`` and ``extra_linkers``) by the new dialect-agnostic module
   ``ixdat.backends.relational``, realizing the "proper table definitions" goal of
-  `PR #75 <https://github.com/ixdat/ixdat/pull/75>`_ without new class-level
-  machinery. Class inheritance maps to extension tables joined on the main table's
+  `PR #75 <https://github.com/ixdat/ixdat/pull/75>`_. Class inheritance maps to
+  extension tables joined on the main table's
   primary key, and ordered many-to-many relationships (e.g. a measurement's data
   series) map to linker tables. Numerical data is stored in numpy-format blob
   columns which are only queried when the data is actually accessed, keeping
   ixdat's laziness intact. A complete object graph is saved in one transaction,
   frequently queried columns are indexed, and an internal schema version enables
   validation and safe additive migration of existing database files.
+
+- Two optional class attributes have been added to ``Saveable`` for the table
+  metadata a relational backend needs but the older backends never did:
+  ``column_types``, giving the type of a column's value ("INTEGER", "REAL",
+  "TEXT", "JSON" or "NDARRAY"), and ``column_references``, naming the columns
+  which hold the id of a row of another table (e.g.
+  ``{"field_id": "data_series"}``), which become foreign keys. Both are optional
+  - a column with no declared type holds whatever type its value already has, so
+  a plain str/int/float column needs no declaration. Unlike
+  ``extra_column_attrs``, both are *merged* over a class's ancestry (by
+  ``Saveable.get_column_types()`` and ``Saveable.get_column_references()``), so a
+  class only declares the columns it introduces itself and a multiply-inheriting
+  class gets the declarations of all of its parents. Because this information
+  lives on the classes, a ``Saveable`` class defined outside of ixdat can have
+  columns of any type without ixdat having to know about it.
 
 - ``Saveable.load(name)`` has been added as the by-name counterpart to
   ``Saveable.get(id)``: e.g. ``Measurement.load("my measurement")`` returns the

--- a/NEXT_CHANGES.rst
+++ b/NEXT_CHANGES.rst
@@ -88,3 +88,34 @@ tools
 - New ``to_jsonable`` function in ``ixdat.tools``: recursively converts numpy
   arrays, numpy scalars, and byte strings into JSON-safe Python primitives.
   `PR #200 <https://github.com/ixdat/ixdat/pull/200>`_
+
+database
+^^^^^^^^
+
+- The ``SQLiteBackend`` (``change_database("sqlite", db_path=...)``) has been added
+  for saving ixdat objects to, and loading them from, a relational database in a
+  single local SQLite file. It requires no new dependencies (python's built-in
+  ``sqlite3`` is used). The schema is derived from the table metadata which every
+  ``Saveable`` class already defines (``table_name``, ``column_attrs``,
+  ``extra_column_attrs`` and ``extra_linkers``) by the new dialect-agnostic module
+  ``ixdat.backends.relational``, realizing the "proper table definitions" goal of
+  `PR #75 <https://github.com/ixdat/ixdat/pull/75>`_ without new class-level
+  machinery. Class inheritance maps to extension tables joined on the main table's
+  primary key, and ordered many-to-many relationships (e.g. a measurement's data
+  series) map to linker tables. Numerical data is stored in numpy-format blob
+  columns which are only queried when the data is actually accessed, keeping
+  ixdat's laziness intact.
+
+- ``Saveable.load(name)`` has been added as the by-name counterpart to
+  ``Saveable.get(id)``: e.g. ``Measurement.load("my measurement")`` returns the
+  most recently saved measurement with that name. It is implemented for both the
+  directory backend and the new SQLite backend, and ``DataBase.load`` is now wired
+  through to the active backend.
+
+- Fixed several latent inconsistencies in the ``Saveable`` table metadata which
+  only matter to relational backends: linker-table references now use the actual
+  table names (``measurement``, ``calculator``, ``spectrums``),
+  ``MultiSpectrum.extra_linkers`` uses a tuple instead of a set, misspelled
+  auxiliary table names (``ec_meaurements``, ``ecms_meaurements``) are corrected,
+  ``Sample`` and ``LabLog`` define ``column_attrs`` as sets, and
+  ``MSConstantBackground`` now saves its ``name``.

--- a/NEXT_CHANGES.rst
+++ b/NEXT_CHANGES.rst
@@ -139,6 +139,15 @@ database
   ``field_ids`` property its ``extra_linkers`` refer to, and its ``xseries`` no
   longer crashes on a lazily loaded (placeholder) field.
 
+- ``Saveable.load_data`` now takes the ``backend`` to load from, rather than a
+  ``DataBase``, matching what it has actually needed since it started using the
+  backend an object came from (which is not necessarily the active one). The old
+  ``db`` keyword still works but is deprecated.
+
+- ``BackendBase.load`` is now implemented by the memory backend as well, so
+  ``Measurement.load("my measurement")`` works there instead of raising a bare
+  ``NotImplementedError``.
+
 - Fixed loading of ``MSCalibration`` and ``MSBackgroundSet``. Both saved without
   complaint but could not be loaded again on any backend: their serialization
   names the referenced objects by id (``ms_cal_result_ids`` and

--- a/NEXT_CHANGES.rst
+++ b/NEXT_CHANGES.rst
@@ -139,6 +139,17 @@ database
   ``field_ids`` property its ``extra_linkers`` refer to, and its ``xseries`` no
   longer crashes on a lazily loaded (placeholder) field.
 
+- Fixed loading of ``MSCalibration`` and ``MSBackgroundSet``. Both saved without
+  complaint but could not be loaded again on any backend: their serialization
+  names the referenced objects by id (``ms_cal_result_ids`` and
+  ``ms_constant_bg_ids``), which their ``__init__`` did not accept, so loading
+  raised a ``TypeError``. They now take those id's, just like ``Measurement``
+  takes ``s_ids``, and hold the referenced ``MSCalResult`` /
+  ``MSConstantBackground`` objects as placeholders until they are used, so a
+  calibration can be loaded without loading every sensitivity factor. Their id
+  properties also now use ``short_identity`` rather than ``id``, so a reference to
+  an object in another backend is no longer silently recorded as a bare id.
+
 - Fixed saving of ``ECOpticalMeasurement``, which raised an ``AttributeError`` on
   any backend: its ``extra_linkers`` refer to a ``ref_id``, but no such property
   existed, and its reference spectrum was missing from ``child_attrs``, so it was

--- a/NEXT_CHANGES.rst
+++ b/NEXT_CHANGES.rst
@@ -130,3 +130,17 @@ database
   loading, load-by-name, row sharing between composed measurements and their
   components, spectra, SQL analytics on the database file with pandas,
   in-place updates, and plotting straight from the database.
+
+- Known limitation: a ``Saveable`` class inheriting from more than one
+  table-defining class (e.g. ``ECMSMeasurement``, which inherits from both
+  ``ECMeasurement`` and ``MSMeasurement``) writes only to the one extension table
+  it declares itself (``ecms_measurements``), not to its other parents'
+  (``ec_measurements``), because ``extra_column_attrs`` is replaced rather than
+  merged across multiple inheritance. Round trips are unaffected, but a query
+  that joins a single ancestor's extension table expecting it to be exhaustive
+  will miss such rows; filter/group by ``measurement.technique`` or ``UNION``
+  across extension tables instead. This is a pre-existing property of
+  ``Saveable`` (it equally affects ``as_dict()`` on the directory backend) and
+  was the central open question of
+  `PR #75 <https://github.com/ixdat/ixdat/pull/75>`_; see the "Known
+  limitation" section of ``docs/source/diving_deeper/backend.rst`` for details.

--- a/NEXT_CHANGES.rst
+++ b/NEXT_CHANGES.rst
@@ -98,7 +98,8 @@ database
   table-definition work in
   `PR #75 <https://github.com/ixdat/ixdat/pull/75>`_. Saves are transactional,
   relationships use foreign keys, arrays remain lazy, and existing tables receive
-  safe additive migrations.
+  safe additive migrations. String-only object arrays from pandas are stored as
+  native NumPy Unicode arrays without enabling pickle.
 
 - ``Saveable`` gained optional ``column_types`` and ``column_references`` metadata.
   Classes declare Python value types, and relational backends map them to their

--- a/NEXT_CHANGES.rst
+++ b/NEXT_CHANGES.rst
@@ -139,6 +139,15 @@ database
   ``field_ids`` property its ``extra_linkers`` refer to, and its ``xseries`` no
   longer crashes on a lazily loaded (placeholder) field.
 
+- Fixed saving of ``ECOpticalMeasurement``, which raised an ``AttributeError`` on
+  any backend: its ``extra_linkers`` refer to a ``ref_id``, but no such property
+  existed, and its reference spectrum was missing from ``child_attrs``, so it was
+  not saved before the measurement which refers to it. It also no longer raises an
+  ``AttributeError`` from ``reference_spectrum`` when it was initiated without one
+  (which is normal - a reference spectrum can be chosen afterwards with
+  ``set_reference_spectrum``); ``reference_spectrum`` and ``ref_id`` are then
+  ``None``, and the measurement saves and loads without a reference.
+
 - A comprehensive demo of the SQLite backend has been added as
   ``development_scripts/demo_sqlite_backend.py``. It runs on data files shipped
   in the repository and shows saving, schema generation with foreign keys, lazy

--- a/NEXT_CHANGES.rst
+++ b/NEXT_CHANGES.rst
@@ -92,99 +92,25 @@ tools
 database
 ^^^^^^^^
 
-- The ``SQLiteBackend`` (``change_database("sqlite", db_path=...)``) has been added
-  for saving ixdat objects to, and loading them from, a relational database in a
-  single local SQLite file. It requires no new dependencies (python's built-in
-  ``sqlite3`` is used). The schema is derived from the table metadata which every
-  ``Saveable`` class already defines (``table_name``, ``column_attrs``,
-  ``extra_column_attrs`` and ``extra_linkers``) by the new dialect-agnostic module
-  ``ixdat.backends.relational``, realizing the "proper table definitions" goal of
-  `PR #75 <https://github.com/ixdat/ixdat/pull/75>`_. Class inheritance maps to
-  extension tables joined on the main table's
-  primary key, and ordered many-to-many relationships (e.g. a measurement's data
-  series) map to linker tables. Numerical data is stored in numpy-format blob
-  columns which are only queried when the data is actually accessed, keeping
-  ixdat's laziness intact. A complete object graph is saved in one transaction,
-  frequently queried columns are indexed, and an internal schema version enables
-  validation and safe additive migration of existing database files.
+- ``SQLiteBackend`` stores ixdat objects in one local SQLite file using Python's
+  built-in ``sqlite3`` module. The schema is derived from ``Saveable`` metadata by
+  the database-independent ``ixdat.backends.relational`` module, continuing the
+  table-definition work in
+  `PR #75 <https://github.com/ixdat/ixdat/pull/75>`_. Saves are transactional,
+  relationships use foreign keys, arrays remain lazy, and existing tables receive
+  safe additive migrations.
 
-- Two optional class attributes have been added to ``Saveable`` for the table
-  metadata a relational backend needs but the older backends never did:
-  ``column_types``, giving the type of a column's value ("INTEGER", "REAL",
-  "TEXT", "JSON" or "NDARRAY"), and ``column_references``, naming the columns
-  which hold the id of a row of another table (e.g.
-  ``{"field_id": "data_series"}``), which become foreign keys. Both are optional
-  - a column with no declared type holds whatever type its value already has, so
-  a plain str/int/float column needs no declaration. Unlike
-  ``extra_column_attrs``, both are *merged* over a class's ancestry (by
-  ``Saveable.get_column_types()`` and ``Saveable.get_column_references()``), so a
-  class only declares the columns it introduces itself and a multiply-inheriting
-  class gets the declarations of all of its parents. Because this information
-  lives on the classes, a ``Saveable`` class defined outside of ixdat can have
-  columns of any type without ixdat having to know about it.
+- ``Saveable`` gained optional ``column_types`` and ``column_references`` metadata.
+  Classes declare Python value types, and relational backends map them to their
+  storage types. Extension columns, linkers, types, and references merge over class
+  ancestry, so multiply-inheriting classes retain each parent's tables without
+  repeating columns.
 
-- ``Saveable.load(name)`` has been added as the by-name counterpart to
-  ``Saveable.get(id)``: e.g. ``Measurement.load("my measurement")`` returns the
-  most recently saved measurement with that name. It is implemented for both the
-  directory backend and the new SQLite backend, and ``DataBase.load`` is now wired
-  through to the active backend.
+- ``Saveable.load(name)`` now returns the newest exact name match on the memory,
+  directory, and SQLite backends. Explicit-backend loads preserve the active
+  database and keep lazy children and arrays connected to their source backend.
 
-- Fixed several latent inconsistencies in the ``Saveable`` table metadata which
-  only matter to relational backends: linker-table references now use the actual
-  table names (``measurement``, ``calculator``, ``spectrums``),
-  ``MultiSpectrum.extra_linkers`` uses a tuple instead of a set, misspelled
-  auxiliary table names (``ec_meaurements``, ``ecms_meaurements``) are corrected,
-  ``Sample`` and ``LabLog`` define ``column_attrs`` as sets, and
-  ``MSConstantBackground`` now saves its ``name``. ``MultiSpectrum`` gained the
-  ``field_ids`` property its ``extra_linkers`` refer to, and its ``xseries`` no
-  longer crashes on a lazily loaded (placeholder) field.
-
-- ``Saveable.load_data`` now takes the ``backend`` to load from, rather than a
-  ``DataBase``, matching what it has actually needed since it started using the
-  backend an object came from (which is not necessarily the active one). The old
-  ``db`` keyword still works but is deprecated.
-
-- ``BackendBase.load`` is now implemented by the memory backend as well, so
-  ``Measurement.load("my measurement")`` works there instead of raising a bare
-  ``NotImplementedError``.
-
-- Fixed loading of ``MSCalibration`` and ``MSBackgroundSet``. Both saved without
-  complaint but could not be loaded again on any backend: their serialization
-  names the referenced objects by id (``ms_cal_result_ids`` and
-  ``ms_constant_bg_ids``), which their ``__init__`` did not accept, so loading
-  raised a ``TypeError``. They now take those id's, just like ``Measurement``
-  takes ``s_ids``, and hold the referenced ``MSCalResult`` /
-  ``MSConstantBackground`` objects as placeholders until they are used, so a
-  calibration can be loaded without loading every sensitivity factor. Their id
-  properties also now use ``short_identity`` rather than ``id``, so a reference to
-  an object in another backend is no longer silently recorded as a bare id.
-
-- Fixed saving of ``ECOpticalMeasurement``, which raised an ``AttributeError`` on
-  any backend: its ``extra_linkers`` refer to a ``ref_id``, but no such property
-  existed, and its reference spectrum was missing from ``child_attrs``, so it was
-  not saved before the measurement which refers to it. It also no longer raises an
-  ``AttributeError`` from ``reference_spectrum`` when it was initiated without one
-  (which is normal - a reference spectrum can be chosen afterwards with
-  ``set_reference_spectrum``); ``reference_spectrum`` and ``ref_id`` are then
-  ``None``, and the measurement saves and loads without a reference.
-
-- A comprehensive demo of the SQLite backend has been added as
-  ``development_scripts/demo_sqlite_backend.py``. It runs on data files shipped
-  in the repository and shows saving, schema generation with foreign keys, lazy
-  loading, load-by-name, row sharing between composed measurements and their
-  components, spectra, SQL analytics on the database file with pandas,
-  in-place updates, and plotting straight from the database.
-
-- Known limitation: a ``Saveable`` class inheriting from more than one
-  table-defining class (e.g. ``ECMSMeasurement``, which inherits from both
-  ``ECMeasurement`` and ``MSMeasurement``) writes only to the one extension table
-  it declares itself (``ecms_measurements``), not to its other parents'
-  (``ec_measurements``), because ``extra_column_attrs`` is replaced rather than
-  merged across multiple inheritance. Round trips are unaffected, but a query
-  that joins a single ancestor's extension table expecting it to be exhaustive
-  will miss such rows; filter/group by ``measurement.technique`` or ``UNION``
-  across extension tables instead. This is a pre-existing property of
-  ``Saveable`` (it equally affects ``as_dict()`` on the directory backend) and
-  was the central open question of
-  `PR #75 <https://github.com/ixdat/ixdat/pull/75>`_; see the "Known
-  limitation" section of ``docs/source/diving_deeper/backend.rst`` for details.
+- Persistence fixes cover existing table metadata, lazy ``MultiSpectrum`` fields,
+  ``MSCalibration``, ``MSBackgroundSet``, and ``ECOpticalMeasurement`` references.
+  ``development_scripts/demo_sqlite_backend.py`` demonstrates the complete backend
+  workflow on repository test data.

--- a/NEXT_CHANGES.rst
+++ b/NEXT_CHANGES.rst
@@ -118,4 +118,13 @@ database
   ``MultiSpectrum.extra_linkers`` uses a tuple instead of a set, misspelled
   auxiliary table names (``ec_meaurements``, ``ecms_meaurements``) are corrected,
   ``Sample`` and ``LabLog`` define ``column_attrs`` as sets, and
-  ``MSConstantBackground`` now saves its ``name``.
+  ``MSConstantBackground`` now saves its ``name``. ``MultiSpectrum`` gained the
+  ``field_ids`` property its ``extra_linkers`` refer to, and its ``xseries`` no
+  longer crashes on a lazily loaded (placeholder) field.
+
+- A comprehensive demo of the SQLite backend has been added as
+  ``development_scripts/demo_sqlite_backend.py``. It runs on data files shipped
+  in the repository and shows saving, schema generation with foreign keys, lazy
+  loading, load-by-name, row sharing between composed measurements and their
+  components, spectra, SQL analytics on the database file with pandas,
+  in-place updates, and plotting straight from the database.

--- a/development_scripts/demo_sqlite_backend.py
+++ b/development_scripts/demo_sqlite_backend.py
@@ -230,8 +230,8 @@ print(
 print(f"  spectrum array before access: {lazy_optical_field._data}")
 print(f"  spectrum array after access:  shape={loaded_optical.spectra.data.shape}")
 
-# These are the table names that hold the pointers described above. They keep
-# relationships out of the main rows and allow lists to keep their order.
+# These tables hold the connections described above. The list relationships store a
+# position for each item. The single reference stores one spectrum id.
 print(
     "  relational paths: multispectrum_fields for XRD fields, field_axes for "
     "spectral axes, and ec_optical_measurements for the reference"

--- a/development_scripts/demo_sqlite_backend.py
+++ b/development_scripts/demo_sqlite_backend.py
@@ -170,6 +170,11 @@ part("8. The database speaks SQL: instant analytics over everything saved")
 # --------------------------------------------------------------------------- #
 
 print("All measurements, joined with their EC details and series counts:\n")
+# NOTE: this join only finds pure ECMeasurement rows, like the ones saved above.
+# An ECMSMeasurement writes its ec_technique to "ecms_measurements" instead of
+# "ec_measurements" - see the "Known limitation" section of
+# docs/source/diving_deeper/backend.rst - so a query meant to cover every EC-ish
+# measurement should filter on measurement.technique or UNION both tables.
 print(
     pd.read_sql_query(
         """

--- a/development_scripts/demo_sqlite_backend.py
+++ b/development_scripts/demo_sqlite_backend.py
@@ -237,3 +237,6 @@ print(f"\nDone. The database file is yours to explore: {DB_FILE}")
 
 if not plt.isinteractive():
     plt.show()
+
+con.close()
+DB.backend.close()

--- a/development_scripts/demo_sqlite_backend.py
+++ b/development_scripts/demo_sqlite_backend.py
@@ -1,24 +1,7 @@
-# -*- coding: utf-8 -*-
 """A tour of ixdat's SQLite database backend.
 
-This demo saves real measurements to a relational database in a single local
-file and shows off everything you gain by doing so:
-
-1.  saving is one line, and the whole schema is created for you
-2.  everything lives in one portable file with referential integrity
-3.  loading is lazy - metadata first, numerical data only on demand
-4.  objects come back by name or id, as the class they were saved as,
-    with their calculators (e.g. calibrations) intact
-5.  measurements built from other measurements reuse their existing data rows
-6.  every ixdat data family works: measurements, spectra, calculators, ...
-7.  the database speaks SQL: query it with pandas or any SQLite tool
-8.  rows can be updated in place
-9.  the full relational schema of ixdat's data model is generated from the
-    classes themselves (what PR #75 drew by hand: https://dbdiagram.io/d/601b...)
-
-It only uses data files shipped in the ixdat repository, so it runs anywhere:
-
-    python demo_sqlite_backend.py
+This demo saves measurements and spectra to a relational database in a single
+local file and walks through the main persistence features:
 """
 
 import shutil
@@ -27,36 +10,36 @@ import tempfile
 import time
 from pathlib import Path
 
+import numpy as np
 import pandas as pd
 from matplotlib import pyplot as plt
 
 from ixdat import Measurement, Spectrum
+from ixdat.data_series import DataSeries, Field, TimeSeries
 from ixdat.db import DB, change_database
+from ixdat.spectra import SpectrumSeries
+from ixdat.techniques.spectroelectrochemistry import ECOpticalMeasurement
 
 plt.close("all")
 
 TEST_DATA_DIR = Path(__file__).absolute().parent.parent / "test_data"
 
 DEMO_DIR = Path(tempfile.gettempdir()) / "ixdat_sqlite_demo"
-shutil.rmtree(DEMO_DIR, ignore_errors=True)  # start fresh on every run
+# Start with an empty folder so every run produces the same ids and row counts.
+shutil.rmtree(DEMO_DIR, ignore_errors=True)
 DB_FILE = DEMO_DIR / "demo_project.sqlite"
 
 
 def part(title):
-    print("\n" + "=" * 75 + f"\n{title}\n" + "=" * 75)
+    print("\n" + "=" * 75 + f"\n{title}\n" + "=" * 75 + "\n")
 
 
-# --------------------------------------------------------------------------- #
 part("1. One line to point ixdat at a database file")
-# --------------------------------------------------------------------------- #
 
 change_database("sqlite", db_path=DB_FILE)
 print(f"Active backend: {DB.backend}")
-print("(No new dependencies - this is python's built-in sqlite3.)")
 
-# --------------------------------------------------------------------------- #
 part("2. Saving a measurement (and its calibration) is one line each")
-# --------------------------------------------------------------------------- #
 
 ec = Measurement.read(TEST_DATA_DIR / "biologic/Pt_poly_cv_CUT.mpt", reader="biologic")
 ec.calibrate(RE_vs_RHE=0.72, A_el=0.196)  # a Calculator, saved along with it
@@ -64,18 +47,17 @@ ec.calibrate(RE_vs_RHE=0.72, A_el=0.196)  # a Calculator, saved along with it
 tic = time.perf_counter()
 ec_id = ec.save()
 toc = time.perf_counter()
-print(f"Saved {ec!r} with all its data series in {(toc - tic) * 1000:.1f} ms")
+print(
+    f"Saved {ec!r} in {DB_FILE} with all its data series in {(toc - tic) * 1000:.1f} ms"
+)
+print(f"  ({DB_FILE.stat().st_size / 1024:.0f} kB)")
 
-# --------------------------------------------------------------------------- #
-part("3. What that created: a real relational database in a single file")
-# --------------------------------------------------------------------------- #
-
-print(f"Everything is in the one file {DB_FILE}")
-print(f"  ({DB_FILE.stat().st_size / 1024:.0f} kB - open it with any SQLite tool,")
-print("   e.g. DB Browser for SQLite, DBeaver, datasette, or the sqlite3 CLI)\n")
-
-# The tables were created on demand, derived from the ixdat classes involved:
-con = sqlite3.connect(DB_FILE)  # a plain SQL connection, to peek behind the scenes
+# A database table is much like one sheet in a spreadsheet. Each row holds one
+# saved item. ixdat reads the class definitions and makes the needed sheets when
+# an item is first saved. The table plan stays beside the Python code.
+#
+# sqlite3 is Python's built-in way to look directly inside the database file.
+con = sqlite3.connect(DB_FILE)
 tables = [
     row[0]
     for row in con.execute(
@@ -86,6 +68,9 @@ for table in tables:
     count = con.execute(f'SELECT COUNT(*) FROM "{table}"').fetchone()[0]
     print(f"  table {table:.<28} {count:>3} rows")
 
+# A foreign key is an id that points to a row in another table. For example, a
+# measurement stores the ids of its data series. SQLite checks these pointers,
+# which prevents a measurement from pointing to a row that does not exist.
 print("\nWith honest-to-goodness foreign keys, e.g.:\n")
 print(
     con.execute(
@@ -95,10 +80,26 @@ print(
 violations = con.execute("PRAGMA foreign_key_check").fetchall()
 print(f"\nForeign key violations in the database: {violations or 'none'}")
 
-# --------------------------------------------------------------------------- #
-part("4. Loading is lazy: metadata now, numbers only when you need them")
-# --------------------------------------------------------------------------- #
+# The schema version says which table layout the file uses. ixdat checks it
+# before reading the file. An index is a small lookup guide that helps SQLite
+# find common values, such as a name or technique, without scanning every row.
+schema_version = con.execute(
+    'SELECT value FROM "_ixdat_metadata" WHERE key = ?', ("schema_version",)
+).fetchone()[0]
+lookup_indexes = con.execute(
+    """
+    SELECT COUNT(*) FROM sqlite_master
+    WHERE type = 'index' AND name LIKE 'ixdat_%'
+    """
+).fetchone()[0]
+print(
+    f"Storage schema version: {schema_version}; lookup indexes created: {lookup_indexes}"
+)
 
+part("3. Loading is lazy: metadata now, numbers only when you need them")
+
+# Names and other small details are cheap to load. Numerical arrays can be much
+# larger, so ixdat leaves them in the database until code asks for `.data`.
 tic = time.perf_counter()
 loaded_ec = Measurement.get(ec_id)
 toc = time.perf_counter()
@@ -115,10 +116,10 @@ print(
     f"in {(toc - tic) * 1000:.2f} ms"
 )
 
-# --------------------------------------------------------------------------- #
-part("5. Objects come back by name, as what they were, calibration included")
-# --------------------------------------------------------------------------- #
+part("4. Objects come back by name, as what they were, calibration included")
 
+# The saved technique tells ixdat which kind of Measurement to rebuild. Links
+# stored in the database also reconnect the measurement to its calibration.
 by_name = Measurement.load("Pt_poly_cv_CUT.mpt")
 print(f"Measurement.load('Pt_poly_cv_CUT.mpt') -> {by_name!r}")
 print(f"  concrete class: {type(by_name).__name__}")
@@ -132,14 +133,15 @@ print(
     "  <- the RE_vs_RHE=0.72 calibration survived the round trip"
 )
 
-# --------------------------------------------------------------------------- #
-part("6. Composed measurements reuse their component data rows")
-# --------------------------------------------------------------------------- #
+part("5. Composed measurements reuse their component data rows")
 
 composed = ec.select(cycle=1) + ec.select(cycle=3)
 composed_id = composed.save()
 print(f"Saved composed measurement (id={composed_id}) built from two cycles.\n")
 
+# The measurement_series table is a list of pointers from measurements to data
+# series. Several measurements can point to the same series row. Large arrays
+# are then stored once even when they are used in several places.
 n_references, n_series = con.execute(
     "SELECT COUNT(*), COUNT(DISTINCT data_series_id) FROM measurement_series"
 ).fetchone()
@@ -151,24 +153,117 @@ print("  the composed measurement and its components *share* rows.")
 reloaded_composed = Measurement.get(composed_id)
 print(f"\nRound trip of the composed measurement: {reloaded_composed == composed}")
 
-# --------------------------------------------------------------------------- #
-part("7. Spectra and other ixdat data families use the same backend")
-# --------------------------------------------------------------------------- #
+part("6. Spectra and other ixdat data families use the same backend")
 
+# A MultiSpectrum groups several spectral fields that share one x-axis. The
+# database keeps pointers to those fields in the same order as the Python list.
 xrd = Spectrum.read(TEST_DATA_DIR / "xrd/twotheta_2th.xy", reader="xrdxy")
 xrd_id = xrd.save()
 loaded_xrd = type(xrd).get(xrd_id)
-print(f"Saved and reloaded {loaded_xrd!r}")
-print(f"  class: {type(loaded_xrd).__name__}, equal: {loaded_xrd == xrd}")
 print(
-    "  (spectra live in their own tables: multispectrum, data_series, "
-    "field_axes, ...)"
+    f"XRD: {type(loaded_xrd).__name__}, {len(loaded_xrd.fields)} field(s), "
+    f"equal after reload: {loaded_xrd == xrd}"
 )
 
-# --------------------------------------------------------------------------- #
-part("8. The database speaks SQL: instant analytics over everything saved")
-# --------------------------------------------------------------------------- #
+# A SpectrumSeries is a grid of numbers. One axis is time and the other is
+# wavelength. The Field holds the grid and pointers to those two axes.
+wavelength = DataSeries(
+    name="wavelength / nm",
+    unit_name="nm",
+    data=np.linspace(400, 700, 4),
+)
+optical_time = TimeSeries(
+    name="optical time / s",
+    unit_name="s",
+    data=np.array([0.0, 1.0, 2.0]),
+    tstamp=1.6e9,
+)
+optical_series = SpectrumSeries(
+    name="time-resolved optical spectra",
+    technique="EC-Optical",
+    tstamp=optical_time.tstamp,
+    field=Field(
+        name="intensity",
+        unit_name="counts",
+        data=np.array(
+            [
+                [1.0, 2.0, 3.0, 4.0],
+                [2.0, 3.0, 4.0, 5.0],
+                [3.0, 4.0, 5.0, 6.0],
+            ]
+        ),
+        axes_series=[optical_time, wavelength],
+    ),
+)
+reference = Spectrum(
+    name="optical reference",
+    technique="optical",
+    tstamp=optical_time.tstamp,
+    field=Field(
+        name="reference intensity",
+        unit_name="counts",
+        data=np.ones(4),
+        axes_series=[wavelength],
+    ),
+)
 
+# This measurement owns the changing SpectrumSeries above and points to one
+# separate Spectrum used as its reference. The database saves the whole group
+# and remembers how its pieces connect.
+optical = ECOpticalMeasurement(
+    name="synthetic EC-Optical measurement",
+    technique="EC-Optical",
+    ec_technique="synthetic potential sweep",
+    tstamp=optical_time.tstamp,
+    series_list=[optical_time],
+    spectrum_series=optical_series,
+    reference_spectrum=reference,
+)
+optical_id = optical.save()
+loaded_optical = Measurement.get(optical_id)
+lazy_optical_field = loaded_optical.spectrum_series.field
+print(
+    f"EC-Optical: {type(loaded_optical).__name__}, "
+    f"linked {type(loaded_optical.spectrum_series).__name__} and "
+    f"{type(loaded_optical.reference_spectrum).__name__}"
+)
+print(f"  spectrum array before access: {lazy_optical_field._data}")
+print(f"  spectrum array after access:  shape={loaded_optical.spectra.data.shape}")
+
+# These are the table names that hold the pointers described above. They keep
+# relationships out of the main rows and allow lists to keep their order.
+print(
+    "  relational paths: multispectrum_fields for XRD fields, field_axes for "
+    "spectral axes, and ec_optical_measurements for the reference"
+)
+
+part("7. A complete object graph is one transaction")
+
+# A transaction makes a save all-or-nothing. This example has metadata that
+# cannot be saved as JSON. SQLite removes the child series it had started to
+# save, so no loose or half-saved rows remain.
+rows_before = con.execute('SELECT COUNT(*) FROM "data_series"').fetchone()[0]
+invalid = Measurement(
+    name="this graph will roll back",
+    technique="simple",
+    metadata={"not JSON": object()},
+    series_list=[DataSeries(name="unsaved child", unit_name="V", data=np.array([1.0]))],
+)
+try:
+    invalid.save()
+except TypeError:
+    pass
+rows_after = con.execute('SELECT COUNT(*) FROM "data_series"').fetchone()[0]
+print(
+    "An invalid parent rolled back itself and its child: "
+    f"data-series rows stayed at {rows_before} ({rows_after == rows_before})."
+)
+
+part("8. The database speaks SQL: instant analytics over everything saved")
+
+# JOIN lines up rows from different tables using their ids. LEFT JOIN keeps a
+# measurement in the result even when it has no matching EC detail or series.
+# GROUP BY gathers all series links for one measurement so COUNT can total them.
 print("All measurements, joined with their EC details and series counts:\n")
 print(
     pd.read_sql_query(
@@ -197,10 +292,9 @@ print(
 )
 print("\n(Anything - pandas, R, LibreOffice, grafana - can query this file.)")
 
-# --------------------------------------------------------------------------- #
 part("9. Rows can be updated in place")
-# --------------------------------------------------------------------------- #
 
+# `force=True` writes the changed values back to the existing row with this id.
 loaded_ec.name = "Pt_poly_cv_CUT.mpt (analyzed 2026-07-02)"
 DB.backend.save(loaded_ec, force=True)
 print(f"Renamed and updated row id={loaded_ec.id}. The database now says:")
@@ -209,10 +303,11 @@ updated_name = con.execute(
 ).fetchone()[0]
 print(f"  {updated_name}")
 
-# --------------------------------------------------------------------------- #
 part("10. The whole schema of ixdat's data model, generated from the classes")
-# --------------------------------------------------------------------------- #
 
+# A schema is the database's blueprint: its tables, columns, and links. ixdat
+# builds this blueprint from the save information already written on its Python
+# classes. A plugin class can describe its own saved values in the same way.
 report = DB.backend.schema_report()
 schema_file = DEMO_DIR / "ixdat_schema.sql"
 schema_file.write_text(report)
@@ -220,24 +315,45 @@ n_tables = report.count("CREATE TABLE")
 print(f"schema_report() derived {n_tables} tables from the imported ixdat classes")
 print(f"  (full DDL written to {schema_file})")
 print("\nA taste - inheritance becomes extension tables joined on id:\n")
+
+# In Python, a TimeSeries is a DataSeries with an extra timestamp. SQL stores
+# the shared DataSeries values in one table and the timestamp in a small extra
+# table. Both rows use the same id, so SQLite knows they describe one object.
+# EC-MS measurements follow the same pattern for their extra values.
 for statement in report.split(";"):
     if '"ecms_measurements"' in statement or '"tstamps"' in statement:
         print(statement.strip() + ";\n")
 
-# --------------------------------------------------------------------------- #
-part("Finally: plots, straight from the database")
-# --------------------------------------------------------------------------- #
+part("11. Close and reopen the complete project")
 
-axes = Measurement.load("Pt_poly_cv_CUT.mpt (analyzed 2026-07-02)").plot_measurement()
+# Closing ends the current connection to the file. The saved rows stay on disk.
+# Loading from the same file rebuilds each requested object and its links.
+con.close()
+DB.backend.close()
+change_database("sqlite", db_path=DB_FILE)
+
+reopened_ec = Measurement.load("Pt_poly_cv_CUT.mpt (analyzed 2026-07-02)")
+reopened_xrd = type(xrd).get(xrd_id)
+reopened_optical = Measurement.get(optical_id)
+print(
+    f"Reopened {type(reopened_ec).__name__}, {type(reopened_xrd).__name__}, "
+    f"and {type(reopened_optical).__name__} from {DB_FILE.name}"
+)
+
+part("Finally: plots, straight from the reopened database")
+
+axes = reopened_ec.plot_measurement()
 axes[0].set_title("EC measurement reloaded from SQLite")
 
-ax = type(xrd).get(xrd_id).plot()
+ax = reopened_xrd.plot()
 ax.set_title("XRD spectrum reloaded from SQLite")
+
+ax = reopened_optical.spectrum_series.heat_plot()
+ax.set_title("SpectrumSeries reloaded through an EC-Optical measurement")
 
 print(f"\nDone. The database file is yours to explore: {DB_FILE}")
 
 if not plt.isinteractive():
     plt.show()
 
-con.close()
 DB.backend.close()

--- a/development_scripts/demo_sqlite_backend.py
+++ b/development_scripts/demo_sqlite_backend.py
@@ -9,7 +9,7 @@ file and shows off everything you gain by doing so:
 3.  loading is lazy - metadata first, numerical data only on demand
 4.  objects come back by name or id, as the class they were saved as,
     with their calculators (e.g. calibrations) intact
-5.  measurements built from other measurements share rows - no data duplication
+5.  measurements built from other measurements reuse their existing data rows
 6.  every ixdat data family works: measurements, spectra, calculators, ...
 7.  the database speaks SQL: query it with pandas or any SQLite tool
 8.  rows can be updated in place
@@ -121,7 +121,7 @@ part("5. Objects come back by name, as what they were, calibration included")
 
 by_name = Measurement.load("Pt_poly_cv_CUT.mpt")
 print(f"Measurement.load('Pt_poly_cv_CUT.mpt') -> {by_name!r}")
-print(f"  class: {type(by_name).__name__} (not just a generic Measurement)")
+print(f"  concrete class: {type(by_name).__name__}")
 print(f"  calculators: {by_name.calculator_list}")
 print(f"  equal to what was saved:  by_name == ec  is  {by_name == ec}")
 
@@ -133,7 +133,7 @@ print(
 )
 
 # --------------------------------------------------------------------------- #
-part("6. Composed measurements share rows - data is never duplicated")
+part("6. Composed measurements reuse their component data rows")
 # --------------------------------------------------------------------------- #
 
 composed = ec.select(cycle=1) + ec.select(cycle=3)
@@ -144,17 +144,15 @@ n_references, n_series = con.execute(
     "SELECT COUNT(*), COUNT(DISTINCT data_series_id) FROM measurement_series"
 ).fetchone()
 n_measurements = con.execute("SELECT COUNT(*) FROM measurement").fetchone()[0]
-print(f"  {n_measurements} measurements now reference series "
-      f"{n_references} times ...")
+print(f"  {n_measurements} measurements now reference series {n_references} times ...")
 print(f"  ... but only {n_series} distinct data series (arrays) are stored:")
 print("  the composed measurement and its components *share* rows.")
 
 reloaded_composed = Measurement.get(composed_id)
-print(f"\nRound trip of the composed measurement: "
-      f"{reloaded_composed == composed}")
+print(f"\nRound trip of the composed measurement: {reloaded_composed == composed}")
 
 # --------------------------------------------------------------------------- #
-part("7. Not just measurements: every ixdat data family gets its tables")
+part("7. Spectra and other ixdat data families use the same backend")
 # --------------------------------------------------------------------------- #
 
 xrd = Spectrum.read(TEST_DATA_DIR / "xrd/twotheta_2th.xy", reader="xrdxy")
@@ -162,19 +160,16 @@ xrd_id = xrd.save()
 loaded_xrd = type(xrd).get(xrd_id)
 print(f"Saved and reloaded {loaded_xrd!r}")
 print(f"  class: {type(loaded_xrd).__name__}, equal: {loaded_xrd == xrd}")
-print("  (spectra live in their own tables: multispectrum, data_series, "
-      "field_axes, ...)")
+print(
+    "  (spectra live in their own tables: multispectrum, data_series, "
+    "field_axes, ...)"
+)
 
 # --------------------------------------------------------------------------- #
 part("8. The database speaks SQL: instant analytics over everything saved")
 # --------------------------------------------------------------------------- #
 
 print("All measurements, joined with their EC details and series counts:\n")
-# NOTE: this join only finds pure ECMeasurement rows, like the ones saved above.
-# An ECMSMeasurement writes its ec_technique to "ecms_measurements" instead of
-# "ec_measurements" - see the "Known limitation" section of
-# docs/source/diving_deeper/backend.rst - so a query meant to cover every EC-ish
-# measurement should filter on measurement.technique or UNION both tables.
 print(
     pd.read_sql_query(
         """
@@ -209,9 +204,10 @@ part("9. Rows can be updated in place")
 loaded_ec.name = "Pt_poly_cv_CUT.mpt (analyzed 2026-07-02)"
 DB.backend.save(loaded_ec, force=True)
 print(f"Renamed and updated row id={loaded_ec.id}. The database now says:")
-print("  " + str(con.execute(
+updated_name = con.execute(
     "SELECT name FROM measurement WHERE id = ?", (loaded_ec.id,)
-).fetchone()[0]))
+).fetchone()[0]
+print(f"  {updated_name}")
 
 # --------------------------------------------------------------------------- #
 part("10. The whole schema of ixdat's data model, generated from the classes")

--- a/development_scripts/demo_sqlite_backend.py
+++ b/development_scripts/demo_sqlite_backend.py
@@ -1,0 +1,239 @@
+# -*- coding: utf-8 -*-
+"""A tour of ixdat's SQLite database backend.
+
+This demo saves real measurements to a relational database in a single local
+file and shows off everything you gain by doing so:
+
+1.  saving is one line, and the whole schema is created for you
+2.  everything lives in one portable file with referential integrity
+3.  loading is lazy - metadata first, numerical data only on demand
+4.  objects come back by name or id, as the class they were saved as,
+    with their calculators (e.g. calibrations) intact
+5.  measurements built from other measurements share rows - no data duplication
+6.  every ixdat data family works: measurements, spectra, calculators, ...
+7.  the database speaks SQL: query it with pandas or any SQLite tool
+8.  rows can be updated in place
+9.  the full relational schema of ixdat's data model is generated from the
+    classes themselves (what PR #75 drew by hand: https://dbdiagram.io/d/601b...)
+
+It only uses data files shipped in the ixdat repository, so it runs anywhere:
+
+    python demo_sqlite_backend.py
+"""
+
+import shutil
+import sqlite3
+import tempfile
+import time
+from pathlib import Path
+
+import pandas as pd
+from matplotlib import pyplot as plt
+
+from ixdat import Measurement, Spectrum
+from ixdat.db import DB, change_database
+
+plt.close("all")
+
+TEST_DATA_DIR = Path(__file__).absolute().parent.parent / "test_data"
+
+DEMO_DIR = Path(tempfile.gettempdir()) / "ixdat_sqlite_demo"
+shutil.rmtree(DEMO_DIR, ignore_errors=True)  # start fresh on every run
+DB_FILE = DEMO_DIR / "demo_project.sqlite"
+
+
+def part(title):
+    print("\n" + "=" * 75 + f"\n{title}\n" + "=" * 75)
+
+
+# --------------------------------------------------------------------------- #
+part("1. One line to point ixdat at a database file")
+# --------------------------------------------------------------------------- #
+
+change_database("sqlite", db_path=DB_FILE)
+print(f"Active backend: {DB.backend}")
+print("(No new dependencies - this is python's built-in sqlite3.)")
+
+# --------------------------------------------------------------------------- #
+part("2. Saving a measurement (and its calibration) is one line each")
+# --------------------------------------------------------------------------- #
+
+ec = Measurement.read(TEST_DATA_DIR / "biologic/Pt_poly_cv_CUT.mpt", reader="biologic")
+ec.calibrate(RE_vs_RHE=0.72, A_el=0.196)  # a Calculator, saved along with it
+
+tic = time.perf_counter()
+ec_id = ec.save()
+toc = time.perf_counter()
+print(f"Saved {ec!r} with all its data series in {(toc - tic) * 1000:.1f} ms")
+
+# --------------------------------------------------------------------------- #
+part("3. What that created: a real relational database in a single file")
+# --------------------------------------------------------------------------- #
+
+print(f"Everything is in the one file {DB_FILE}")
+print(f"  ({DB_FILE.stat().st_size / 1024:.0f} kB - open it with any SQLite tool,")
+print("   e.g. DB Browser for SQLite, DBeaver, datasette, or the sqlite3 CLI)\n")
+
+# The tables were created on demand, derived from the ixdat classes involved:
+con = sqlite3.connect(DB_FILE)  # a plain SQL connection, to peek behind the scenes
+tables = [
+    row[0]
+    for row in con.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' ORDER BY name"
+    )
+]
+for table in tables:
+    count = con.execute(f'SELECT COUNT(*) FROM "{table}"').fetchone()[0]
+    print(f"  table {table:.<28} {count:>3} rows")
+
+print("\nWith honest-to-goodness foreign keys, e.g.:\n")
+print(
+    con.execute(
+        "SELECT sql FROM sqlite_master WHERE name='measurement_series'"
+    ).fetchone()[0]
+)
+violations = con.execute("PRAGMA foreign_key_check").fetchall()
+print(f"\nForeign key violations in the database: {violations or 'none'}")
+
+# --------------------------------------------------------------------------- #
+part("4. Loading is lazy: metadata now, numbers only when you need them")
+# --------------------------------------------------------------------------- #
+
+tic = time.perf_counter()
+loaded_ec = Measurement.get(ec_id)
+toc = time.perf_counter()
+print(f"Measurement.get({ec_id}) took {(toc - tic) * 1000:.2f} ms")
+print("  ... because it read *no* numerical data:")
+series = loaded_ec.series_list[0]
+print(f"  {series.name!r}._data is {series._data}")
+
+tic = time.perf_counter()
+n_points = len(series.data)  # NOW the array is fetched from the database
+toc = time.perf_counter()
+print(
+    f"  first access to .data fetched {n_points} points "
+    f"in {(toc - tic) * 1000:.2f} ms"
+)
+
+# --------------------------------------------------------------------------- #
+part("5. Objects come back by name, as what they were, calibration included")
+# --------------------------------------------------------------------------- #
+
+by_name = Measurement.load("Pt_poly_cv_CUT.mpt")
+print(f"Measurement.load('Pt_poly_cv_CUT.mpt') -> {by_name!r}")
+print(f"  class: {type(by_name).__name__} (not just a generic Measurement)")
+print(f"  calculators: {by_name.calculator_list}")
+print(f"  equal to what was saved:  by_name == ec  is  {by_name == ec}")
+
+t, v_raw = by_name.grab("raw_potential")
+t, v = by_name.grab("potential")  # calibrated, thanks to the reloaded ECCalibration
+print(
+    f"  mean(potential - raw_potential) = {(v - v_raw).mean():.2f} V"
+    "  <- the RE_vs_RHE=0.72 calibration survived the round trip"
+)
+
+# --------------------------------------------------------------------------- #
+part("6. Composed measurements share rows - data is never duplicated")
+# --------------------------------------------------------------------------- #
+
+composed = ec.select(cycle=1) + ec.select(cycle=3)
+composed_id = composed.save()
+print(f"Saved composed measurement (id={composed_id}) built from two cycles.\n")
+
+n_references, n_series = con.execute(
+    "SELECT COUNT(*), COUNT(DISTINCT data_series_id) FROM measurement_series"
+).fetchone()
+n_measurements = con.execute("SELECT COUNT(*) FROM measurement").fetchone()[0]
+print(f"  {n_measurements} measurements now reference series "
+      f"{n_references} times ...")
+print(f"  ... but only {n_series} distinct data series (arrays) are stored:")
+print("  the composed measurement and its components *share* rows.")
+
+reloaded_composed = Measurement.get(composed_id)
+print(f"\nRound trip of the composed measurement: "
+      f"{reloaded_composed == composed}")
+
+# --------------------------------------------------------------------------- #
+part("7. Not just measurements: every ixdat data family gets its tables")
+# --------------------------------------------------------------------------- #
+
+xrd = Spectrum.read(TEST_DATA_DIR / "xrd/twotheta_2th.xy", reader="xrdxy")
+xrd_id = xrd.save()
+loaded_xrd = type(xrd).get(xrd_id)
+print(f"Saved and reloaded {loaded_xrd!r}")
+print(f"  class: {type(loaded_xrd).__name__}, equal: {loaded_xrd == xrd}")
+print("  (spectra live in their own tables: multispectrum, data_series, "
+      "field_axes, ...)")
+
+# --------------------------------------------------------------------------- #
+part("8. The database speaks SQL: instant analytics over everything saved")
+# --------------------------------------------------------------------------- #
+
+print("All measurements, joined with their EC details and series counts:\n")
+print(
+    pd.read_sql_query(
+        """
+        SELECT m.id, m.name, m.technique, e.ec_technique,
+               COUNT(ms.data_series_id) AS n_series
+        FROM measurement m
+        LEFT JOIN ec_measurements e ON e.id = m.id
+        LEFT JOIN measurement_series ms ON ms.measurement_id = m.id
+        GROUP BY m.id ORDER BY m.id
+        """,
+        con,
+    ).to_string(index=False)
+)
+
+print("\nAll calculators, joined with their calibration constants:\n")
+print(
+    pd.read_sql_query(
+        """
+        SELECT c.id, c.name, c.calculator_type, cal.RE_vs_RHE, cal.A_el, cal.R_Ohm
+        FROM calculator c
+        LEFT JOIN ec_calibration cal ON cal.id = c.id
+        """,
+        con,
+    ).to_string(index=False)
+)
+print("\n(Anything - pandas, R, LibreOffice, grafana - can query this file.)")
+
+# --------------------------------------------------------------------------- #
+part("9. Rows can be updated in place")
+# --------------------------------------------------------------------------- #
+
+loaded_ec.name = "Pt_poly_cv_CUT.mpt (analyzed 2026-07-02)"
+DB.backend.save(loaded_ec, force=True)
+print(f"Renamed and updated row id={loaded_ec.id}. The database now says:")
+print("  " + str(con.execute(
+    "SELECT name FROM measurement WHERE id = ?", (loaded_ec.id,)
+).fetchone()[0]))
+
+# --------------------------------------------------------------------------- #
+part("10. The whole schema of ixdat's data model, generated from the classes")
+# --------------------------------------------------------------------------- #
+
+report = DB.backend.schema_report()
+schema_file = DEMO_DIR / "ixdat_schema.sql"
+schema_file.write_text(report)
+n_tables = report.count("CREATE TABLE")
+print(f"schema_report() derived {n_tables} tables from the imported ixdat classes")
+print(f"  (full DDL written to {schema_file})")
+print("\nA taste - inheritance becomes extension tables joined on id:\n")
+for statement in report.split(";"):
+    if '"ecms_measurements"' in statement or '"tstamps"' in statement:
+        print(statement.strip() + ";\n")
+
+# --------------------------------------------------------------------------- #
+part("Finally: plots, straight from the database")
+# --------------------------------------------------------------------------- #
+
+axes = Measurement.load("Pt_poly_cv_CUT.mpt (analyzed 2026-07-02)").plot_measurement()
+axes[0].set_title("EC measurement reloaded from SQLite")
+
+ax = type(xrd).get(xrd_id).plot()
+ax.set_title("XRD spectrum reloaded from SQLite")
+
+print(f"\nDone. The database file is yours to explore: {DB_FILE}")
+
+if not plt.isinteractive():
+    plt.show()

--- a/development_scripts/demo_sqlite_webapp.py
+++ b/development_scripts/demo_sqlite_webapp.py
@@ -1,0 +1,92 @@
+"""Save ixdat data and view the SQLite tables in a browser."""
+
+import html
+import sqlite3
+import tempfile
+import webbrowser
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+from urllib.parse import parse_qs
+
+from ixdat import Measurement, Spectrum
+from ixdat.db import DB, change_database
+
+
+DATA = Path(__file__).resolve().parents[1] / "test_data"
+DATABASE = Path(tempfile.gettempdir()) / "ixdat_web_demo.sqlite"
+
+
+def save_data():
+    if DATABASE.exists():
+        DATABASE.unlink()
+    change_database("sqlite", db_path=DATABASE)
+    Measurement.read(DATA / "biologic/Pt_poly_cv_CUT.mpt", reader="biologic").save()
+    Measurement.read(DATA / "biologic/Pt_poly_cv.mpt", reader="biologic").save()
+    Spectrum.read(DATA / "xrd/twotheta_2th.xy", reader="xrdxy").save()
+    DB.backend.close()
+
+
+def make_page(selected):
+    db = sqlite3.connect(DATABASE.resolve().as_uri() + "?mode=ro", uri=True)
+    tables = [
+        row[0]
+        for row in db.execute(
+            "SELECT name FROM sqlite_master "
+            "WHERE type='table' AND name NOT LIKE 'sqlite_%' ORDER BY name"
+        )
+    ]
+    table = selected if selected in tables else tables[0]
+    cursor = db.execute('SELECT * FROM "{}"'.format(table))
+    columns = [column[0] for column in cursor.description]
+    rows = cursor.fetchall()
+    db.close()
+
+    links = " ".join(
+        '<a href="/?table={0}">{0}</a>'.format(html.escape(name)) for name in tables
+    )
+    headings = "".join("<th>{}</th>".format(html.escape(name)) for name in columns)
+    body = "".join(
+        "<tr>{}</tr>".format("".join("<td>{}</td>".format(show(value)) for value in row))
+        for row in rows
+    )
+    return (
+        "<!doctype html><title>ixdat SQLite tables</title>"
+        "<style>body{{font:14px sans-serif}}a{{margin-right:1em}}"
+        "table{{border-collapse:collapse}}th,td{{border:1px solid;padding:4px}}"
+        "th{{background:#eee}}</style><h1>ixdat SQLite tables</h1>"
+        "<nav>{}</nav><h2>{}</h2><table><tr>{}</tr>{}</table>"
+    ).format(links, html.escape(table), headings, body)
+
+
+def show(value):
+    return (
+        "{} bytes".format(len(value))
+        if isinstance(value, bytes)
+        else html.escape(str(value))
+    )
+
+
+class Handler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        query = parse_qs(self.path.partition("?")[2])
+        page = make_page(query.get("table", [None])[0]).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "text/html; charset=utf-8")
+        self.end_headers()
+        self.wfile.write(page)
+
+
+def main():
+    save_data()
+    server = HTTPServer(("127.0.0.1", 0), Handler)
+    url = "http://127.0.0.1:{}".format(server.server_port)
+    print("Open {} (Ctrl+C stops the server)".format(url))
+    webbrowser.open(url)
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        server.server_close()
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/source/diving_deeper/backend.rst
+++ b/docs/source/diving_deeper/backend.rst
@@ -72,31 +72,41 @@ The relational schema is not written by hand. It is derived, by
 ``ixdat.backends.relational``, from the table metadata every ``Saveable`` class
 already carries: ``table_name`` and ``column_attrs`` for the main table,
 ``extra_column_attrs`` for extension tables, and ``extra_linkers`` for linker tables.
+The extension and linker definitions are merged over class ancestry. Each class
+declares the tables and columns it introduces, and multiply-inheriting classes retain
+the definitions of every parent.
 
 Two further class attributes tell a relational backend how to store each column.
-Both are optional, and both are *merged* over a class's ancestry, so a class only
-declares what it introduces itself::
+Both are optional and follow the same ancestry-merging rule::
 
     class XRFSpectrum(Spectrum):
-        extra_column_attrs = {"xrf_spectrums": {"excitation_energy", "detector_gains"}}
-        column_types = {"excitation_energy": "REAL", "detector_gains": "JSON"}
+        extra_column_attrs = {
+            "xrf_spectrums": {
+                "excitation_energy", "detector_gains", "calibration_id"
+            }
+        }
+        column_types = {"excitation_energy": float, "detector_gains": list}
         column_references = {"calibration_id": "calculator"}
 
-``column_types`` gives the type of a column's value: ``"INTEGER"``, ``"REAL"`` and
-``"TEXT"`` are stored as-is, ``"JSON"`` is for dicts and lists, and ``"NDARRAY"`` is
-for numpy arrays, which are stored as a blob and loaded only on access. A column
-which is not listed has no fixed type and is stored as whatever type its value
-already has, so a plain str/int/float column needs no declaration. Saving a dict,
-list, or array to such a column raises a ``DataBaseError`` naming the column, rather
-than guessing.
+``column_types`` gives the Python type of a column's value. Supported declarations
+are ``int``, ``float``, ``str``, ``dict``, ``list``, ``tuple``, and
+``numpy.ndarray``. Each relational backend maps these to its own storage types.
+SQLite stores containers as JSON and arrays as blobs loaded on access. A column
+which is not listed has no fixed type and stores its scalar value directly. Saving
+a container or array to an untyped column raises a ``DataBaseError`` naming the
+column.
 
 ``column_references`` names the columns which hold the id of a single row of another
 table; these become integer foreign keys to that table's ``id``. A reference to
 *several* rows of another table belongs in ``extra_linkers`` instead.
 
-Because this lives on the classes rather than in a table inside ixdat, a ``Saveable``
-class defined in a plugin or a user's own script gets its tables built correctly
-without any change to ixdat.
+Keeping this information on the classes lets a ``Saveable`` class in a plugin or
+user script define its own relational tables directly.
+
+Extension tables represent inheritance without repeating parent columns. For example,
+``ECMSMeasurement`` contributes ``tspan_bg`` to ``ecms_measurements`` and inherits
+``ec_technique`` from ``ECMeasurement`` in ``ec_measurements``. Both tables use the
+measurement's main-table id as their primary and foreign key.
 
 Connections and threads
 -----------------------
@@ -105,42 +115,6 @@ Call ``backend.close()`` when finished. Switching the global database does not c
 the previous backend because objects loaded from it may still need its connection for
 lazy data. An ``SQLiteBackend`` connection belongs to the thread which created it;
 create a separate backend instance per thread.
-
-Known limitation: multiply-inheriting classes and extension tables
---------------------------------------------------------------------
-
-A ``Saveable`` class which inherits from more than one other table-defining class
-(for example ``ECMSMeasurement``, which inherits from both ``ECMeasurement`` and
-``MSMeasurement``) declares its own ``extra_column_attrs``, which *replaces* rather
-than merges with the ``extra_column_attrs`` of each parent. In practice this means
-such a class writes only to the one extension table it declares itself (e.g.
-``ecms_measurements``), not to the extension tables of its other parents (e.g.
-``ec_measurements``) — even though the row is, semantically, also an EC measurement.
-
-Round-tripping is unaffected: every attribute is still saved and reloaded correctly,
-because classes with this shape (``ECMSMeasurement``, ``MSSpectroMeasurement``, ...)
-already duplicate the small number of overlapping columns into their own extension
-table by hand. What breaks is a query that joins against only *one* parent's
-extension table expecting it to be exhaustive, for example::
-
-    -- misses every ECMSMeasurement row, though they are EC measurements too:
-    SELECT m.id, m.name, e.ec_technique
-    FROM measurement m
-    JOIN ec_measurements e ON e.id = m.id
-
-Filter or group by ``measurement.technique`` instead of joining a single extension
-table when you want "every measurement of a given family", or ``UNION`` across the
-extension tables of the classes you care about.
-
-This is not new to the SQLite backend: it is a limitation of how ``Saveable``
-resolves ``extra_column_attrs`` across multiple inheritance
-(``ixdat.db.Saveable.get_main_dict``/``as_dict``), so it equally affects
-``obj.as_dict()`` on the directory backend for any class which does not manually
-duplicate its overlapping columns the way ``ECMSMeasurement`` does today. Properly
-merging table definitions across multiple inheritance was the central open question
-of `PR #75 <https://github.com/ixdat/ixdat/pull/75>`_ and remains unresolved;
-fixing it belongs in ``Saveable`` itself; it is out of scope for the database
-backends.
 
 The directory backend
 ---------------------

--- a/docs/source/diving_deeper/backend.rst
+++ b/docs/source/diving_deeper/backend.rst
@@ -136,9 +136,11 @@ are ``int``, ``float``, ``str``, ``dict``, ``list``, ``tuple``, and
 ``numpy.ndarray``. Each relational backend maps these to its own storage types.
 SQLite stores containers as JSON and arrays as blobs. As described above, the column
 named ``data`` stays in the file until its property is accessed; other array columns
-load with the object's ordinary values. A column which is not listed has no fixed
-type and stores its scalar value directly. Saving a container or array to an untyped
-column raises a ``DataBaseError`` naming the column.
+load with the object's ordinary values. Pandas represents text columns as object
+arrays. When every item in such an array is a string, SQLite stores it as a native
+NumPy Unicode array so that it can be loaded safely without pickle. A column which is
+not listed has no fixed type and stores its scalar value directly. Saving a container
+or array to an untyped column raises a ``DataBaseError`` naming the column.
 
 The key in ``relationships`` is the Python attribute holding the linked object.
 ``Relationship`` names the linked table and the attribute holding its saved id.

--- a/docs/source/diving_deeper/backend.rst
+++ b/docs/source/diving_deeper/backend.rst
@@ -65,6 +65,39 @@ version. On first use, ixdat validates each table against the schema derived fro
 incompatible column type, primary key, relationship, or newer schema version raises a
 ``DataBaseError`` instead of risking a misread or partial write.
 
+Defining the tables of a ``Saveable`` class
+-------------------------------------------
+
+The relational schema is not written by hand. It is derived, by
+``ixdat.backends.relational``, from the table metadata every ``Saveable`` class
+already carries: ``table_name`` and ``column_attrs`` for the main table,
+``extra_column_attrs`` for extension tables, and ``extra_linkers`` for linker tables.
+
+Two further class attributes tell a relational backend how to store each column.
+Both are optional, and both are *merged* over a class's ancestry, so a class only
+declares what it introduces itself::
+
+    class XRFSpectrum(Spectrum):
+        extra_column_attrs = {"xrf_spectrums": {"excitation_energy", "detector_gains"}}
+        column_types = {"excitation_energy": "REAL", "detector_gains": "JSON"}
+        column_references = {"calibration_id": "calculator"}
+
+``column_types`` gives the type of a column's value: ``"INTEGER"``, ``"REAL"`` and
+``"TEXT"`` are stored as-is, ``"JSON"`` is for dicts and lists, and ``"NDARRAY"`` is
+for numpy arrays, which are stored as a blob and loaded only on access. A column
+which is not listed has no fixed type and is stored as whatever type its value
+already has, so a plain str/int/float column needs no declaration. Saving a dict,
+list, or array to such a column raises a ``DataBaseError`` naming the column, rather
+than guessing.
+
+``column_references`` names the columns which hold the id of a single row of another
+table; these become integer foreign keys to that table's ``id``. A reference to
+*several* rows of another table belongs in ``extra_linkers`` instead.
+
+Because this lives on the classes rather than in a table inside ixdat, a ``Saveable``
+class defined in a plugin or a user's own script gets its tables built correctly
+without any change to ixdat.
+
 Connections and threads
 -----------------------
 

--- a/docs/source/diving_deeper/backend.rst
+++ b/docs/source/diving_deeper/backend.rst
@@ -1,6 +1,89 @@
 .. _backend:
 
-Backend
-==============================================
+Database backends
+=================
 
-In the future, ``ixdat`` will support different backends such as an SQL database.
+An ixdat object remembers the backend from which it was loaded. This makes linked
+objects and numerical arrays lazy: metadata is loaded immediately, while referenced
+objects and array data are read only when accessed.
+
+SQLite
+------
+
+The SQLite backend stores a complete ixdat project in one portable ``.sqlite`` file.
+It uses Python's built-in :mod:`sqlite3` module and requires no optional dependency::
+
+    from ixdat.db import change_database
+
+    backend = change_database("sqlite", db_path="my_project.sqlite")
+    measurement_id = measurement.save()
+
+    by_id = Measurement.get(measurement_id)
+    by_name = Measurement.load(measurement.name)
+
+``Saveable.load(name)`` returns the most recently saved row with that exact name.
+``Saveable.get(id)`` selects a specific row. Arrays stored in data series are NumPy
+``.npy`` payloads inside SQLite blob columns and remain unloaded until ``.data`` is
+accessed. Use ``db_path=":memory:"`` for a temporary, in-memory SQLite database.
+
+An object can also be loaded from a backend without permanently changing the active
+database::
+
+    from ixdat.backends import SQLiteBackend
+
+    archive = SQLiteBackend("archive.sqlite")
+    try:
+        old_measurement = Measurement.get(12, backend=archive)
+        old_data = old_measurement.series_list[0].data
+    finally:
+        archive.close()
+
+Access lazy children and arrays before closing their backend. A context manager is
+convenient when the lifetime is limited::
+
+    from ixdat.db import DB
+
+    with SQLiteBackend("archive.sqlite") as archive:
+        with DB.temporary_backend(archive):
+            measurement = Measurement.load("my measurement")
+            data = measurement.series_list[0].data
+
+Persistence guarantees
+----------------------
+
+Saving a ``Saveable`` and its complete graph of child objects is one transaction. If
+any row, extension table, linker, or array fails to save, none of that graph's changes
+are committed and newly assigned in-memory identities are restored.
+
+Foreign-key checks are enabled on every backend connection. Ordered relationships are
+stored in linker tables, and subclass-only values are stored in one-to-one extension
+tables. Frequently used name, discriminator, and reverse-link columns are indexed.
+
+The database contains an internal ``_ixdat_metadata`` table with its storage schema
+version. On first use, ixdat validates each table against the schema derived from its
+``Saveable`` class. Newly introduced nullable columns are added automatically. An
+incompatible column type, primary key, relationship, or newer schema version raises a
+``DataBaseError`` instead of risking a misread or partial write.
+
+Connections and threads
+-----------------------
+
+Call ``backend.close()`` when finished. Switching the global database does not close
+the previous backend because objects loaded from it may still need its connection for
+lazy data. An ``SQLiteBackend`` connection belongs to the thread which created it;
+create a separate backend instance per thread.
+
+The directory backend
+---------------------
+
+The directory backend stores JSON metadata and NumPy arrays in a folder hierarchy::
+
+    change_database(
+        "directory",
+        directory=Path("data"),
+        project_name="my_project",
+    )
+
+It implements the same ``save()``, ``get(id)``, and exact ``load(name)`` interface,
+but SQLite is preferable when transactional saves, relational queries, compact
+distribution, and schema validation are important.

--- a/docs/source/diving_deeper/backend.rst
+++ b/docs/source/diving_deeper/backend.rst
@@ -73,6 +73,42 @@ the previous backend because objects loaded from it may still need its connectio
 lazy data. An ``SQLiteBackend`` connection belongs to the thread which created it;
 create a separate backend instance per thread.
 
+Known limitation: multiply-inheriting classes and extension tables
+--------------------------------------------------------------------
+
+A ``Saveable`` class which inherits from more than one other table-defining class
+(for example ``ECMSMeasurement``, which inherits from both ``ECMeasurement`` and
+``MSMeasurement``) declares its own ``extra_column_attrs``, which *replaces* rather
+than merges with the ``extra_column_attrs`` of each parent. In practice this means
+such a class writes only to the one extension table it declares itself (e.g.
+``ecms_measurements``), not to the extension tables of its other parents (e.g.
+``ec_measurements``) — even though the row is, semantically, also an EC measurement.
+
+Round-tripping is unaffected: every attribute is still saved and reloaded correctly,
+because classes with this shape (``ECMSMeasurement``, ``MSSpectroMeasurement``, ...)
+already duplicate the small number of overlapping columns into their own extension
+table by hand. What breaks is a query that joins against only *one* parent's
+extension table expecting it to be exhaustive, for example::
+
+    -- misses every ECMSMeasurement row, though they are EC measurements too:
+    SELECT m.id, m.name, e.ec_technique
+    FROM measurement m
+    JOIN ec_measurements e ON e.id = m.id
+
+Filter or group by ``measurement.technique`` instead of joining a single extension
+table when you want "every measurement of a given family", or ``UNION`` across the
+extension tables of the classes you care about.
+
+This is not new to the SQLite backend: it is a limitation of how ``Saveable``
+resolves ``extra_column_attrs`` across multiple inheritance
+(``ixdat.db.Saveable.get_main_dict``/``as_dict``), so it equally affects
+``obj.as_dict()`` on the directory backend for any class which does not manually
+duplicate its overlapping columns the way ``ECMSMeasurement`` does today. Properly
+merging table definitions across multiple inheritance was the central open question
+of `PR #75 <https://github.com/ixdat/ixdat/pull/75>`_ and remains unresolved;
+fixing it belongs in ``Saveable`` itself; it is out of scope for the database
+backends.
+
 The directory backend
 ---------------------
 

--- a/docs/source/diving_deeper/backend.rst
+++ b/docs/source/diving_deeper/backend.rst
@@ -3,9 +3,9 @@
 Database backends
 =================
 
-An ixdat object remembers the backend from which it was loaded. This makes linked
-objects and numerical arrays lazy: metadata is loaded immediately, while referenced
-objects and array data are read only when accessed.
+An ixdat object remembers the backend from which it was loaded. This keeps linked
+objects and ``DataSeries.data`` out of the first load. ixdat reads them from the
+remembered backend when they are first accessed.
 
 SQLite
 ------
@@ -24,7 +24,37 @@ It uses Python's built-in :mod:`sqlite3` module and requires no optional depende
 ``Saveable.load(name)`` returns the most recently saved row with that exact name.
 ``Saveable.get(id)`` selects a specific row. Arrays stored in data series are NumPy
 ``.npy`` payloads inside SQLite blob columns and remain unloaded until ``.data`` is
-accessed. Use ``db_path=":memory:"`` for a temporary, in-memory SQLite database.
+accessed. This delayed loading belongs specifically to the column named ``data``.
+Another NumPy-array column, such as one added by a plugin, loads with the object's
+other stored values.
+
+The string ``":memory:"`` is a special SQLite address. Calling
+``sqlite3.connect(":memory:")`` creates a temporary database which belongs to that
+one connection and has no file on disk. Calling it again creates another empty
+database, even though both calls use the same address string. ixdat therefore treats
+each in-memory backend as a separate database and gives it a unique internal address.
+This keeps objects from two temporary databases from receiving the same identity when
+both happen to contain, for example, a ``data_series`` row with ``id=1``. Closing the
+connection removes its temporary database. Use ``db_path=":memory:"`` when this
+short-lived storage is useful.
+
+Two ``SQLiteBackend`` objects can open separate connections to the same file. They
+remain separate Python objects, and ``shares_storage_with()`` reports that both
+connections reach the same saved rows. ixdat uses this explicit check when deciding
+whether an object already belongs to the target database file. SQLite coordinates
+writes made through the separate connections.
+
+An object's ``id`` is its integer row number inside one backend. Its
+``short_identity`` is always ``(backend, id)``, so a reference still identifies the
+right object when one measurement uses data from several backends. A storage backend
+turns these references into local integer ids when it saves the connected objects.
+The backend in this tuple is the live Python backend object. Two backend objects can
+open separate connections to the same file, so compare such references with
+``same_short_identity()`` when their table is already known::
+
+    from ixdat.db import same_short_identity
+
+    same_short_identity(first.short_identity, second.short_identity)
 
 An object can also be loaded from a backend without permanently changing the active
 database::
@@ -38,8 +68,9 @@ database::
     finally:
         archive.close()
 
-Access lazy children and arrays before closing their backend. A context manager is
-convenient when the lifetime is limited::
+Every backend can be used as a context manager. Leaving the ``with`` block calls
+``backend.close()``. For SQLite, this closes the open connection. Access lazily
+loaded related objects and ``.data`` arrays before leaving the block::
 
     from ixdat.db import DB
 
@@ -51,54 +82,82 @@ convenient when the lifetime is limited::
 Persistence guarantees
 ----------------------
 
-Saving a ``Saveable`` and its complete graph of child objects is one transaction. If
-any row, extension table, linker, or array fails to save, none of that graph's changes
-are committed and newly assigned in-memory identities are restored.
+Saving a ``Saveable`` and all the related objects it owns is one transaction. If any
+row, extension table, table of connections, or array fails to save, none of those
+changes are committed and newly assigned in-memory identities are restored.
 
 Foreign-key checks are enabled on every backend connection. Ordered relationships are
-stored in linker tables, and subclass-only values are stored in one-to-one extension
-tables. Frequently used name, discriminator, and reverse-link columns are indexed.
+stored in tables of connections, also called linker tables. Values added by a more
+specialized class are stored in one-to-one extension tables. Frequently used name,
+discriminator, and reverse-link columns are indexed.
 
-The database contains an internal ``_ixdat_metadata`` table with its storage schema
-version. On first use, ixdat validates each table against the schema derived from its
-``Saveable`` class. Newly introduced nullable columns are added automatically. An
-incompatible column type, primary key, relationship, or newer schema version raises a
-``DataBaseError`` instead of risking a misread or partial write.
+Every new database contains an internal ``_ixdat_metadata`` table recording storage
+schema version 1. ixdat opens an existing database only when it records the same
+version. An unversioned database or a different version raises ``DataBaseError`` with
+instructions to migrate its objects into a new database.
+
+Saving an object creates any tables needed for object types that have not previously
+been saved. Reading validates existing tables and leaves the database unchanged. A
+missing column, incompatible column type, primary key, or relationship raises
+``DataBaseError`` and requires an explicit migration. A future schema upgrade should
+read objects from a supported old database and save them into a new database, leaving
+the source file unchanged.
 
 Defining the tables of a ``Saveable`` class
 -------------------------------------------
 
 The relational schema is not written by hand. It is derived, by
 ``ixdat.backends.relational``, from the table metadata every ``Saveable`` class
-already carries: ``table_name`` and ``column_attrs`` for the main table,
-``extra_column_attrs`` for extension tables, and ``extra_linkers`` for linker tables.
-The extension and linker definitions are merged over class ancestry. Each class
-declares the tables and columns it introduces, and multiply-inheriting classes retain
-the definitions of every parent.
+already carries. ``table_name`` and ``column_attrs`` define ordinary values in the
+main table, and ``extra_column_attrs`` defines ordinary values in extension tables.
+Relationships to other saved objects are declared with ``Relationship``. These
+definitions are merged over class ancestry, so each class only declares what it adds.
 
-Two further class attributes tell a relational backend how to store each column.
-Both are optional and follow the same ancestry-merging rule::
+For example, this class stores two ordinary values and one reference to a saved
+calculator::
+
+    from ixdat.db import Relationship
 
     class XRFSpectrum(Spectrum):
         extra_column_attrs = {
-            "xrf_spectrums": {
-                "excitation_energy", "detector_gains", "calibration_id"
-            }
+            "xrf_spectrums": {"excitation_energy", "detector_gains"}
         }
         column_types = {"excitation_energy": float, "detector_gains": list}
-        column_references = {"calibration_id": "calculator"}
+        relationships = {
+            "calibration": Relationship(
+                "calculator",
+                "calibration_id",
+                storage_table="xrf_spectrums",
+            )
+        }
 
 ``column_types`` gives the Python type of a column's value. Supported declarations
 are ``int``, ``float``, ``str``, ``dict``, ``list``, ``tuple``, and
 ``numpy.ndarray``. Each relational backend maps these to its own storage types.
-SQLite stores containers as JSON and arrays as blobs loaded on access. A column
-which is not listed has no fixed type and stores its scalar value directly. Saving
-a container or array to an untyped column raises a ``DataBaseError`` naming the
-column.
+SQLite stores containers as JSON and arrays as blobs. As described above, the column
+named ``data`` stays in the file until its property is accessed; other array columns
+load with the object's ordinary values. A column which is not listed has no fixed
+type and stores its scalar value directly. Saving a container or array to an untyped
+column raises a ``DataBaseError`` naming the column.
 
-``column_references`` names the columns which hold the id of a single row of another
-table; these become integer foreign keys to that table's ``id``. A reference to
-*several* rows of another table belongs in ``extra_linkers`` instead.
+The key in ``relationships`` is the Python attribute holding the linked object.
+``Relationship`` names the linked table and the attribute holding its saved id.
+``storage_table`` says where ixdat stores that id. Leaving it out for a single object
+places the id in the main table. A list uses ``many=True`` and requires a
+``storage_table`` for its rows of connections. Each row receives a ``position`` so
+ixdat can rebuild the list in the same order, including repeated objects.
+
+By default, saving a new owner saves new related objects first. This gives each related
+object the id which the owner needs to store. A normal repeated ``save()`` keeps
+already-saved rows unchanged. After changing a saved object or replacing one of its
+relationships, ``DB.backend.save(owner, force=True)`` updates the owner and its related
+objects together. Set ``save_related=False`` when the related object should stay
+outside the owner's save process.
+
+Older plugin classes can continue to use ``extra_linkers``, ``column_references``, and
+``child_attrs``. ixdat converts those declarations into the same table descriptions.
+For an older ``extra_linkers`` declaration, an id attribute ending in ``_ids`` means
+that it contains an ordered list.
 
 Keeping this information on the classes lets a ``Saveable`` class in a plugin or
 user script define its own relational tables directly.
@@ -111,10 +170,12 @@ measurement's main-table id as their primary and foreign key.
 Connections and threads
 -----------------------
 
-Call ``backend.close()`` when finished. Switching the global database does not close
-the previous backend because objects loaded from it may still need its connection for
-lazy data. An ``SQLiteBackend`` connection belongs to the thread which created it;
-create a separate backend instance per thread.
+All backends provide ``close()`` and support the context-manager form shown above. A
+backend overrides ``close()`` when it owns a long-lived resource. SQLite uses it to
+close the open connection. Switching the global database does not close the previous
+backend because objects loaded from it may still need its connection for lazy data.
+An ``SQLiteBackend`` connection belongs to the thread which created it; create a
+separate backend instance per thread.
 
 The directory backend
 ---------------------

--- a/src/ixdat/backends/__init__.py
+++ b/src/ixdat/backends/__init__.py
@@ -9,12 +9,14 @@ Constants:
 from .backend_base import BackendBase
 from .memory_backend import MemoryBackend
 from .directory_backend import DirBackend
+from .sqlite_backend import SQLiteBackend
 
 
 BACKEND_CLASSES = {
     "none": BackendBase,
     "memory": MemoryBackend,
     "directory": DirBackend,
+    "sqlite": SQLiteBackend,
 }
 # FIXME: should automate that all initiated backends get added to database_backends?
 database_backends = {

--- a/src/ixdat/backends/__init__.py
+++ b/src/ixdat/backends/__init__.py
@@ -21,6 +21,6 @@ BACKEND_CLASSES = {
 # FIXME: should automate that all initiated backends get added to database_backends?
 database_backends = {
     "none": BackendBase(),  # Just assigns id's but doesn't keep track.
-    "memory": MemoryBackend(),  # Keeps track so child objects can be passed around
+    "memory": MemoryBackend(),  # Keeps related objects available by id
     "directory": DirBackend(),  # Saves json files, stand-in for SQL, mainly for testing
 }

--- a/src/ixdat/backends/backend_base.py
+++ b/src/ixdat/backends/backend_base.py
@@ -1,5 +1,7 @@
 """This module implements the simplest backend, which just counts objects."""
 
+from ..exceptions import DataBaseError
+
 
 class BackendBase:
     """Base class listing the functions that must be implemented in a database backend.
@@ -17,6 +19,12 @@ class BackendBase:
     a workflow should instead be initiated with MemoryBackend (backend="memory").
     Other backends imply an object is saved to or loaded form a database including
     ixdat's directory backend (backend="directory")
+
+    Every backend can be used as a context manager. A backend which owns a
+    long-lived resource can override close() to release it.
+
+    ``shares_storage_with()`` lets separate backend objects say that they reach
+    the same saved objects while remaining separate Python objects.
     """
 
     backend_type = "none"
@@ -26,6 +34,37 @@ class BackendBase:
     def __init__(self):
         """Initialize the backend with dict for {table_name (str): id_counter (int)}"""
         self.next_available_ids = {}
+
+    def close(self):
+        """Release resources owned by this backend, if any."""
+
+    def __enter__(self):
+        """Return this backend for use as a context manager."""
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        """Release this backend's resources when leaving a context manager."""
+        self.close()
+
+    def shares_storage_with(self, other):
+        """Return whether this backend and ``other`` reach the same saved objects."""
+        return self is other
+
+    def _dereference(self, value):
+        """Return the local integer from a ``(backend, id)`` reference."""
+        if (
+            isinstance(value, tuple)
+            and len(value) == 2
+            and isinstance(value[0], BackendBase)
+        ):
+            backend, i = value
+            if self.shares_storage_with(backend):
+                return i
+            raise DataBaseError(
+                f"Can't save a reference to id={i} of {backend} in {self}. "
+                "Save the referenced object here first."
+            )
+        return value
 
     def get_next_available_id(self, table_name, obj=None):
         """Return the id counter for table_name, starting with 1."""

--- a/src/ixdat/backends/backend_base.py
+++ b/src/ixdat/backends/backend_base.py
@@ -51,7 +51,7 @@ class BackendBase:
         return self is other
 
     def _dereference(self, value):
-        """Return the local integer from a ``(backend, id)`` reference."""
+        """Return the local id from a ``(backend, id)`` reference."""
         if (
             isinstance(value, tuple)
             and len(value) == 2

--- a/src/ixdat/backends/backend_base.py
+++ b/src/ixdat/backends/backend_base.py
@@ -45,6 +45,10 @@ class BackendBase:
         """Load the object with id=i of a Savable class. Must be implemented."""
         raise NotImplementedError
 
+    def load(self, cls, name):
+        """Load the newest object of a Savable class by name. Must be implemented."""
+        raise NotImplementedError
+
     def load_obj_data(self, obj):
         """Load and return the 'data' of a saveable object. Must be implemented."""
         raise NotImplementedError

--- a/src/ixdat/backends/directory_backend.py
+++ b/src/ixdat/backends/directory_backend.py
@@ -159,10 +159,18 @@ class DirBackend(BackendBase):
             for path in folder.iterdir():
                 if path.is_dir() or path.suffix != self.metadata_suffix:
                     continue
-                if name_from_path(path) == fixed_name:
-                    i = id_from_path(path)
-                    if i is not None and (i_to_load is None or i > i_to_load):
-                        i_to_load = i
+                if name_from_path(path) != fixed_name:
+                    continue
+                # Filename escaping is not one-to-one: for example, ``a/b`` and
+                # the literal name ``a_DIV_b`` have the same escaped form. Check
+                # the authoritative name in the row before accepting a candidate.
+                with open(path, "r") as file:
+                    row = json.load(file)
+                if row.get("name") != name:
+                    continue
+                i = id_from_path(path)
+                if i is not None and (i_to_load is None or i > i_to_load):
+                    i_to_load = i
         if i_to_load is None:
             raise DataBaseError(
                 f"{self} has no row named '{name}' in table '{cls.table_name}'"
@@ -195,8 +203,10 @@ class DirBackend(BackendBase):
             self.save_data(obj_as_dict["data"], table_name, i, fixed_name)
             obj_as_dict["data"] = None  # FIXME this could instead point to the data.
         file_name = f"{i}_{fixed_name}{self.metadata_suffix}"
+        from ..tools import to_jsonable
+
         with open(folder / file_name, "w") as f:
-            json.dump(obj_as_dict, f, indent=4)
+            json.dump(to_jsonable(obj_as_dict), f, indent=4)
         return i
 
     def update_row(self, table_name, i, obj_as_dict):
@@ -210,8 +220,10 @@ class DirBackend(BackendBase):
             self.save_data(obj_as_dict["data"], table_name, i, fixed_name)
             obj_as_dict["data"] = None  # FIXME this could instead point to the data.
         file_name = f"{i}_{fixed_name}{self.metadata_suffix}"
+        from ..tools import to_jsonable
+
         with open(folder / file_name, "w") as f:
-            json.dump(obj_as_dict, f, indent=4)
+            json.dump(to_jsonable(obj_as_dict), f, indent=4)
 
     def get_row_as_dict(self, table_name, i):
         """Return the serialization of the object represented in row i of table_name"""

--- a/src/ixdat/backends/directory_backend.py
+++ b/src/ixdat/backends/directory_backend.py
@@ -9,6 +9,7 @@ import json
 import numpy as np
 from .backend_base import BackendBase
 from ..config import config, prompt_for_permission
+from ..exceptions import DataBaseError
 
 
 char_substitutions = {  # substitutions needed to name .json file with data series name
@@ -148,6 +149,25 @@ class DirBackend(BackendBase):
         obj.set_backend(self)
         obj.set_id(i)
         return obj
+
+    def load(self, cls, name):
+        """Return the most recently saved object of cls with the given name"""
+        folder = self.project_directory / cls.table_name
+        fixed_name = fix_name_for_saving(name)
+        i_to_load = None
+        if folder.exists():
+            for path in folder.iterdir():
+                if path.is_dir() or path.suffix != self.metadata_suffix:
+                    continue
+                if name_from_path(path) == fixed_name:
+                    i = id_from_path(path)
+                    if i is not None and (i_to_load is None or i > i_to_load):
+                        i_to_load = i
+        if i_to_load is None:
+            raise DataBaseError(
+                f"{self} has no row named '{name}' in table '{cls.table_name}'"
+            )
+        return self.get(cls, i_to_load)
 
     def contains(self, table_name, i):
         """Check if id `i` is already a principle key in the table named `table_name`"""

--- a/src/ixdat/backends/directory_backend.py
+++ b/src/ixdat/backends/directory_backend.py
@@ -92,19 +92,21 @@ class DirBackend(BackendBase):
                 whether to save.
         """
         # First, we save any objects referenced by this object that need to survive a
-        # save-load cycle. These are listed in obj.child_attrs. They need to be saved
-        # first, so that they get their id's in this backend for the main object to
-        # correctly reference. This is done recursively.
-        if obj.child_attrs:
-            for child_list_name in obj.child_attrs:
-                # save any data objects first as this may change the references
-                child_list = getattr(obj, child_list_name) or []
-                for child_obj in child_list:
-                    self.save(child_obj, force=force, no_updates=True)
+        # save-load cycle. They need to be saved first, so that they get their ids in
+        # this backend for the main object to reference correctly.
+        for related_obj in obj.iter_related_objects():
+            self.save(related_obj, force=force, no_updates=True)
         # Now we're ready to save the main object.
         # The table_name is the table, the as_dict is the info for the row in the table.
         table_name = obj.table_name
         obj_as_dict = obj.as_dict()
+        reference_attrs = set(obj.get_column_references())
+        reference_attrs.update(
+            id_attr for _, id_attr in obj.get_extra_linkers().values()
+        )
+        for attr in reference_attrs:
+            if attr in obj_as_dict:
+                obj_as_dict[attr] = self._dereference_reference_value(obj_as_dict[attr])
         # check if it's already saved and decide what to do if so:
         if obj.backend is self and self.contains(table_name, obj.id):
             okay_to_update = not no_updates
@@ -126,6 +128,12 @@ class DirBackend(BackendBase):
             obj.set_id(i)
             obj.set_backend(self)
             return i
+
+    def _dereference_reference_value(self, value):
+        """Convert backend-aware references to ids for the directory files."""
+        if isinstance(value, list):
+            return [self._dereference_reference_value(item) for item in value]
+        return self._dereference(value)
 
     def save_data(self, data, table_name, i, fixed_name=None):
         """Save the data item of a given row, by default as .ix.npy
@@ -216,16 +224,31 @@ class DirBackend(BackendBase):
         folder = self.project_directory / table_name
         if not folder.exists():
             folder.mkdir()
+        old_metadata_paths = [
+            path
+            for path in folder.iterdir()
+            if path.suffix == self.metadata_suffix and id_from_path(path) == i
+        ]
         obj_as_dict.update({"id": i})
         fixed_name = fix_name_for_saving(obj_as_dict["name"])
         if "data" in obj_as_dict:
             self.save_data(obj_as_dict["data"], table_name, i, fixed_name)
             obj_as_dict["data"] = None  # FIXME this could instead point to the data.
         file_name = f"{i}_{fixed_name}{self.metadata_suffix}"
+        new_metadata_path = folder / file_name
         from ..tools import to_jsonable
 
-        with open(folder / file_name, "w") as f:
+        with open(new_metadata_path, "w") as f:
             json.dump(to_jsonable(obj_as_dict), f, indent=4)
+        # The saved name is part of the filename. Once the new file is complete,
+        # remove files left under an earlier name so loading by id finds one row.
+        for old_metadata_path in old_metadata_paths:
+            if old_metadata_path == new_metadata_path:
+                continue
+            old_metadata_path.unlink()
+            old_data_path = old_metadata_path.with_suffix(self.data_suffix)
+            if old_data_path.exists():
+                old_data_path.unlink()
 
     def get_row_as_dict(self, table_name, i):
         """Return the serialization of the object represented in row i of table_name"""
@@ -276,3 +299,7 @@ class DirBackend(BackendBase):
         ):
             return True
         return False
+
+    def shares_storage_with(self, other):
+        """Return whether ``other`` refers to the same directory."""
+        return self == other

--- a/src/ixdat/backends/directory_backend.py
+++ b/src/ixdat/backends/directory_backend.py
@@ -161,9 +161,9 @@ class DirBackend(BackendBase):
                     continue
                 if name_from_path(path) != fixed_name:
                     continue
-                # Filename escaping is not one-to-one: for example, ``a/b`` and
-                # the literal name ``a_DIV_b`` have the same escaped form. Check
-                # the authoritative name in the row before accepting a candidate.
+                # two different real names can produce the same escaped file name
+                # (e.g. "a/b" and the literal name "a_DIV_b"), so before accepting
+                # this file, double check its real, un-escaped name inside it:
                 with open(path, "r") as file:
                     row = json.load(file)
                 if row.get("name") != name:
@@ -203,6 +203,8 @@ class DirBackend(BackendBase):
             self.save_data(obj_as_dict["data"], table_name, i, fixed_name)
             obj_as_dict["data"] = None  # FIXME this could instead point to the data.
         file_name = f"{i}_{fixed_name}{self.metadata_suffix}"
+        # metadata dicts can contain numpy numbers/arrays, which json.dump can't
+        # write directly, so convert those to plain Python values first:
         from ..tools import to_jsonable
 
         with open(folder / file_name, "w") as f:

--- a/src/ixdat/backends/memory_backend.py
+++ b/src/ixdat/backends/memory_backend.py
@@ -8,7 +8,7 @@ class MemoryBackend(BackendBase):
     This means that a Savable object can make a serializable representation of itself
     that includes the short_identity in the memory backend of objects that it
     references, and a new Savable object made from this representation can find the
-    original objects. See db.Savable.as_dict(), which ensures that "child objects"
+    original objects. See db.Saveable.as_dict(), which ensures that related objects
     are in memory.
     """
 

--- a/src/ixdat/backends/memory_backend.py
+++ b/src/ixdat/backends/memory_backend.py
@@ -1,4 +1,5 @@
 from .backend_base import BackendBase
+from ..exceptions import DataBaseError
 
 
 class MemoryBackend(BackendBase):
@@ -29,6 +30,17 @@ class MemoryBackend(BackendBase):
     def get(self, cls, i):
         """Return an object of a specified class and id by looking up in memory"""
         return self.objects[cls.table_name][i]
+
+    def load(self, cls, name):
+        """Return the most recently saved object of cls with the given name"""
+        objects_by_id = self.objects.get(cls.table_name, {})
+        # id's count up as objects are saved, so the highest one is the newest:
+        for i in sorted(objects_by_id, reverse=True):
+            if objects_by_id[i].name == name:
+                return objects_by_id[i]
+        raise DataBaseError(
+            f"{self} has no object named '{name}' in table '{cls.table_name}'"
+        )
 
     def save(self, obj):
         """Save the object into memory, and change its backend to this backend."""

--- a/src/ixdat/backends/relational.py
+++ b/src/ixdat/backends/relational.py
@@ -10,47 +10,53 @@ Every Saveable class already says how it should be saved:
 - ``extra_linkers`` names *linker tables*, which record ordered references from
   a row to several rows of another table (e.g. "measurement_series" records
   which data series belong to which measurement, and in what order),
-- ``column_types`` gives the *logical type* of the columns where it matters, and
+- ``column_types`` gives the Python type of the columns where it matters, and
 - ``column_references`` names the columns which hold the id of a row of another
   table (e.g. a spectrum's "field_id" refers to the "data_series" table).
 
 This module turns that information into plain table descriptions (`TableSchema`
 and `LinkerTableSchema`) that don't depend on any particular database - a
 backend (see :class:`~ixdat.backends.sqlite_backend.SQLiteBackend`) then turns
-those into real SQL. This does the same job PR #75
-(https://github.com/ixdat/ixdat/pull/75) set out to do, but by reading the
-class attributes ixdat already has instead of asking every class to redeclare
-its columns in a new format.
+those into real SQL. This continues the work started in PR #75
+(https://github.com/ixdat/ixdat/pull/75), using ixdat's existing class
+attributes as the source of truth.
 
 Classes that share a ``table_name`` (e.g. every Measurement subclass) share one
 main table; each subclass's own extra attributes go in its own extension table,
-linked back to the main table's id. Which subclass a row belongs to isn't
-stored as a separate column - it's worked out the same way the directory
-backend already does it, from a column like "technique" or "calculator_type".
+linked back to the main table's id. The backend determines a row's subclass the
+same way the directory backend does, from a column like "technique" or
+"calculator_type".
 
-A column's *logical type* tells a backend how to store its value:
-
-- "INTEGER", "REAL", "TEXT": plain numbers/text, stored as-is,
-- "JSON": dicts and lists, stored as JSON text,
-- "NDARRAY": numpy arrays, stored as a binary blob and only loaded when needed,
-- None: no fixed type; stored as whatever type the value already is.
+A column's Python type tells a backend how to store its value. The SQLite backend
+maps ``int``, ``float``, and ``str`` to scalar columns, ``dict``, ``list``, and
+``tuple`` to JSON, and ``numpy.ndarray`` to a lazily loaded binary payload. ``None``
+means that a column has no fixed type.
 
 A class states these in ``column_types``, alongside the ``column_attrs`` that
 introduce the columns, and they are merged over the class's ancestry by
-``Saveable.get_column_types()``. A column left out still works - it's just
-stored using whatever scalar type Python gives it - so a new class with a plain
-str/int/float attribute needs to declare nothing. ``column_references``, merged
-the same way by ``Saveable.get_column_references()``, says which columns hold
-the id of a row of another table, and thus become foreign keys.
+``Saveable.get_column_types()``. An undeclared scalar column uses its runtime
+Python type, so a new class with a plain str/int/float attribute needs no type
+declaration. ``column_references``, merged the same way by
+``Saveable.get_column_references()``, says which columns hold the id of a row of
+another table, and thus become foreign keys.
 
-Keeping this on the classes, rather than in a table here, is what lets a class
-outside of ixdat define columns of any type without ixdat knowing about it.
+Keeping this on the classes lets external ixdat classes define columns of any
+supported type through their own declarations.
 """
+
+import numpy as np
 
 from ..exceptions import DataBaseError
 
 
-KNOWN_COLUMN_TYPES = ("INTEGER", "REAL", "TEXT", "JSON", "NDARRAY")
+KNOWN_COLUMN_TYPES = (int, float, str, dict, list, tuple, np.ndarray)
+
+
+def _type_name(dtype):
+    """Return a readable name for a declared Python column type."""
+    if isinstance(dtype, str):
+        return dtype
+    return getattr(dtype, "__name__", repr(dtype))
 
 
 class ColumnSchema:
@@ -62,7 +68,7 @@ class ColumnSchema:
         Args:
             name (str): The name of the column, which is also the name of the
                 attribute of the Saveable class that it stores
-            dtype (str or None): The logical type of the column (see module
+            dtype (type or None): The Python type of the column (see module
                 docstring). None means unspecified/dynamic.
             foreign_key (tuple or None): The (table_name, column_name) that this
                 column's values refer to, if it is a foreign key
@@ -162,7 +168,7 @@ class LinkerTableSchema:
 
     @property
     def is_list(self):
-        """Whether the attribute holds a list of id's rather than a single id"""
+        """Whether the attribute holds a list of ids or one id."""
         return self.id_attr.endswith("_ids")
 
     def __repr__(self):
@@ -177,6 +183,32 @@ def _ordered(attrs):
     return sorted(attrs, key=lambda attr: (attr != "name", attr))
 
 
+def _validate_column_metadata(cls):
+    """Reject type or reference declarations for columns the class does not store."""
+    stored_attrs = set(cls.column_attrs or ())
+    for attrs in cls.get_extra_column_attrs().values():
+        stored_attrs.update(attrs)
+
+    declarations = {
+        "column_types": cls.get_column_types(),
+        "column_references": cls.get_column_references(),
+    }
+    for metadata_name, metadata in declarations.items():
+        unknown_attrs = set(metadata) - stored_attrs
+        if unknown_attrs:
+            raise DataBaseError(
+                f"{cls.__name__} declares {metadata_name} for unknown column(s): "
+                f"{', '.join(sorted(unknown_attrs))}."
+            )
+    for attr, dtype in declarations["column_types"].items():
+        if dtype is not None and dtype not in KNOWN_COLUMN_TYPES:
+            raise DataBaseError(
+                f"{cls.__name__} gives its column '{attr}' the unknown type "
+                f"{_type_name(dtype)!r}. The types a column can have are "
+                f"{', '.join(_type_name(known) for known in KNOWN_COLUMN_TYPES)}."
+            )
+
+
 def _columns(cls, attrs):
     """Return the ColumnSchemas for the named column attributes of a Saveable class"""
     types = cls.get_column_types()
@@ -184,18 +216,12 @@ def _columns(cls, attrs):
     columns = []
     for attr in _ordered(attrs):
         dtype = types.get(attr)
-        if dtype and dtype not in KNOWN_COLUMN_TYPES:
-            raise DataBaseError(
-                f"{cls.__name__} gives its column '{attr}' the unknown type "
-                f"'{dtype}'. The types a column can have are "
-                f"{', '.join(KNOWN_COLUMN_TYPES)}."
-            )
         referenced_table = references.get(attr)
         columns.append(
             ColumnSchema(
                 attr,
                 # a column holding another row's id is that id's type:
-                dtype="INTEGER" if referenced_table else dtype,
+                dtype=int if referenced_table else dtype,
                 foreign_key=(referenced_table, "id") if referenced_table else None,
             )
         )
@@ -204,36 +230,28 @@ def _columns(cls, attrs):
 
 def main_table_schema(cls):
     """Return the TableSchema of the main table of a Saveable class"""
-    columns = [ColumnSchema("id", dtype="INTEGER")]
+    _validate_column_metadata(cls)
+    columns = [ColumnSchema("id", dtype=int)]
     columns += _columns(cls, cls.column_attrs or [])
     return TableSchema(cls.table_name, columns)
 
 
 def extension_table_schemas(cls):
-    """Return the list of TableSchema of the extension tables of a Saveable class
-
-    Only looks at what `cls` itself declares in `extra_column_attrs`, not what its
-    parent classes declare. Usually fine, since a class only overrides this if it
-    needs its own extra columns - but a class inheriting from *two* table-defining
-    classes (like `ECMSMeasurement`) ends up only writing to its own extension
-    table, not its other parent's. See the "Known limitation" section of
-    docs/source/diving_deeper/backend.rst.
-    """
+    """Return the extension-table schemas of a Saveable class and its ancestors."""
+    _validate_column_metadata(cls)
     schemas = []
-    for table_name, attrs in (cls.extra_column_attrs or {}).items():
-        columns = [
-            ColumnSchema("id", dtype="INTEGER", foreign_key=(cls.table_name, "id"))
-        ]
+    for table_name, attrs in cls.get_extra_column_attrs().items():
+        columns = [ColumnSchema("id", dtype=int, foreign_key=(cls.table_name, "id"))]
         columns += _columns(cls, attrs)
         schemas.append(TableSchema(table_name, columns, extends=cls.table_name))
     return schemas
 
 
 def linker_table_schemas(cls):
-    """Return the list of LinkerTableSchema of the linker tables of a Saveable class"""
+    """Return the linker-table schemas of a Saveable class and its ancestors."""
     return [
         LinkerTableSchema(table_name, cls.table_name, linked_table, id_attr)
-        for table_name, (linked_table, id_attr) in (cls.extra_linkers or {}).items()
+        for table_name, (linked_table, id_attr) in cls.get_extra_linkers().items()
     ]
 
 
@@ -265,11 +283,10 @@ def saveable_classes():
 def family_table_schemas(cls):
     """Return the extension and linker tables of all classes sharing cls's main table
 
-    Before reading a row, we don't yet know which subclass it actually is (a row
-    in "measurement" could turn out to be an ECMSMeasurement, say), so a backend
-    needs to check the extension/linker tables of every class that could share
-    this main table, not just `cls`. A row will only actually have entries in the
-    tables its real class wrote to, so checking extra tables is harmless.
+    Before reading a row, its exact subclass is unknown (a row in "measurement"
+    could be an ECMSMeasurement, for example). A backend therefore checks the
+    extension/linker tables of every class that shares this main table. A row has
+    entries only in the tables its concrete class wrote to.
 
     Only classes that have already been imported can be found this way. Importing
     ixdat imports all of its own techniques, so this only matters for external

--- a/src/ixdat/backends/relational.py
+++ b/src/ixdat/backends/relational.py
@@ -1,47 +1,11 @@
-"""This module derives a relational database schema from ixdat's Saveable classes
+"""Derive backend-neutral table descriptions from Saveable metadata.
 
-Every Saveable class already says how it should be saved:
+This module converts the persistence information on Saveable classes into
+ColumnSchema, TableSchema, and LinkerTableSchema objects for relational
+backends.
 
-- ``table_name`` is the name of its main table,
-- ``column_attrs`` are the attributes stored as columns of that table,
-- ``extra_column_attrs`` names *extension tables*: one extra table per subclass
-  that adds its own columns without changing the shared main table (e.g. the
-  "ec_measurements" table adds "ec_technique" to rows of "measurement"), and
-- ``extra_linkers`` names *linker tables*, which record ordered references from
-  a row to several rows of another table (e.g. "measurement_series" records
-  which data series belong to which measurement, and in what order),
-- ``column_types`` gives the Python type of the columns where it matters, and
-- ``column_references`` names the columns which hold the id of a row of another
-  table (e.g. a spectrum's "field_id" refers to the "data_series" table).
-
-This module turns that information into plain table descriptions (`TableSchema`
-and `LinkerTableSchema`) that don't depend on any particular database - a
-backend (see :class:`~ixdat.backends.sqlite_backend.SQLiteBackend`) then turns
-those into real SQL. This continues the work started in PR #75
-(https://github.com/ixdat/ixdat/pull/75), using ixdat's existing class
-attributes as the source of truth.
-
-Classes that share a ``table_name`` (e.g. every Measurement subclass) share one
-main table; each subclass's own extra attributes go in its own extension table,
-linked back to the main table's id. The backend determines a row's subclass the
-same way the directory backend does, from a column like "technique" or
-"calculator_type".
-
-A column's Python type tells a backend how to store its value. The SQLite backend
-maps ``int``, ``float``, and ``str`` to scalar columns, ``dict``, ``list``, and
-``tuple`` to JSON, and ``numpy.ndarray`` to a lazily loaded binary payload. ``None``
-means that a column has no fixed type.
-
-A class states these in ``column_types``, alongside the ``column_attrs`` that
-introduce the columns, and they are merged over the class's ancestry by
-``Saveable.get_column_types()``. An undeclared scalar column uses its runtime
-Python type, so a new class with a plain str/int/float attribute needs no type
-declaration. ``column_references``, merged the same way by
-``Saveable.get_column_references()``, says which columns hold the id of a row of
-another table, and thus become foreign keys.
-
-Keeping this on the classes lets external ixdat classes define columns of any
-supported type through their own declarations.
+See :ref:`backend` for the persistence model, supported types, inheritance,
+and linked objects.
 """
 
 import numpy as np

--- a/src/ixdat/backends/relational.py
+++ b/src/ixdat/backends/relational.py
@@ -63,18 +63,18 @@ class TableSchema:
     table (see module docstring).
     """
 
-    def __init__(self, name, columns, extends=None):
+    def __init__(self, name, columns, base_table=None):
         """Initiate a table description
 
         Args:
             name (str): The name of the table
             columns (list of ColumnSchema): The columns, starting with "id"
-            extends (str or None): The name of the main table this table
-                extends, if it is an extension table
+            base_table (str or None): The name of the main table this extension
+                table adds values to
         """
         self.name = name
         self.columns = columns
-        self.extends = extends
+        self.base_table = base_table
 
     @property
     def column_names(self):
@@ -90,16 +90,16 @@ class TableSchema:
 
 
 class LinkerTableSchema:
-    """The description of a many-to-many linker table
+    """The description of a table which stores connections between saved objects
 
     A linker table relates rows of an owner table to rows of a linked table,
-    preserving order. For example, "measurement_series" has the columns
+    preserving order for a list. For example, "measurement_series" has the columns
     (measurement_id, position, data_series_id), and each of its rows represents
     a measurement's ownership of one data series. Its rows are built from and
-    loaded into the id-list attribute (e.g. "s_ids") of the owner class.
+    loaded into the id attribute (e.g. "s_ids") of the owner class.
     """
 
-    def __init__(self, name, owner_table, linked_table, id_attr):
+    def __init__(self, name, owner_table, linked_table, id_attr, many):
         """Initiate a linker table description
 
         Args:
@@ -107,14 +107,17 @@ class LinkerTableSchema:
             owner_table (str): The name of the owning main table
             linked_table (str): The name of the table linked to
             id_attr (str): The attribute of the owner class with the id or
-                ordered id's of the linked rows. By ixdat convention, id-list
-                attributes end in "_ids" (e.g. "s_ids") while single-reference
-                attributes end in "_id" (e.g. "ref_id").
+                ordered ids of the linked rows
+            many (bool): Whether the id attribute holds an ordered list. New
+                ``Relationship`` definitions provide this directly. Older
+                ``extra_linkers`` definitions use their established ``_ids`` naming
+                rule.
         """
         self.name = name
         self.owner_table = owner_table
         self.linked_table = linked_table
         self.id_attr = id_attr
+        self.many = many
 
     @property
     def owner_column(self):
@@ -130,11 +133,6 @@ class LinkerTableSchema:
             return "linked_" + self.linked_table + "_id"
         return self.linked_table + "_id"
 
-    @property
-    def is_list(self):
-        """Whether the attribute holds a list of ids or one id."""
-        return self.id_attr.endswith("_ids")
-
     def __repr__(self):
         return (
             f"LinkerTableSchema('{self.name}', "
@@ -149,7 +147,7 @@ def _ordered(attrs):
 
 def _validate_column_metadata(cls):
     """Reject type or reference declarations for columns the class does not store."""
-    stored_attrs = set(cls.column_attrs or ())
+    stored_attrs = set(cls.get_main_column_attrs())
     for attrs in cls.get_extra_column_attrs().values():
         stored_attrs.update(attrs)
 
@@ -196,7 +194,7 @@ def main_table_schema(cls):
     """Return the TableSchema of the main table of a Saveable class"""
     _validate_column_metadata(cls)
     columns = [ColumnSchema("id", dtype=int)]
-    columns += _columns(cls, cls.column_attrs or [])
+    columns += _columns(cls, cls.get_main_column_attrs())
     return TableSchema(cls.table_name, columns)
 
 
@@ -207,14 +205,29 @@ def extension_table_schemas(cls):
     for table_name, attrs in cls.get_extra_column_attrs().items():
         columns = [ColumnSchema("id", dtype=int, foreign_key=(cls.table_name, "id"))]
         columns += _columns(cls, attrs)
-        schemas.append(TableSchema(table_name, columns, extends=cls.table_name))
+        schemas.append(TableSchema(table_name, columns, base_table=cls.table_name))
     return schemas
 
 
 def linker_table_schemas(cls):
-    """Return the linker-table schemas of a Saveable class and its ancestors."""
+    """Return the connection-table schemas of a Saveable class and its ancestors.
+
+    New relationships state ``many`` directly. Older ``extra_linkers`` declarations
+    keep their established rule: an id attribute ending in ``_ids`` contains a list.
+    """
+    many_by_table = {
+        relationship.storage_table: relationship.many
+        for relationship in cls.get_relationships().values()
+        if relationship.many
+    }
     return [
-        LinkerTableSchema(table_name, cls.table_name, linked_table, id_attr)
+        LinkerTableSchema(
+            table_name,
+            cls.table_name,
+            linked_table,
+            id_attr,
+            many=many_by_table.get(table_name, id_attr.endswith("_ids")),
+        )
         for table_name, (linked_table, id_attr) in cls.get_extra_linkers().items()
     ]
 

--- a/src/ixdat/backends/relational.py
+++ b/src/ixdat/backends/relational.py
@@ -1,0 +1,287 @@
+"""This module derives a relational database schema from ixdat's Saveable classes
+
+Every Saveable class already describes its own persistence declaratively:
+
+- ``table_name`` names the main table of the class,
+- ``column_attrs`` names the attributes stored as columns of the main table,
+- ``extra_column_attrs`` names one-to-one *extension tables* which add columns
+  for inheriting classes without changing the main table (e.g. the
+  "ec_measurements" table adds "ec_technique" to rows of "measurement"), and
+- ``extra_linkers`` names many-to-many *linker tables* which relate rows of the
+  main table to rows of another table in an ordered way (e.g. the
+  "measurement_series" table relates a measurement to its data series).
+
+This module turns that metadata into explicit, dialect-free table descriptions
+(`TableSchema` and `LinkerTableSchema`), which a relational backend (see
+:class:`~ixdat.backends.sqlite_backend.SQLiteBackend`) translates into DDL and
+queries. It is the successor to the table definitions proposed in
+https://github.com/ixdat/ixdat/pull/75, but derives the schema from the class
+attributes which ixdat already maintains instead of introducing new ones.
+
+Class inheritance maps to the database as follows: all classes sharing a
+``table_name`` (e.g. all Measurement subclasses) share the main table, and each
+subclass stores its additional attributes in its extension tables, joined on the
+main table's primary key. A row's concrete class is not stored explicitly; it is
+recovered by the classes' own ``from_dict`` dispatch (on "technique",
+"series_type" or "calculator_type"), exactly as for the directory backend.
+
+Columns have a *logical type*, used by backends to decide how a value is encoded:
+
+- "INTEGER", "REAL", "TEXT": scalars, stored natively,
+- "JSON": dicts and lists, stored as JSON text,
+- "NDARRAY": numpy arrays, stored as binary blobs and loaded lazily,
+- None: unspecified; stored as whatever scalar type the value has.
+
+The logical types of ixdat's known column attributes are collected here in
+``COLUMN_TYPES``; attributes not listed are stored dynamically, so a class with
+new str/int/float attributes works without any registration.
+"""
+
+COLUMN_TYPES = {
+    # numpy data, stored as a blob and loaded lazily:
+    "data": "NDARRAY",
+    # json-serializable dicts and lists:
+    "metadata": "JSON",
+    "aliases": "JSON",
+    "tspan_bg": "JSON",
+    # known floats:
+    "tstamp": "REAL",
+    "bg": "REAL",
+    "F": "REAL",
+    "RE_vs_RHE": "REAL",
+    "A_el": "REAL",
+    "R_Ohm": "REAL",
+    # known strings:
+    "name": "TEXT",
+    "technique": "TEXT",
+    "ec_technique": "TEXT",
+    "unit_name": "TEXT",
+    "series_type": "TEXT",
+    "sample_name": "TEXT",
+    "calculator_type": "TEXT",
+    "mol": "TEXT",
+    "mass": "TEXT",
+    "cal_type": "TEXT",
+    # single references to rows of other tables:
+    "field_id": "INTEGER",
+    "spectrum_id": "INTEGER",
+}
+
+FOREIGN_KEY_COLUMNS = {
+    # {column attribute: the (table, column) its value refers to}
+    "field_id": ("data_series", "id"),
+    "spectrum_id": ("spectrums", "id"),
+}
+
+
+class ColumnSchema:
+    """The description of one column of a table"""
+
+    def __init__(self, name, dtype=None, foreign_key=None):
+        """Initiate a column description
+
+        Args:
+            name (str): The name of the column, which is also the name of the
+                attribute of the Saveable class that it stores
+            dtype (str or None): The logical type of the column (see module
+                docstring). None means unspecified/dynamic.
+            foreign_key (tuple or None): The (table_name, column_name) that this
+                column's values refer to, if it is a foreign key
+        """
+        self.name = name
+        self.dtype = dtype
+        self.foreign_key = foreign_key
+
+    def __repr__(self):
+        return f"ColumnSchema('{self.name}', dtype={self.dtype})"
+
+    def __eq__(self, other):
+        return (
+            self.__class__ is other.__class__
+            and self.name == other.name
+            and self.dtype == other.dtype
+            and self.foreign_key == other.foreign_key
+        )
+
+
+class TableSchema:
+    """The description of a main table or a one-to-one extension table
+
+    A main table has one row per object and an "id" primary key column. An
+    extension table also has one row per object, but its "id" column is both
+    primary key and foreign key to the main table it extends - this is how
+    columns of inheriting classes are represented without changing the main
+    table (see module docstring).
+    """
+
+    def __init__(self, name, columns, extends=None):
+        """Initiate a table description
+
+        Args:
+            name (str): The name of the table
+            columns (list of ColumnSchema): The columns, starting with "id"
+            extends (str or None): The name of the main table this table
+                extends, if it is an extension table
+        """
+        self.name = name
+        self.columns = columns
+        self.extends = extends
+
+    @property
+    def column_names(self):
+        return [column.name for column in self.columns]
+
+    @property
+    def data_columns(self):
+        """The columns which hold attribute values, i.e. all but "id" """
+        return [column for column in self.columns if column.name != "id"]
+
+    def __repr__(self):
+        return f"TableSchema('{self.name}', columns={self.column_names})"
+
+
+class LinkerTableSchema:
+    """The description of a many-to-many linker table
+
+    A linker table relates rows of an owner table to rows of a linked table,
+    preserving order. For example, "measurement_series" has the columns
+    (measurement_id, position, data_series_id), and each of its rows represents
+    a measurement's ownership of one data series. Its rows are built from and
+    loaded into the id-list attribute (e.g. "s_ids") of the owner class.
+    """
+
+    def __init__(self, name, owner_table, linked_table, id_attr):
+        """Initiate a linker table description
+
+        Args:
+            name (str): The name of the linker table
+            owner_table (str): The name of the owning main table
+            linked_table (str): The name of the table linked to
+            id_attr (str): The attribute of the owner class with the id or
+                ordered id's of the linked rows. By ixdat convention, id-list
+                attributes end in "_ids" (e.g. "s_ids") while single-reference
+                attributes end in "_id" (e.g. "ref_id").
+        """
+        self.name = name
+        self.owner_table = owner_table
+        self.linked_table = linked_table
+        self.id_attr = id_attr
+
+    @property
+    def owner_column(self):
+        """The name of the column with the id of the owning row"""
+        return self.owner_table + "_id"
+
+    @property
+    def linked_column(self):
+        """The name of the column with the id of the linked row"""
+        if self.linked_table == self.owner_table:
+            # e.g. "component_measurements", which links measurements to
+            # measurements, gets the columns (measurement_id, linked_measurement_id)
+            return "linked_" + self.linked_table + "_id"
+        return self.linked_table + "_id"
+
+    @property
+    def is_list(self):
+        """Whether the attribute holds a list of id's rather than a single id"""
+        return self.id_attr.endswith("_ids")
+
+    def __repr__(self):
+        return (
+            f"LinkerTableSchema('{self.name}', "
+            f"{self.owner_table} -> {self.linked_table})"
+        )
+
+
+def _ordered(attrs):
+    """Return the attribute names in deterministic order, with "name" first"""
+    return sorted(attrs, key=lambda attr: (attr != "name", attr))
+
+
+def _column(attr):
+    """Return the ColumnSchema for a column attribute"""
+    return ColumnSchema(
+        attr,
+        dtype=COLUMN_TYPES.get(attr),
+        foreign_key=FOREIGN_KEY_COLUMNS.get(attr),
+    )
+
+
+def main_table_schema(cls):
+    """Return the TableSchema of the main table of a Saveable class"""
+    columns = [ColumnSchema("id", dtype="INTEGER")]
+    columns += [_column(attr) for attr in _ordered(cls.column_attrs or [])]
+    return TableSchema(cls.table_name, columns)
+
+
+def extension_table_schemas(cls):
+    """Return the list of TableSchema of the extension tables of a Saveable class"""
+    schemas = []
+    for table_name, attrs in (cls.extra_column_attrs or {}).items():
+        columns = [
+            ColumnSchema("id", dtype="INTEGER", foreign_key=(cls.table_name, "id"))
+        ]
+        columns += [_column(attr) for attr in _ordered(attrs)]
+        schemas.append(TableSchema(table_name, columns, extends=cls.table_name))
+    return schemas
+
+
+def linker_table_schemas(cls):
+    """Return the list of LinkerTableSchema of the linker tables of a Saveable class"""
+    return [
+        LinkerTableSchema(table_name, cls.table_name, linked_table, id_attr)
+        for table_name, (linked_table, id_attr) in (cls.extra_linkers or {}).items()
+    ]
+
+
+def table_schemas_of(cls):
+    """Return all table descriptions needed to save objects of a Saveable class"""
+    return (
+        [main_table_schema(cls)]
+        + extension_table_schemas(cls)
+        + linker_table_schemas(cls)
+    )
+
+
+def saveable_classes():
+    """Return the list of all imported Saveable classes"""
+    from ..db import Saveable  # here to avoid circular import
+
+    classes = []
+
+    def collect(cls):
+        for subclass in cls.__subclasses__():
+            if subclass not in classes:
+                classes.append(subclass)
+            collect(subclass)
+
+    collect(Saveable)
+    return classes
+
+
+def family_table_schemas(cls):
+    """Return the extension and linker tables of all classes sharing cls's main table
+
+    When loading a row, the concrete class is not known in advance (e.g.
+    `Measurement.get(i)` may need to build an ECMSMeasurement), so a backend
+    collects the row's attributes from every extension and linker table that any
+    class sharing the main table defines. Each row only has entries in the
+    tables its concrete class wrote, so no wrong attributes are picked up.
+
+    Only classes that have been imported are found. Importing ixdat imports all
+    of its own techniques, so this is only a consideration for external plugins.
+
+    Returns:
+        (list of TableSchema, list of LinkerTableSchema): The extension table
+            and linker table descriptions, deduplicated by table name.
+    """
+    extension_schemas = {}
+    linker_schemas = {}
+    for family_cls in saveable_classes():
+        if family_cls.table_name != cls.table_name:
+            continue
+        for schema in extension_table_schemas(family_cls):
+            extension_schemas.setdefault(schema.name, schema)
+        for schema in linker_table_schemas(family_cls):
+            linker_schemas.setdefault(schema.name, schema)
+    return list(extension_schemas.values()), list(linker_schemas.values())

--- a/src/ixdat/backends/relational.py
+++ b/src/ixdat/backends/relational.py
@@ -9,7 +9,10 @@ Every Saveable class already says how it should be saved:
   "ec_measurements" table adds "ec_technique" to rows of "measurement"), and
 - ``extra_linkers`` names *linker tables*, which record ordered references from
   a row to several rows of another table (e.g. "measurement_series" records
-  which data series belong to which measurement, and in what order).
+  which data series belong to which measurement, and in what order),
+- ``column_types`` gives the *logical type* of the columns where it matters, and
+- ``column_references`` names the columns which hold the id of a row of another
+  table (e.g. a spectrum's "field_id" refers to the "data_series" table).
 
 This module turns that information into plain table descriptions (`TableSchema`
 and `LinkerTableSchema`) that don't depend on any particular database - a
@@ -25,55 +28,29 @@ linked back to the main table's id. Which subclass a row belongs to isn't
 stored as a separate column - it's worked out the same way the directory
 backend already does it, from a column like "technique" or "calculator_type".
 
-Each column also has a *logical type*, which tells a backend how to store a
-value:
+A column's *logical type* tells a backend how to store its value:
 
 - "INTEGER", "REAL", "TEXT": plain numbers/text, stored as-is,
 - "JSON": dicts and lists, stored as JSON text,
 - "NDARRAY": numpy arrays, stored as a binary blob and only loaded when needed,
 - None: no fixed type; stored as whatever type the value already is.
 
-``COLUMN_TYPES`` below lists the logical type for every attribute name ixdat
-already knows about. Anything not listed still works - it's just stored using
-whatever scalar type Python gives it - so a new class with a plain str/int/float
-attribute needs no changes here.
+A class states these in ``column_types``, alongside the ``column_attrs`` that
+introduce the columns, and they are merged over the class's ancestry by
+``Saveable.get_column_types()``. A column left out still works - it's just
+stored using whatever scalar type Python gives it - so a new class with a plain
+str/int/float attribute needs to declare nothing. ``column_references``, merged
+the same way by ``Saveable.get_column_references()``, says which columns hold
+the id of a row of another table, and thus become foreign keys.
+
+Keeping this on the classes, rather than in a table here, is what lets a class
+outside of ixdat define columns of any type without ixdat knowing about it.
 """
 
-COLUMN_TYPES = {
-    # numpy data, stored as a blob and loaded lazily:
-    "data": "NDARRAY",
-    # json-serializable dicts and lists:
-    "metadata": "JSON",
-    "aliases": "JSON",
-    "tspan_bg": "JSON",
-    # known floats:
-    "tstamp": "REAL",
-    "bg": "REAL",
-    "F": "REAL",
-    "RE_vs_RHE": "REAL",
-    "A_el": "REAL",
-    "R_Ohm": "REAL",
-    # known strings:
-    "name": "TEXT",
-    "technique": "TEXT",
-    "ec_technique": "TEXT",
-    "unit_name": "TEXT",
-    "series_type": "TEXT",
-    "sample_name": "TEXT",
-    "calculator_type": "TEXT",
-    "mol": "TEXT",
-    "mass": "TEXT",
-    "cal_type": "TEXT",
-    # single references to rows of other tables:
-    "field_id": "INTEGER",
-    "spectrum_id": "INTEGER",
-}
+from ..exceptions import DataBaseError
 
-FOREIGN_KEY_COLUMNS = {
-    # {column attribute: the (table, column) its value refers to}
-    "field_id": ("data_series", "id"),
-    "spectrum_id": ("spectrums", "id"),
-}
+
+KNOWN_COLUMN_TYPES = ("INTEGER", "REAL", "TEXT", "JSON", "NDARRAY")
 
 
 class ColumnSchema:
@@ -200,19 +177,35 @@ def _ordered(attrs):
     return sorted(attrs, key=lambda attr: (attr != "name", attr))
 
 
-def _column(attr):
-    """Return the ColumnSchema for a column attribute"""
-    return ColumnSchema(
-        attr,
-        dtype=COLUMN_TYPES.get(attr),
-        foreign_key=FOREIGN_KEY_COLUMNS.get(attr),
-    )
+def _columns(cls, attrs):
+    """Return the ColumnSchemas for the named column attributes of a Saveable class"""
+    types = cls.get_column_types()
+    references = cls.get_column_references()
+    columns = []
+    for attr in _ordered(attrs):
+        dtype = types.get(attr)
+        if dtype and dtype not in KNOWN_COLUMN_TYPES:
+            raise DataBaseError(
+                f"{cls.__name__} gives its column '{attr}' the unknown type "
+                f"'{dtype}'. The types a column can have are "
+                f"{', '.join(KNOWN_COLUMN_TYPES)}."
+            )
+        referenced_table = references.get(attr)
+        columns.append(
+            ColumnSchema(
+                attr,
+                # a column holding another row's id is that id's type:
+                dtype="INTEGER" if referenced_table else dtype,
+                foreign_key=(referenced_table, "id") if referenced_table else None,
+            )
+        )
+    return columns
 
 
 def main_table_schema(cls):
     """Return the TableSchema of the main table of a Saveable class"""
     columns = [ColumnSchema("id", dtype="INTEGER")]
-    columns += [_column(attr) for attr in _ordered(cls.column_attrs or [])]
+    columns += _columns(cls, cls.column_attrs or [])
     return TableSchema(cls.table_name, columns)
 
 
@@ -231,7 +224,7 @@ def extension_table_schemas(cls):
         columns = [
             ColumnSchema("id", dtype="INTEGER", foreign_key=(cls.table_name, "id"))
         ]
-        columns += [_column(attr) for attr in _ordered(attrs)]
+        columns += _columns(cls, attrs)
         schemas.append(TableSchema(table_name, columns, extends=cls.table_name))
     return schemas
 

--- a/src/ixdat/backends/relational.py
+++ b/src/ixdat/backends/relational.py
@@ -275,6 +275,10 @@ def family_table_schemas(cls):
     ixdat imports all of its own techniques, so this only matters for external
     plugin classes that haven't been imported yet.
 
+    A class whose own table metadata is broken is skipped here, so that one
+    misdeclared class doesn't stop every other row of the shared main table from
+    being read. Its error is raised when that class is itself saved or loaded.
+
     Returns:
         (list of TableSchema, list of LinkerTableSchema): The extension table
             and linker table descriptions, deduplicated by table name.
@@ -284,8 +288,15 @@ def family_table_schemas(cls):
     for family_cls in saveable_classes():
         if family_cls.table_name != cls.table_name:
             continue
-        for schema in extension_table_schemas(family_cls):
+        try:
+            found_extensions = extension_table_schemas(family_cls)
+            found_linkers = linker_table_schemas(family_cls)
+        except DataBaseError:
+            if family_cls is cls:
+                raise  # cls is the class we were asked about, so it must be right
+            continue  # a sibling of cls; the row being read doesn't need it
+        for schema in found_extensions:
             extension_schemas.setdefault(schema.name, schema)
-        for schema in linker_table_schemas(family_cls):
+        for schema in found_linkers:
             linker_schemas.setdefault(schema.name, schema)
     return list(extension_schemas.values()), list(linker_schemas.values())

--- a/src/ixdat/backends/relational.py
+++ b/src/ixdat/backends/relational.py
@@ -215,7 +215,14 @@ def main_table_schema(cls):
 
 
 def extension_table_schemas(cls):
-    """Return the list of TableSchema of the extension tables of a Saveable class"""
+    """Return the list of TableSchema of the extension tables of a Saveable class
+
+    Note: this reads `cls.extra_column_attrs` directly, i.e. only what `cls` itself
+    declares. A class inheriting from more than one table-defining class (such as
+    `ECMSMeasurement`) has its own `extra_column_attrs` *replace* rather than merge
+    with its parents', so it writes only to the extension table it declares itself.
+    See the "Known limitation" section in docs/source/diving_deeper/backend.rst.
+    """
     schemas = []
     for table_name, attrs in (cls.extra_column_attrs or {}).items():
         columns = [

--- a/src/ixdat/backends/relational.py
+++ b/src/ixdat/backends/relational.py
@@ -1,40 +1,42 @@
 """This module derives a relational database schema from ixdat's Saveable classes
 
-Every Saveable class already describes its own persistence declaratively:
+Every Saveable class already says how it should be saved:
 
-- ``table_name`` names the main table of the class,
-- ``column_attrs`` names the attributes stored as columns of the main table,
-- ``extra_column_attrs`` names one-to-one *extension tables* which add columns
-  for inheriting classes without changing the main table (e.g. the
+- ``table_name`` is the name of its main table,
+- ``column_attrs`` are the attributes stored as columns of that table,
+- ``extra_column_attrs`` names *extension tables*: one extra table per subclass
+  that adds its own columns without changing the shared main table (e.g. the
   "ec_measurements" table adds "ec_technique" to rows of "measurement"), and
-- ``extra_linkers`` names many-to-many *linker tables* which relate rows of the
-  main table to rows of another table in an ordered way (e.g. the
-  "measurement_series" table relates a measurement to its data series).
+- ``extra_linkers`` names *linker tables*, which record ordered references from
+  a row to several rows of another table (e.g. "measurement_series" records
+  which data series belong to which measurement, and in what order).
 
-This module turns that metadata into explicit, dialect-free table descriptions
-(`TableSchema` and `LinkerTableSchema`), which a relational backend (see
-:class:`~ixdat.backends.sqlite_backend.SQLiteBackend`) translates into DDL and
-queries. It is the successor to the table definitions proposed in
-https://github.com/ixdat/ixdat/pull/75, but derives the schema from the class
-attributes which ixdat already maintains instead of introducing new ones.
+This module turns that information into plain table descriptions (`TableSchema`
+and `LinkerTableSchema`) that don't depend on any particular database - a
+backend (see :class:`~ixdat.backends.sqlite_backend.SQLiteBackend`) then turns
+those into real SQL. This does the same job PR #75
+(https://github.com/ixdat/ixdat/pull/75) set out to do, but by reading the
+class attributes ixdat already has instead of asking every class to redeclare
+its columns in a new format.
 
-Class inheritance maps to the database as follows: all classes sharing a
-``table_name`` (e.g. all Measurement subclasses) share the main table, and each
-subclass stores its additional attributes in its extension tables, joined on the
-main table's primary key. A row's concrete class is not stored explicitly; it is
-recovered by the classes' own ``from_dict`` dispatch (on "technique",
-"series_type" or "calculator_type"), exactly as for the directory backend.
+Classes that share a ``table_name`` (e.g. every Measurement subclass) share one
+main table; each subclass's own extra attributes go in its own extension table,
+linked back to the main table's id. Which subclass a row belongs to isn't
+stored as a separate column - it's worked out the same way the directory
+backend already does it, from a column like "technique" or "calculator_type".
 
-Columns have a *logical type*, used by backends to decide how a value is encoded:
+Each column also has a *logical type*, which tells a backend how to store a
+value:
 
-- "INTEGER", "REAL", "TEXT": scalars, stored natively,
+- "INTEGER", "REAL", "TEXT": plain numbers/text, stored as-is,
 - "JSON": dicts and lists, stored as JSON text,
-- "NDARRAY": numpy arrays, stored as binary blobs and loaded lazily,
-- None: unspecified; stored as whatever scalar type the value has.
+- "NDARRAY": numpy arrays, stored as a binary blob and only loaded when needed,
+- None: no fixed type; stored as whatever type the value already is.
 
-The logical types of ixdat's known column attributes are collected here in
-``COLUMN_TYPES``; attributes not listed are stored dynamically, so a class with
-new str/int/float attributes works without any registration.
+``COLUMN_TYPES`` below lists the logical type for every attribute name ixdat
+already knows about. Anything not listed still works - it's just stored using
+whatever scalar type Python gives it - so a new class with a plain str/int/float
+attribute needs no changes here.
 """
 
 COLUMN_TYPES = {
@@ -217,11 +219,12 @@ def main_table_schema(cls):
 def extension_table_schemas(cls):
     """Return the list of TableSchema of the extension tables of a Saveable class
 
-    Note: this reads `cls.extra_column_attrs` directly, i.e. only what `cls` itself
-    declares. A class inheriting from more than one table-defining class (such as
-    `ECMSMeasurement`) has its own `extra_column_attrs` *replace* rather than merge
-    with its parents', so it writes only to the extension table it declares itself.
-    See the "Known limitation" section in docs/source/diving_deeper/backend.rst.
+    Only looks at what `cls` itself declares in `extra_column_attrs`, not what its
+    parent classes declare. Usually fine, since a class only overrides this if it
+    needs its own extra columns - but a class inheriting from *two* table-defining
+    classes (like `ECMSMeasurement`) ends up only writing to its own extension
+    table, not its other parent's. See the "Known limitation" section of
+    docs/source/diving_deeper/backend.rst.
     """
     schemas = []
     for table_name, attrs in (cls.extra_column_attrs or {}).items():
@@ -269,14 +272,15 @@ def saveable_classes():
 def family_table_schemas(cls):
     """Return the extension and linker tables of all classes sharing cls's main table
 
-    When loading a row, the concrete class is not known in advance (e.g.
-    `Measurement.get(i)` may need to build an ECMSMeasurement), so a backend
-    collects the row's attributes from every extension and linker table that any
-    class sharing the main table defines. Each row only has entries in the
-    tables its concrete class wrote, so no wrong attributes are picked up.
+    Before reading a row, we don't yet know which subclass it actually is (a row
+    in "measurement" could turn out to be an ECMSMeasurement, say), so a backend
+    needs to check the extension/linker tables of every class that could share
+    this main table, not just `cls`. A row will only actually have entries in the
+    tables its real class wrote to, so checking extra tables is harmless.
 
-    Only classes that have been imported are found. Importing ixdat imports all
-    of its own techniques, so this is only a consideration for external plugins.
+    Only classes that have already been imported can be found this way. Importing
+    ixdat imports all of its own techniques, so this only matters for external
+    plugin classes that haven't been imported yet.
 
     Returns:
         (list of TableSchema, list of LinkerTableSchema): The extension table

--- a/src/ixdat/backends/relational.py
+++ b/src/ixdat/backends/relational.py
@@ -215,8 +215,8 @@ def linker_table_schemas(cls):
     New relationships state ``many`` directly. Older ``extra_linkers`` declarations
     keep their established rule: an id attribute ending in ``_ids`` contains a list.
     """
-    many_by_table = {
-        relationship.storage_table: relationship.many
+    many_tables = {
+        relationship.storage_table
         for relationship in cls.get_relationships().values()
         if relationship.many
     }
@@ -226,7 +226,7 @@ def linker_table_schemas(cls):
             cls.table_name,
             linked_table,
             id_attr,
-            many=many_by_table.get(table_name, id_attr.endswith("_ids")),
+            many=table_name in many_tables or id_attr.endswith("_ids"),
         )
         for table_name, (linked_table, id_attr) in cls.get_extra_linkers().items()
     ]

--- a/src/ixdat/backends/sqlite_backend.py
+++ b/src/ixdat/backends/sqlite_backend.py
@@ -48,6 +48,15 @@ from ..exceptions import DataBaseError
 DATABASE_FILE_SUFFIX = ".sqlite"
 SCHEMA_VERSION = 1
 METADATA_TABLE = "_ixdat_metadata"
+SQLITE_TYPES = {
+    int: "INTEGER",
+    float: "REAL",
+    str: "TEXT",
+    dict: "JSON",
+    list: "JSON",
+    tuple: "JSON",
+    np.ndarray: "NDARRAY",
+}
 
 
 def _quote_identifier(identifier):
@@ -100,7 +109,7 @@ class SQLiteBackend(BackendBase):
     @property
     def address(self):
         """The path to the SQLite database file"""
-        return str(self.db_path)
+        return str(self.db_path if self._is_memory else self._resolved_path)
 
     def close(self):
         """Close the connection to the database file"""
@@ -226,7 +235,7 @@ class SQLiteBackend(BackendBase):
     def _save_action(self, obj, force, updates_forbidden, existing_tables):
         """Return ``insert``, ``update``, or ``skip`` for one planned object."""
         row_exists = False
-        if obj.backend is self and obj.table_name in existing_tables:
+        if obj.backend == self and obj.table_name in existing_tables:
             row_exists = self.connection.execute(
                 f"SELECT 1 FROM {_quote_identifier(obj.table_name)} " 'WHERE "id" = ?',
                 (obj.id,),
@@ -339,9 +348,11 @@ class SQLiteBackend(BackendBase):
         existing_tables = self._ensure_existing_family_tables(
             extension_schemas + linker_schemas
         )
-        # Leave NDARRAY columns out of the query; `load_obj_data` gets them lazily:
+        # Leave ndarray columns out; `load_obj_data` gets them lazily:
         columns = [
-            column for column in main_schema.data_columns if column.dtype != "NDARRAY"
+            column
+            for column in main_schema.data_columns
+            if column.dtype is not np.ndarray
         ]
         row = self.connection.execute(
             _select_sql(main_schema.name, [column.name for column in columns])
@@ -357,7 +368,7 @@ class SQLiteBackend(BackendBase):
             for column, value in zip(columns, row)
         }
         for column in main_schema.data_columns:
-            if column.dtype == "NDARRAY":
+            if column.dtype is np.ndarray:
                 obj_as_dict[column.name] = None  # signals lazy loading
         for schema in extension_schemas:
             if schema.name not in existing_tables:
@@ -410,10 +421,10 @@ class SQLiteBackend(BackendBase):
         return self.get(cls, row[0])
 
     def load_obj_data(self, obj):
-        """Return the numerical data of an object, from its NDARRAY column"""
+        """Return the numerical data of an object from its ndarray column."""
         main_schema = relational.main_table_schema(type(obj))
         for column in main_schema.data_columns:
-            if column.dtype == "NDARRAY":
+            if column.dtype is np.ndarray:
                 row = self.connection.execute(
                     _select_sql(main_schema.name, [column.name]) + ' WHERE "id" = ?',
                     (obj.id,),
@@ -581,7 +592,7 @@ class SQLiteBackend(BackendBase):
                 )
                 continue
             actual = table_info[column.name]
-            expected_type = column.dtype or ""
+            expected_type = SQLITE_TYPES.get(column.dtype, "")
             if expected_type and actual["type"] != expected_type:
                 self._incompatible_schema(
                     schema.name,
@@ -677,11 +688,11 @@ class SQLiteBackend(BackendBase):
         value = self._dereference(value)
         if value is None:
             return None
-        if column.dtype == "NDARRAY":
+        if column.dtype is np.ndarray:
             buffer = BytesIO()
             np.save(buffer, np.asarray(value), allow_pickle=False)
             return sqlite3.Binary(buffer.getvalue())
-        if column.dtype == "JSON":
+        if column.dtype in (dict, list, tuple):
             # metadata dicts sometimes contain numpy numbers/arrays, which plain
             # json.dumps can't handle - convert those to normal Python values first:
             from ..tools import to_jsonable
@@ -693,7 +704,7 @@ class SQLiteBackend(BackendBase):
             raise DataBaseError(
                 f"Can't save value {value!r} in the dynamically typed column "
                 f"'{column.name}'. If this column should hold dicts/lists or numpy "
-                f"arrays, give it the type 'JSON' or 'NDARRAY', respectively, in "
+                f"arrays, give it the type dict/list or numpy.ndarray in "
                 "the `column_types` of the class which defines the column."
             )
         return value
@@ -702,10 +713,11 @@ class SQLiteBackend(BackendBase):
         """Return the python representation of a value, per its column's dtype"""
         if value is None:
             return None
-        if column.dtype == "NDARRAY":
+        if column.dtype is np.ndarray:
             return np.load(BytesIO(value), allow_pickle=False)
-        if column.dtype == "JSON":
-            return json.loads(value)
+        if column.dtype in (dict, list, tuple):
+            decoded = json.loads(value)
+            return tuple(decoded) if column.dtype is tuple else decoded
         return value
 
     def _dereference(self, value):
@@ -759,7 +771,7 @@ def _column_definition(column, include_primary_key=True):
     """Return the DDL fragment defining one regular table column."""
     definition = _quote_identifier(column.name)
     if column.dtype:
-        definition += " " + column.dtype
+        definition += " " + SQLITE_TYPES[column.dtype]
     if include_primary_key and column.name == "id":
         definition += " PRIMARY KEY"
     if column.foreign_key:

--- a/src/ixdat/backends/sqlite_backend.py
+++ b/src/ixdat/backends/sqlite_backend.py
@@ -692,8 +692,15 @@ class SQLiteBackend(BackendBase):
         if value is None:
             return None
         if column.dtype is np.ndarray:
+            array = np.asarray(value)
+            # Pandas represents text columns as object arrays. NumPy can save the
+            # same strings without pickle once they use its native Unicode type.
+            if array.dtype == object and all(
+                isinstance(item, str) for item in array.flat
+            ):
+                array = array.astype(str)
             buffer = BytesIO()
-            np.save(buffer, np.asarray(value), allow_pickle=False)
+            np.save(buffer, array, allow_pickle=False)
             return sqlite3.Binary(buffer.getvalue())
         if column.dtype in (dict, list, tuple):
             # metadata dicts sometimes contain numpy numbers/arrays, which plain

--- a/src/ixdat/backends/sqlite_backend.py
+++ b/src/ixdat/backends/sqlite_backend.py
@@ -1,0 +1,428 @@
+"""This module implements an SQLite database backend for ixdat
+
+The SQLite backend saves ixdat objects to, and loads them from, a proper
+relational database in a single local file. The schema is not written by hand:
+it is derived from the table metadata that every Saveable class already defines
+(see :module:`~ixdat.backends.relational`). Tables are created on demand with
+``CREATE TABLE IF NOT EXISTS``, so any Saveable class - including ones defined
+in external plugins - can be saved without registration here.
+
+Use it like any other ixdat backend::
+
+    from ixdat.db import change_database
+
+    change_database("sqlite", db_path="my_project.sqlite")
+    measurement.save()
+    ...
+    loaded = Measurement.get(1)
+    # or, by name:
+    loaded = Measurement.load("my measurement")
+
+Numerical data (numpy arrays) is stored in NDARRAY (numpy-format blob) columns,
+which are excluded from queries until the data is actually needed - keeping
+ixdat's laziness intact: `Measurement.get()` touches only metadata, and each
+DataSeries fetches its array from the database the first time `.data` is
+accessed.
+
+Note that an SQLiteBackend's connection belongs to the thread that created the
+backend, as is the default for python's sqlite3 module.
+"""
+
+import json
+import sqlite3
+from io import BytesIO
+from pathlib import Path
+
+import numpy as np
+
+from . import relational
+from .backend_base import BackendBase
+from ..config import config, prompt_for_permission
+from ..exceptions import DataBaseError
+
+
+DATABASE_FILE_SUFFIX = ".sqlite"
+
+
+class SQLiteBackend(BackendBase):
+    """A database backend which saves and loads ixdat objects in an SQLite file"""
+
+    backend_type = "sqlite"
+
+    def __init__(self, db_path=None, directory=None, project_name=None):
+        """Initiate the backend, connecting to (and if needed creating) the database
+
+        Args:
+            db_path (Path or str): The path to the SQLite database file. By
+                default it is named after the project and put in ixdat's
+                standard data directory, mirroring the directory backend.
+            directory (Path): The directory for the default database file
+            project_name (str): The project name for the default database file
+        """
+        if db_path:
+            self.db_path = Path(db_path)
+        else:
+            directory = Path(directory or config.standard_data_directory)
+            project_name = project_name or config.default_project_name
+            self.db_path = directory / (project_name + DATABASE_FILE_SUFFIX)
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        self.connection = sqlite3.connect(self.db_path)
+        self.connection.execute("PRAGMA foreign_keys = ON")
+        self._ensured_classes = set()
+        super().__init__()
+
+    @property
+    def address(self):
+        """The path to the SQLite database file"""
+        return str(self.db_path)
+
+    def close(self):
+        """Close the connection to the database file"""
+        self.connection.close()
+
+    def __eq__(self, other):
+        """Two SQLiteBackends are equivalent if they use the same database file"""
+        if other is self:
+            return True
+        return (
+            other.__class__ is self.__class__
+            and other.db_path.resolve() == self.db_path.resolve()
+        )
+
+    # ------- saving  ------- #
+
+    def save(self, obj, force=False, no_updates=True):
+        """Save a Saveable object as rows of the tables defined by its class
+
+        Args:
+            obj (Saveable): the object to save
+            force (bool): Whether to force updates if the object is already saved
+            no_updates (bool): Whether to allow updates if the object is already
+                saved. If both force and no_updates are False, the user will be
+                prompted on whether to save.
+        """
+        # First, save the objects that this object references, so that they get
+        # their id's in this backend for the object's rows to correctly refer
+        # to. This is done recursively, and mirrors the directory backend.
+        if obj.child_attrs:
+            for child_list_name in obj.child_attrs:
+                child_list = getattr(obj, child_list_name) or []
+                for child_obj in child_list:
+                    self.save(child_obj, force=force, no_updates=True)
+        self._ensure_tables(type(obj))
+        # If it's already saved here, decide whether to update it:
+        if obj.backend is self and self.contains(obj.table_name, obj.id):
+            okay_to_update = not no_updates
+            update_the_row = force or (
+                okay_to_update
+                and prompt_for_permission(
+                    f"Are you sure you would like to overwrite "
+                    f"{self} table={obj.table_name} id={obj.id} with {obj}? "
+                    f"(You can use save() with force=True to suppress this.)"
+                )
+            )
+            if update_the_row:
+                self.update_row(obj)
+                return obj.id  # return the id of the updated row
+            else:
+                return  # return nothing since nothing was done
+        i = self.add_row(obj)
+        obj.set_id(i)
+        obj.set_backend(self)
+        return i
+
+    def add_row(self, obj):
+        """Insert the object's rows in its main, extension, and linker tables"""
+        main_schema = relational.main_table_schema(type(obj))
+        main_dict = obj.get_main_dict()
+        columns = main_schema.data_columns
+        values = [self._encode(column, main_dict[column.name]) for column in columns]
+        with self.connection as connection:
+            cursor = connection.execute(
+                _insert_sql(main_schema.name, [column.name for column in columns]),
+                values,
+            )
+            i = cursor.lastrowid
+            self._insert_extras(connection, obj, i)
+        return i
+
+    def update_row(self, obj):
+        """Update the object's rows in its main, extension, and linker tables"""
+        main_schema = relational.main_table_schema(type(obj))
+        main_dict = obj.get_main_dict()
+        columns = main_schema.data_columns
+        values = [self._encode(column, main_dict[column.name]) for column in columns]
+        assignments = ", ".join(f'"{column.name}" = ?' for column in columns)
+        with self.connection as connection:
+            connection.execute(
+                f'UPDATE "{main_schema.name}" SET {assignments} WHERE "id" = ?',
+                values + [obj.id],
+            )
+            for schema in relational.extension_table_schemas(type(obj)):
+                connection.execute(
+                    f'DELETE FROM "{schema.name}" WHERE "id" = ?', (obj.id,)
+                )
+            for linker in relational.linker_table_schemas(type(obj)):
+                connection.execute(
+                    f'DELETE FROM "{linker.name}" WHERE "{linker.owner_column}" = ?',
+                    (obj.id,),
+                )
+            self._insert_extras(connection, obj, obj.id)
+
+    def _insert_extras(self, connection, obj, i):
+        """Insert the object's rows in its extension and linker tables"""
+        for schema in relational.extension_table_schemas(type(obj)):
+            columns = schema.data_columns
+            values = [
+                self._encode(column, getattr(obj, column.name)) for column in columns
+            ]
+            connection.execute(
+                _insert_sql(
+                    schema.name, ["id"] + [column.name for column in columns]
+                ),
+                [i] + values,
+            )
+        for linker in relational.linker_table_schemas(type(obj)):
+            identities = getattr(obj, linker.id_attr)
+            if identities is None:
+                continue
+            if not linker.is_list:
+                identities = [identities]
+            for position, identity in enumerate(identities):
+                linked_id = self._dereference(identity)
+                if not isinstance(linked_id, int):
+                    raise DataBaseError(
+                        f"{obj!r} refers to {linker.id_attr}={identity}, which is "
+                        f"not the id of a row saved in {self}. Do the referenced "
+                        "objects live in another backend?"
+                    )
+                connection.execute(
+                    _insert_sql(
+                        linker.name,
+                        [linker.owner_column, "position", linker.linked_column],
+                    ),
+                    (i, position, linked_id),
+                )
+
+    # ------- loading  ------- #
+
+    def get(self, cls, i):
+        """Return the object of Saveable class cls built from the rows with id=i
+
+        The object's attributes are collected from cls's main table and from the
+        extension and linker tables of every class sharing that main table (only
+        the tables its concrete class wrote have rows with its id). Numerical
+        data is not loaded here - it is loaded lazily via `load_obj_data`.
+        """
+        self._ensure_tables(cls)
+        main_schema = relational.main_table_schema(cls)
+        # Leave NDARRAY columns out of the query; `load_obj_data` gets them lazily:
+        columns = [
+            column for column in main_schema.data_columns if column.dtype != "NDARRAY"
+        ]
+        row = self.connection.execute(
+            _select_sql(main_schema.name, [column.name for column in columns])
+            + ' WHERE "id" = ?',
+            (i,),
+        ).fetchone()
+        if row is None:
+            raise DataBaseError(
+                f"{self} has no row with id={i} in table '{main_schema.name}'"
+            )
+        obj_as_dict = {
+            column.name: self._decode(column, value)
+            for column, value in zip(columns, row)
+        }
+        for column in main_schema.data_columns:
+            if column.dtype == "NDARRAY":
+                obj_as_dict[column.name] = None  # signals lazy loading
+        existing_tables = self._existing_tables()
+        extension_schemas, linker_schemas = relational.family_table_schemas(cls)
+        for schema in extension_schemas:
+            if schema.name not in existing_tables:
+                continue
+            columns = schema.data_columns
+            row = self.connection.execute(
+                _select_sql(schema.name, [column.name for column in columns])
+                + ' WHERE "id" = ?',
+                (i,),
+            ).fetchone()
+            if row is not None:
+                obj_as_dict.update(
+                    {
+                        column.name: self._decode(column, value)
+                        for column, value in zip(columns, row)
+                    }
+                )
+        for linker in linker_schemas:
+            if linker.name not in existing_tables:
+                continue
+            rows = self.connection.execute(
+                _select_sql(linker.name, [linker.linked_column])
+                + f' WHERE "{linker.owner_column}" = ? ORDER BY "position"',
+                (i,),
+            ).fetchall()
+            if rows:
+                linked_ids = [row[0] for row in rows]
+                obj_as_dict[linker.id_attr] = (
+                    linked_ids if linker.is_list else linked_ids[0]
+                )
+        obj = cls.from_dict(obj_as_dict)
+        obj.set_backend(self)
+        obj.set_id(i)
+        return obj
+
+    def load(self, cls, name):
+        """Return the most recently saved object of Saveable class cls with the name"""
+        self._ensure_tables(cls)
+        row = self.connection.execute(
+            f'SELECT "id" FROM "{cls.table_name}" WHERE "name" = ? '
+            'ORDER BY "id" DESC LIMIT 1',
+            (name,),
+        ).fetchone()
+        if row is None:
+            raise DataBaseError(
+                f"{self} has no row named '{name}' in table '{cls.table_name}'"
+            )
+        return self.get(cls, row[0])
+
+    def load_obj_data(self, obj):
+        """Return the numerical data of an object, from its NDARRAY column"""
+        main_schema = relational.main_table_schema(type(obj))
+        for column in main_schema.data_columns:
+            if column.dtype == "NDARRAY":
+                row = self.connection.execute(
+                    _select_sql(main_schema.name, [column.name]) + ' WHERE "id" = ?',
+                    (obj.id,),
+                ).fetchone()
+                return self._decode(column, row[0]) if row else None
+
+    def contains(self, table_name, i):
+        """Check if id `i` is already a principle key in the table named `table_name`"""
+        if table_name not in self._existing_tables():
+            return False
+        row = self.connection.execute(
+            f'SELECT 1 FROM "{table_name}" WHERE "id" = ?', (i,)
+        ).fetchone()
+        return row is not None
+
+    def get_next_available_id(self, table_name, obj=None):
+        """Return the next available id for a given table"""
+        if table_name not in self._existing_tables():
+            return 1
+        row = self.connection.execute(
+            f'SELECT COALESCE(MAX("id"), 0) + 1 FROM "{table_name}"'
+        ).fetchone()
+        return row[0]
+
+    # ------- schema  ------- #
+
+    def _ensure_tables(self, cls):
+        """Create the tables needed by a Saveable class, if they don't yet exist"""
+        if cls in self._ensured_classes:
+            return
+        with self.connection as connection:
+            for schema in relational.table_schemas_of(cls):
+                connection.execute(_create_table_sql(schema))
+        self._ensured_classes.add(cls)
+
+    def _existing_tables(self):
+        """Return the set of names of the tables in the database"""
+        rows = self.connection.execute(
+            "SELECT name FROM sqlite_master WHERE type = 'table'"
+        ).fetchall()
+        return {row[0] for row in rows}
+
+    # ------- value encoding  ------- #
+
+    def _encode(self, column, value):
+        """Return the database representation of a value, per its column's dtype"""
+        value = self._dereference(value)
+        if value is None:
+            return None
+        if column.dtype == "NDARRAY":
+            buffer = BytesIO()
+            np.save(buffer, np.asarray(value), allow_pickle=False)
+            return sqlite3.Binary(buffer.getvalue())
+        if column.dtype == "JSON":
+            return json.dumps(value)
+        if isinstance(value, np.generic):
+            return value.item()
+        if isinstance(value, (dict, list, tuple, np.ndarray)):
+            raise DataBaseError(
+                f"Can't save value {value!r} in the dynamically typed column "
+                f"'{column.name}'. If this column should hold dicts/lists or "
+                "numpy arrays, add it to COLUMN_TYPES in ixdat.backends.relational "
+                "as 'JSON' or 'NDARRAY', respectively."
+            )
+        return value
+
+    def _decode(self, column, value):
+        """Return the python representation of a value, per its column's dtype"""
+        if value is None:
+            return None
+        if column.dtype == "NDARRAY":
+            return np.load(BytesIO(value), allow_pickle=False)
+        if column.dtype == "JSON":
+            return json.loads(value)
+        return value
+
+    def _dereference(self, value):
+        """Turn a `short_identity` into an id, requiring that it refers to self"""
+        if (
+            isinstance(value, tuple)
+            and len(value) == 2
+            and isinstance(value[0], BackendBase)
+        ):
+            backend, i = value
+            if backend is self or backend == self:
+                return i
+            raise DataBaseError(
+                f"Can't save a reference to id={i} of {backend} in {self}. "
+                "Save the referenced object here first."
+            )
+        return value
+
+
+def _create_table_sql(schema):
+    """Return the CREATE TABLE statement for a table or linker table schema"""
+    if isinstance(schema, relational.LinkerTableSchema):
+        return (
+            f'CREATE TABLE IF NOT EXISTS "{schema.name}" (\n'
+            f'    "{schema.owner_column}" INTEGER NOT NULL '
+            f'REFERENCES "{schema.owner_table}"("id"),\n'
+            f'    "position" INTEGER NOT NULL,\n'
+            f'    "{schema.linked_column}" INTEGER NOT NULL '
+            f'REFERENCES "{schema.linked_table}"("id"),\n'
+            f'    PRIMARY KEY ("{schema.owner_column}", "position")\n'
+            ")"
+        )
+    column_definitions = []
+    for column in schema.columns:
+        definition = f'"{column.name}"'
+        if column.dtype:
+            definition += " " + column.dtype
+        if column.name == "id":
+            definition += " PRIMARY KEY"
+        if column.foreign_key:
+            foreign_table, foreign_column = column.foreign_key
+            definition += f' REFERENCES "{foreign_table}"("{foreign_column}")'
+        column_definitions.append("    " + definition)
+    return (
+        f'CREATE TABLE IF NOT EXISTS "{schema.name}" (\n'
+        + ",\n".join(column_definitions)
+        + "\n)"
+    )
+
+
+def _insert_sql(table_name, column_names):
+    """Return a parametrized INSERT statement for the named table and columns"""
+    columns = ", ".join(f'"{name}"' for name in column_names)
+    placeholders = ", ".join("?" for _ in column_names)
+    return f'INSERT INTO "{table_name}" ({columns}) VALUES ({placeholders})'
+
+
+def _select_sql(table_name, column_names):
+    """Return a SELECT statement for the named table and columns"""
+    columns = ", ".join(f'"{name}"' for name in column_names)
+    return f'SELECT {columns} FROM "{table_name}"'

--- a/src/ixdat/backends/sqlite_backend.py
+++ b/src/ixdat/backends/sqlite_backend.py
@@ -1,35 +1,10 @@
-"""This module implements an SQLite database backend for ixdat
+"""SQLite storage backend for ixdat.
 
-Saves and loads ixdat objects using Python's built-in ``sqlite3`` module, so no
-extra dependency is needed. The table layout isn't written by hand - it's built
-from the same table info each Saveable class already carries (see
-:module:`~ixdat.backends.relational`). Tables are created the first time they're
-needed, so any Saveable class, including ones from external plugins, works here
-without extra setup.
+SQLiteBackend stores complete ixdat object graphs in one SQLite file using the
+table descriptions from ixdat.backends.relational.
 
-Basic usage::
-
-    from ixdat.db import change_database
-
-    change_database("sqlite", db_path="my_project.sqlite")
-    measurement.save()
-    ...
-    loaded = Measurement.get(1)
-    loaded = Measurement.load("my measurement")  # or, by name
-
-Numeric arrays (numpy data) are stored as blobs and are only read from the
-database when ``.data`` is actually accessed, so opening an object stays fast
-even in a large project.
-
-Saving an object and everything it references happens in one transaction, so a
-crash partway through can't leave the database half-written. The first time a
-table is used, it's checked against what the current Saveable class expects;
-missing columns are added automatically, and anything that can't be changed
-safely raises a :class:`~ixdat.exceptions.DataBaseError` instead of silently
-doing the wrong thing.
-
-Note: one SQLiteBackend belongs to the thread that created it - this is just how
-Python's sqlite3 module works. Make a separate backend instance per thread.
+See :ref:`backend` for usage, persistence guarantees, schema updates, and
+connection lifetimes.
 """
 
 import json

--- a/src/ixdat/backends/sqlite_backend.py
+++ b/src/ixdat/backends/sqlite_backend.py
@@ -79,8 +79,12 @@ class SQLiteBackend(BackendBase):
             directory = Path(directory or config.standard_data_directory)
             project_name = project_name or config.default_project_name
             self.db_path = directory / (project_name + DATABASE_FILE_SUFFIX)
+        self._resolved_path = None  # what identifies this database, see __eq__
         if not self._is_memory:
             self.db_path.parent.mkdir(parents=True, exist_ok=True)
+            # resolved once here: two backends on one file must compare and hash
+            # alike however their paths were written, and resolving hits the disk
+            self._resolved_path = self.db_path.resolve()
         self.connection = sqlite3.connect(self.db_path)
         self.connection.execute("PRAGMA foreign_keys = ON")
         self._closed = False
@@ -121,7 +125,18 @@ class SQLiteBackend(BackendBase):
         if self._is_memory or other._is_memory:
             # Separate ":memory:" connections are separate databases.
             return False
-        return other.db_path.resolve() == self.db_path.resolve()
+        return other._resolved_path == self._resolved_path
+
+    def __hash__(self):
+        """Hash by the database file, so that equal backends hash alike
+
+        Defining __eq__ sets __hash__ to None unless it is defined too, which would
+        make this backend unhashable. Saveable does the same thing for the same
+        reason. Two ":memory:" backends are never equal, so they hash by identity.
+        """
+        if self._is_memory:
+            return object.__hash__(self)
+        return hash(self._resolved_path)
 
     # ------- saving  ------- #
 

--- a/src/ixdat/backends/sqlite_backend.py
+++ b/src/ixdat/backends/sqlite_backend.py
@@ -24,6 +24,11 @@ ixdat's laziness intact: `Measurement.get()` touches only metadata, and each
 DataSeries fetches its array from the database the first time `.data` is
 accessed.
 
+Saving an object and all of its referenced children is one transaction. Existing
+tables are checked against a versioned schema when they are first used; new nullable
+columns are added automatically, while changes which cannot be migrated without
+ambiguity raise :class:`~ixdat.exceptions.DataBaseError`.
+
 Note that an SQLiteBackend's connection belongs to the thread that created the
 backend, as is the default for python's sqlite3 module.
 """
@@ -42,6 +47,13 @@ from ..exceptions import DataBaseError
 
 
 DATABASE_FILE_SUFFIX = ".sqlite"
+SCHEMA_VERSION = 1
+METADATA_TABLE = "_ixdat_metadata"
+
+
+def _quote_identifier(identifier):
+    """Return an SQLite identifier with embedded quotes escaped."""
+    return '"' + identifier.replace('"', '""') + '"'
 
 
 class SQLiteBackend(BackendBase):
@@ -59,16 +71,27 @@ class SQLiteBackend(BackendBase):
             directory (Path): The directory for the default database file
             project_name (str): The project name for the default database file
         """
-        if db_path:
+        self._is_memory = str(db_path) == ":memory:"
+        if self._is_memory:
+            self.db_path = ":memory:"
+        elif db_path:
             self.db_path = Path(db_path)
         else:
             directory = Path(directory or config.standard_data_directory)
             project_name = project_name or config.default_project_name
             self.db_path = directory / (project_name + DATABASE_FILE_SUFFIX)
-        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        if not self._is_memory:
+            self.db_path.parent.mkdir(parents=True, exist_ok=True)
         self.connection = sqlite3.connect(self.db_path)
         self.connection.execute("PRAGMA foreign_keys = ON")
+        self._closed = False
         self._ensured_classes = set()
+        self._ensured_schema_definitions = set()
+        try:
+            self._initialize_schema_metadata()
+        except Exception:
+            self.close()
+            raise
         super().__init__()
 
     @property
@@ -78,21 +101,33 @@ class SQLiteBackend(BackendBase):
 
     def close(self):
         """Close the connection to the database file"""
-        self.connection.close()
+        if not self._closed:
+            self.connection.close()
+            self._closed = True
+
+    def __enter__(self):
+        """Return this backend for use as a context manager."""
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        """Close the connection when leaving a context manager."""
+        self.close()
 
     def __eq__(self, other):
         """Two SQLiteBackends are equivalent if they use the same database file"""
         if other is self:
             return True
-        return (
-            other.__class__ is self.__class__
-            and other.db_path.resolve() == self.db_path.resolve()
-        )
+        if other.__class__ is not self.__class__:
+            return False
+        if self._is_memory or other._is_memory:
+            # Separate ":memory:" connections are separate databases.
+            return False
+        return other.db_path.resolve() == self.db_path.resolve()
 
     # ------- saving  ------- #
 
     def save(self, obj, force=False, no_updates=True):
-        """Save a Saveable object as rows of the tables defined by its class
+        """Atomically save an object and all objects it references.
 
         Args:
             obj (Saveable): the object to save
@@ -101,73 +136,149 @@ class SQLiteBackend(BackendBase):
                 saved. If both force and no_updates are False, the user will be
                 prompted on whether to save.
         """
-        # First, save the objects that this object references, so that they get
-        # their id's in this backend for the object's rows to correctly refer
-        # to. This is done recursively, and mirrors the directory backend.
-        if obj.child_attrs:
-            for child_list_name in obj.child_attrs:
-                child_list = getattr(obj, child_list_name) or []
-                for child_obj in child_list:
-                    self.save(child_obj, force=force, no_updates=True)
-        self._ensure_tables(type(obj))
-        # If it's already saved here, decide whether to update it:
-        if obj.backend is self and self.contains(obj.table_name, obj.id):
-            okay_to_update = not no_updates
-            update_the_row = force or (
-                okay_to_update
-                and prompt_for_permission(
-                    f"Are you sure you would like to overwrite "
-                    f"{self} table={obj.table_name} id={obj.id} with {obj}? "
-                    f"(You can use save() with force=True to suppress this.)"
+        plan = self._build_save_plan(obj, force=force, no_updates=no_updates)
+        for planned_obj, action in plan:
+            if action != "skip":
+                self._ensure_tables(type(planned_obj))
+
+        original_states = []
+        root_result = None
+        try:
+            # The plan is in child-first order, so every foreign-key target is
+            # inserted before the row which refers to it. One connection context
+            # makes the complete object graph a single transaction.
+            with self.connection as connection:
+                for planned_obj, action in plan:
+                    if action == "skip":
+                        continue
+                    if action == "update":
+                        self._update_row(connection, planned_obj)
+                        result = planned_obj.id
+                    else:
+                        original_states.append(
+                            (planned_obj, planned_obj._backend, planned_obj._id)
+                        )
+                        result = self._add_row(connection, planned_obj)
+                        planned_obj.set_id(result)
+                        planned_obj.set_backend(self)
+                    if planned_obj is obj:
+                        root_result = result
+        except Exception:
+            # A rollback removes inserted rows; keep the corresponding in-memory
+            # objects honest by restoring their pre-save identities as well.
+            for saved_obj, old_backend, old_id in reversed(original_states):
+                saved_obj._backend = old_backend
+                saved_obj._id = old_id
+            raise
+        return root_result
+
+    def _build_save_plan(self, root, force, no_updates):
+        """Return unique objects in child-first order with insert/update actions."""
+        plan = []
+        visited = set()
+        visiting = set()
+        existing_tables = self._existing_tables()
+
+        def visit(obj, updates_forbidden):
+            object_key = id(obj)
+            if object_key in visited:
+                return
+            if object_key in visiting:
+                raise DataBaseError(
+                    f"Can't save a cyclic object graph rooted at {root!r}."
+                )
+            visiting.add(object_key)
+            if obj.child_attrs:
+                for child_list_name in obj.child_attrs:
+                    for child_obj in getattr(obj, child_list_name) or []:
+                        visit(child_obj, updates_forbidden=True)
+            visiting.remove(object_key)
+            visited.add(object_key)
+            plan.append(
+                (
+                    obj,
+                    self._save_action(
+                        obj, force, updates_forbidden, existing_tables
+                    ),
                 )
             )
-            if update_the_row:
-                self.update_row(obj)
-                return obj.id  # return the id of the updated row
-            else:
-                return  # return nothing since nothing was done
-        i = self.add_row(obj)
-        obj.set_id(i)
-        obj.set_backend(self)
-        return i
+
+        visit(root, updates_forbidden=no_updates)
+        return plan
+
+    def _save_action(self, obj, force, updates_forbidden, existing_tables):
+        """Return ``insert``, ``update``, or ``skip`` for one planned object."""
+        row_exists = False
+        if obj.backend is self and obj.table_name in existing_tables:
+            row_exists = self.connection.execute(
+                f"SELECT 1 FROM {_quote_identifier(obj.table_name)} "
+                'WHERE "id" = ?',
+                (obj.id,),
+            ).fetchone()
+        if row_exists:
+            if force:
+                return "update"
+            if not updates_forbidden and prompt_for_permission(
+                f"Are you sure you would like to overwrite "
+                f"{self} table={obj.table_name} id={obj.id} with {obj}? "
+                f"(You can use save() with force=True to suppress this.)"
+            ):
+                return "update"
+            return "skip"
+        return "insert"
 
     def add_row(self, obj):
         """Insert the object's rows in its main, extension, and linker tables"""
+        self._ensure_tables(type(obj))
+        with self.connection as connection:
+            return self._add_row(connection, obj)
+
+    def _add_row(self, connection, obj):
+        """Insert one object's rows using an existing transaction."""
         main_schema = relational.main_table_schema(type(obj))
         main_dict = obj.get_main_dict()
         columns = main_schema.data_columns
         values = [self._encode(column, main_dict[column.name]) for column in columns]
-        with self.connection as connection:
-            cursor = connection.execute(
-                _insert_sql(main_schema.name, [column.name for column in columns]),
-                values,
-            )
-            i = cursor.lastrowid
-            self._insert_extras(connection, obj, i)
+        cursor = connection.execute(
+            _insert_sql(main_schema.name, [column.name for column in columns]),
+            values,
+        )
+        i = cursor.lastrowid
+        self._insert_extras(connection, obj, i)
         return i
 
     def update_row(self, obj):
         """Update the object's rows in its main, extension, and linker tables"""
+        self._ensure_tables(type(obj))
+        with self.connection as connection:
+            self._update_row(connection, obj)
+
+    def _update_row(self, connection, obj):
+        """Update one object's rows using an existing transaction."""
         main_schema = relational.main_table_schema(type(obj))
         main_dict = obj.get_main_dict()
         columns = main_schema.data_columns
         values = [self._encode(column, main_dict[column.name]) for column in columns]
-        assignments = ", ".join(f'"{column.name}" = ?' for column in columns)
-        with self.connection as connection:
+        assignments = ", ".join(
+            f"{_quote_identifier(column.name)} = ?" for column in columns
+        )
+        connection.execute(
+            f"UPDATE {_quote_identifier(main_schema.name)} "
+            f"SET {assignments} WHERE \"id\" = ?",
+            values + [obj.id],
+        )
+        for schema in relational.extension_table_schemas(type(obj)):
             connection.execute(
-                f'UPDATE "{main_schema.name}" SET {assignments} WHERE "id" = ?',
-                values + [obj.id],
+                f"DELETE FROM {_quote_identifier(schema.name)} WHERE \"id\" = ?",
+                (obj.id,),
             )
-            for schema in relational.extension_table_schemas(type(obj)):
-                connection.execute(
-                    f'DELETE FROM "{schema.name}" WHERE "id" = ?', (obj.id,)
-                )
-            for linker in relational.linker_table_schemas(type(obj)):
-                connection.execute(
-                    f'DELETE FROM "{linker.name}" WHERE "{linker.owner_column}" = ?',
-                    (obj.id,),
-                )
-            self._insert_extras(connection, obj, obj.id)
+        for linker in relational.linker_table_schemas(type(obj)):
+            connection.execute(
+                f"DELETE FROM {_quote_identifier(linker.name)} WHERE "
+                f"{_quote_identifier(linker.owner_column)} = ?",
+                (obj.id,),
+            )
+        self._insert_extras(connection, obj, obj.id)
 
     def _insert_extras(self, connection, obj, i):
         """Insert the object's rows in its extension and linker tables"""
@@ -216,6 +327,10 @@ class SQLiteBackend(BackendBase):
         """
         self._ensure_tables(cls)
         main_schema = relational.main_table_schema(cls)
+        extension_schemas, linker_schemas = relational.family_table_schemas(cls)
+        existing_tables = self._ensure_existing_family_tables(
+            extension_schemas + linker_schemas
+        )
         # Leave NDARRAY columns out of the query; `load_obj_data` gets them lazily:
         columns = [
             column for column in main_schema.data_columns if column.dtype != "NDARRAY"
@@ -236,8 +351,6 @@ class SQLiteBackend(BackendBase):
         for column in main_schema.data_columns:
             if column.dtype == "NDARRAY":
                 obj_as_dict[column.name] = None  # signals lazy loading
-        existing_tables = self._existing_tables()
-        extension_schemas, linker_schemas = relational.family_table_schemas(cls)
         for schema in extension_schemas:
             if schema.name not in existing_tables:
                 continue
@@ -259,7 +372,8 @@ class SQLiteBackend(BackendBase):
                 continue
             rows = self.connection.execute(
                 _select_sql(linker.name, [linker.linked_column])
-                + f' WHERE "{linker.owner_column}" = ? ORDER BY "position"',
+                + f" WHERE {_quote_identifier(linker.owner_column)} = ? "
+                'ORDER BY "position"',
                 (i,),
             ).fetchall()
             if rows:
@@ -276,7 +390,8 @@ class SQLiteBackend(BackendBase):
         """Return the most recently saved object of Saveable class cls with the name"""
         self._ensure_tables(cls)
         row = self.connection.execute(
-            f'SELECT "id" FROM "{cls.table_name}" WHERE "name" = ? '
+            f"SELECT \"id\" FROM {_quote_identifier(cls.table_name)} "
+            'WHERE "name" = ? '
             'ORDER BY "id" DESC LIMIT 1',
             (name,),
         ).fetchone()
@@ -302,7 +417,7 @@ class SQLiteBackend(BackendBase):
         if table_name not in self._existing_tables():
             return False
         row = self.connection.execute(
-            f'SELECT 1 FROM "{table_name}" WHERE "id" = ?', (i,)
+            f"SELECT 1 FROM {_quote_identifier(table_name)} WHERE \"id\" = ?", (i,)
         ).fetchone()
         return row is not None
 
@@ -311,20 +426,210 @@ class SQLiteBackend(BackendBase):
         if table_name not in self._existing_tables():
             return 1
         row = self.connection.execute(
-            f'SELECT COALESCE(MAX("id"), 0) + 1 FROM "{table_name}"'
+            f"SELECT COALESCE(MAX(\"id\"), 0) + 1 "
+            f"FROM {_quote_identifier(table_name)}"
         ).fetchone()
         return row[0]
 
     # ------- schema  ------- #
 
+    def _initialize_schema_metadata(self):
+        """Create and validate the small, backend-owned schema metadata table."""
+        metadata_table = _quote_identifier(METADATA_TABLE)
+        with self.connection as connection:
+            connection.execute(
+                f"CREATE TABLE IF NOT EXISTS {metadata_table} ("
+                '"key" TEXT PRIMARY KEY, "value" TEXT NOT NULL)'
+            )
+            row = connection.execute(
+                f"SELECT \"value\" FROM {metadata_table} "
+                'WHERE "key" = ?',
+                ("schema_version",),
+            ).fetchone()
+            if row is None:
+                # Databases made by pre-release versions of this backend did not
+                # carry a version. Their tables are validated and additively migrated
+                # by `_ensure_tables` before use.
+                connection.execute(
+                    f"INSERT INTO {metadata_table} (\"key\", \"value\") "
+                    'VALUES (?, ?)',
+                    ("schema_version", str(SCHEMA_VERSION)),
+                )
+                return
+            try:
+                database_version = int(row[0])
+            except (TypeError, ValueError):
+                raise DataBaseError(
+                    f"Invalid ixdat schema version {row[0]!r} in {self.db_path}."
+                )
+            if database_version != SCHEMA_VERSION:
+                relation = "newer" if database_version > SCHEMA_VERSION else "older"
+                raise DataBaseError(
+                    f"The database {self.db_path} uses {relation} ixdat schema "
+                    f"version {database_version}; this ixdat supports version "
+                    f"{SCHEMA_VERSION}. Migrate the database before opening it."
+                )
+
     def _ensure_tables(self, cls):
-        """Create the tables needed by a Saveable class, if they don't yet exist"""
+        """Create, validate, and additively migrate tables needed by ``cls``."""
         if cls in self._ensured_classes:
             return
+        existing_tables = self._existing_tables()
+        ensured_definitions = []
         with self.connection as connection:
             for schema in relational.table_schemas_of(cls):
-                connection.execute(_create_table_sql(schema))
+                if schema.name in existing_tables:
+                    self._validate_or_migrate_table(connection, schema)
+                else:
+                    connection.execute(_create_table_sql(schema))
+                    existing_tables.add(schema.name)
+                self._ensure_indexes(connection, schema)
+                ensured_definitions.append((schema.name, _create_table_sql(schema)))
+        self._ensured_schema_definitions.update(ensured_definitions)
         self._ensured_classes.add(cls)
+
+    def _ensure_existing_family_tables(self, schemas):
+        """Validate subclass tables and return the current table-name set."""
+        existing_tables = self._existing_tables()
+        ensured_definitions = []
+        with self.connection as connection:
+            for schema in schemas:
+                schema_definition = (schema.name, _create_table_sql(schema))
+                if (
+                    schema.name not in existing_tables
+                    or schema_definition in self._ensured_schema_definitions
+                ):
+                    continue
+                self._validate_or_migrate_table(connection, schema)
+                self._ensure_indexes(connection, schema)
+                ensured_definitions.append(schema_definition)
+        self._ensured_schema_definitions.update(ensured_definitions)
+        return existing_tables
+
+    def _validate_or_migrate_table(self, connection, schema):
+        """Add missing nullable columns and reject incompatible table layouts."""
+        table_info = {
+            row[1]: {"type": row[2].upper(), "not_null": row[3], "pk": row[5]}
+            for row in connection.execute(
+                f"PRAGMA table_info({_quote_identifier(schema.name)})"
+            ).fetchall()
+        }
+        if isinstance(schema, relational.LinkerTableSchema):
+            expected_names = {
+                schema.owner_column,
+                "position",
+                schema.linked_column,
+            }
+            if not expected_names.issubset(table_info):
+                self._incompatible_schema(
+                    schema.name,
+                    "linker columns are missing or use obsolete names",
+                )
+            for column_name in expected_names:
+                column = table_info[column_name]
+                if column["type"] != "INTEGER" or not column["not_null"]:
+                    self._incompatible_schema(
+                        schema.name,
+                        f"linker column {column_name!r} must be a non-null INTEGER",
+                    )
+            expected_pk = [schema.owner_column, "position"]
+            actual_pk = [
+                name
+                for name, info in sorted(
+                    table_info.items(), key=lambda item: item[1]["pk"] or 999
+                )
+                if info["pk"]
+            ]
+            if actual_pk != expected_pk:
+                self._incompatible_schema(
+                    schema.name,
+                    f"primary key is {actual_pk}, expected {expected_pk}",
+                )
+            self._validate_foreign_key(
+                connection,
+                schema.name,
+                schema.owner_column,
+                schema.owner_table,
+                "id",
+            )
+            self._validate_foreign_key(
+                connection,
+                schema.name,
+                schema.linked_column,
+                schema.linked_table,
+                "id",
+            )
+            return
+
+        for column in schema.columns:
+            if column.name not in table_info:
+                if column.name == "id":
+                    self._incompatible_schema(
+                        schema.name, 'primary-key column "id" missing'
+                    )
+                connection.execute(
+                    f"ALTER TABLE {_quote_identifier(schema.name)} ADD COLUMN "
+                    + _column_definition(column, include_primary_key=False)
+                )
+                continue
+            actual = table_info[column.name]
+            expected_type = column.dtype or ""
+            if expected_type and actual["type"] != expected_type:
+                self._incompatible_schema(
+                    schema.name,
+                    f"column {column.name!r} has type {actual['type']!r}, "
+                    f"expected {expected_type!r}",
+                )
+            if column.name == "id" and not actual["pk"]:
+                self._incompatible_schema(schema.name, 'column "id" is not primary key')
+            if column.foreign_key:
+                self._validate_foreign_key(
+                    connection, schema.name, column.name, *column.foreign_key
+                )
+
+    def _validate_foreign_key(
+        self, connection, table_name, column_name, foreign_table, foreign_column
+    ):
+        """Require one expected foreign-key relationship on an existing table."""
+        foreign_keys = connection.execute(
+            f"PRAGMA foreign_key_list({_quote_identifier(table_name)})"
+        ).fetchall()
+        relationship = (column_name, foreign_table, foreign_column)
+        actual_relationships = {(row[3], row[2], row[4]) for row in foreign_keys}
+        if relationship not in actual_relationships:
+            self._incompatible_schema(
+                table_name,
+                f"foreign key {column_name!r} -> "
+                f"{foreign_table!r}.{foreign_column!r} is missing",
+            )
+
+    def _incompatible_schema(self, table_name, reason):
+        """Raise an actionable error for a migration that cannot be done safely."""
+        raise DataBaseError(
+            f"Incompatible schema for table {table_name!r} in {self.db_path}: "
+            f"{reason}. A manual database migration is required."
+        )
+
+    @staticmethod
+    def _ensure_indexes(connection, schema):
+        """Create indexes used by name lookup, dispatch, and reverse relationships."""
+        if isinstance(schema, relational.LinkerTableSchema):
+            indexed_columns = [(schema.linked_column,)]
+        else:
+            column_names = set(schema.column_names)
+            indexed_columns = []
+            if "name" in column_names:
+                indexed_columns.append(("name", "id"))
+            for discriminator in ("technique", "series_type", "calculator_type"):
+                if discriminator in column_names:
+                    indexed_columns.append((discriminator,))
+        for columns in indexed_columns:
+            index_name = "ixdat_" + schema.name + "_" + "_".join(columns)
+            column_sql = ", ".join(_quote_identifier(column) for column in columns)
+            connection.execute(
+                f"CREATE INDEX IF NOT EXISTS {_quote_identifier(index_name)} "
+                f"ON {_quote_identifier(schema.name)} ({column_sql})"
+            )
 
     def _existing_tables(self):
         """Return the set of names of the tables in the database"""
@@ -361,7 +666,12 @@ class SQLiteBackend(BackendBase):
             np.save(buffer, np.asarray(value), allow_pickle=False)
             return sqlite3.Binary(buffer.getvalue())
         if column.dtype == "JSON":
-            return json.dumps(value)
+            # Readers frequently expose numpy scalars and arrays in otherwise
+            # JSON-compatible metadata. Use ixdat's shared normalization so both
+            # built-in backends accept the same scientific metadata values.
+            from ..tools import to_jsonable
+
+            return json.dumps(to_jsonable(value))
         if isinstance(value, np.generic):
             return value.item()
         if isinstance(value, (dict, list, tuple, np.ndarray)):
@@ -404,41 +714,53 @@ def _create_table_sql(schema):
     """Return the CREATE TABLE statement for a table or linker table schema"""
     if isinstance(schema, relational.LinkerTableSchema):
         return (
-            f'CREATE TABLE IF NOT EXISTS "{schema.name}" (\n'
-            f'    "{schema.owner_column}" INTEGER NOT NULL '
-            f'REFERENCES "{schema.owner_table}"("id"),\n'
+            f"CREATE TABLE IF NOT EXISTS {_quote_identifier(schema.name)} (\n"
+            f"    {_quote_identifier(schema.owner_column)} INTEGER NOT NULL "
+            f"REFERENCES {_quote_identifier(schema.owner_table)}(\"id\"),\n"
             f'    "position" INTEGER NOT NULL,\n'
-            f'    "{schema.linked_column}" INTEGER NOT NULL '
-            f'REFERENCES "{schema.linked_table}"("id"),\n'
-            f'    PRIMARY KEY ("{schema.owner_column}", "position")\n'
+            f"    {_quote_identifier(schema.linked_column)} INTEGER NOT NULL "
+            f"REFERENCES {_quote_identifier(schema.linked_table)}(\"id\"),\n"
+            f"    PRIMARY KEY ({_quote_identifier(schema.owner_column)}, "
+            '"position")\n'
             ")"
         )
-    column_definitions = []
-    for column in schema.columns:
-        definition = f'"{column.name}"'
-        if column.dtype:
-            definition += " " + column.dtype
-        if column.name == "id":
-            definition += " PRIMARY KEY"
-        if column.foreign_key:
-            foreign_table, foreign_column = column.foreign_key
-            definition += f' REFERENCES "{foreign_table}"("{foreign_column}")'
-        column_definitions.append("    " + definition)
+    column_definitions = [
+        "    " + _column_definition(column) for column in schema.columns
+    ]
     return (
-        f'CREATE TABLE IF NOT EXISTS "{schema.name}" (\n'
+        f"CREATE TABLE IF NOT EXISTS {_quote_identifier(schema.name)} (\n"
         + ",\n".join(column_definitions)
         + "\n)"
     )
 
 
+def _column_definition(column, include_primary_key=True):
+    """Return the DDL fragment defining one regular table column."""
+    definition = _quote_identifier(column.name)
+    if column.dtype:
+        definition += " " + column.dtype
+    if include_primary_key and column.name == "id":
+        definition += " PRIMARY KEY"
+    if column.foreign_key:
+        foreign_table, foreign_column = column.foreign_key
+        definition += (
+            f" REFERENCES {_quote_identifier(foreign_table)}"
+            f"({_quote_identifier(foreign_column)})"
+        )
+    return definition
+
+
 def _insert_sql(table_name, column_names):
     """Return a parametrized INSERT statement for the named table and columns"""
-    columns = ", ".join(f'"{name}"' for name in column_names)
+    columns = ", ".join(_quote_identifier(name) for name in column_names)
     placeholders = ", ".join("?" for _ in column_names)
-    return f'INSERT INTO "{table_name}" ({columns}) VALUES ({placeholders})'
+    return (
+        f"INSERT INTO {_quote_identifier(table_name)} ({columns}) "
+        f"VALUES ({placeholders})"
+    )
 
 
 def _select_sql(table_name, column_names):
     """Return a SELECT statement for the named table and columns"""
-    columns = ", ".join(f'"{name}"' for name in column_names)
-    return f'SELECT {columns} FROM "{table_name}"'
+    columns = ", ".join(_quote_identifier(name) for name in column_names)
+    return f"SELECT {columns} FROM {_quote_identifier(table_name)}"

--- a/src/ixdat/backends/sqlite_backend.py
+++ b/src/ixdat/backends/sqlite_backend.py
@@ -22,7 +22,7 @@ from ..exceptions import DataBaseError
 
 DATABASE_FILE_SUFFIX = ".sqlite"
 SCHEMA_VERSION = 1
-METADATA_TABLE = "_ixdat_metadata"
+METADATA_TABLE_NAME = "_ixdat_metadata"
 SQLITE_TYPES = {
     int: "INTEGER",
     float: "REAL",
@@ -55,27 +55,41 @@ class SQLiteBackend(BackendBase):
             project_name (str): The project name for the default database file
         """
         self._is_memory = str(db_path) == ":memory:"
+        # SQLite gives each ":memory:" connection its own temporary database. Give
+        # each one a unique ixdat address so their saved-object identities stay apart.
+        self._memory_address = f":memory:{id(self)}" if self._is_memory else None
         if self._is_memory:
             self.db_path = ":memory:"
+            database_is_new = True
         elif db_path:
             self.db_path = Path(db_path)
+            database_is_new = (
+                not self.db_path.exists() or self.db_path.stat().st_size == 0
+            )
         else:
             directory = Path(directory or config.standard_data_directory)
             project_name = project_name or config.default_project_name
             self.db_path = directory / (project_name + DATABASE_FILE_SUFFIX)
-        self._resolved_path = None  # what identifies this database, see __eq__
+            database_is_new = (
+                not self.db_path.exists() or self.db_path.stat().st_size == 0
+            )
+        # The resolved path identifies file storage in shares_storage_with().
+        self._resolved_path = None
         if not self._is_memory:
             self.db_path.parent.mkdir(parents=True, exist_ok=True)
-            # resolved once here: two backends on one file must compare and hash
-            # alike however their paths were written, and resolving hits the disk
+            # Resolve once so differently written paths to one file identify the
+            # same storage without repeatedly accessing the filesystem.
             self._resolved_path = self.db_path.resolve()
         self.connection = sqlite3.connect(self.db_path)
+        # SQLite configures foreign-key checking per connection and leaves it off
+        # by default. Enable it here so every saved id must point to an existing row:
+        # https://www.sqlite.org/pragma.html#pragma_foreign_keys
         self.connection.execute("PRAGMA foreign_keys = ON")
         self._closed = False
         self._ensured_classes = set()
         self._ensured_schema_definitions = set()
         try:
-            self._initialize_schema_metadata()
+            self._initialize_schema_metadata(database_is_new)
         except Exception:
             self.close()
             raise
@@ -83,8 +97,8 @@ class SQLiteBackend(BackendBase):
 
     @property
     def address(self):
-        """The path to the SQLite database file"""
-        return str(self.db_path if self._is_memory else self._resolved_path)
+        """The file path, or the unique identity of an in-memory database."""
+        return self._memory_address if self._is_memory else str(self._resolved_path)
 
     def close(self):
         """Close the connection to the database file"""
@@ -92,16 +106,8 @@ class SQLiteBackend(BackendBase):
             self.connection.close()
             self._closed = True
 
-    def __enter__(self):
-        """Return this backend for use as a context manager."""
-        return self
-
-    def __exit__(self, exc_type, exc_value, traceback):
-        """Close the connection when leaving a context manager."""
-        self.close()
-
-    def __eq__(self, other):
-        """Two SQLiteBackends are equivalent if they use the same database file"""
+    def shares_storage_with(self, other):
+        """Return whether ``other`` reaches the same SQLite database."""
         if other is self:
             return True
         if other.__class__ is not self.__class__:
@@ -110,17 +116,6 @@ class SQLiteBackend(BackendBase):
             # Separate ":memory:" connections are separate databases.
             return False
         return other._resolved_path == self._resolved_path
-
-    def __hash__(self):
-        """Hash by the database file, so that equal backends hash alike
-
-        Defining __eq__ sets __hash__ to None unless it is defined too, which would
-        make this backend unhashable. Saveable does the same thing for the same
-        reason. Two ":memory:" backends are never equal, so they hash by identity.
-        """
-        if self._is_memory:
-            return object.__hash__(self)
-        return hash(self._resolved_path)
 
     # ------- saving  ------- #
 
@@ -137,7 +132,7 @@ class SQLiteBackend(BackendBase):
         plan = self._build_save_plan(obj, force=force, no_updates=no_updates)
         for planned_obj, action in plan:
             if action != "skip":
-                self._ensure_tables(type(planned_obj))
+                self._ensure_tables_for_save(type(planned_obj))
 
         original_states = []
         root_result = None
@@ -180,6 +175,9 @@ class SQLiteBackend(BackendBase):
         existing_tables = self._existing_tables()
 
         def visit(obj, updates_forbidden):
+            # Python's built-in id() identifies this exact in-memory object. That
+            # lets the walk detect a cycle even when two ixdat objects have equal
+            # saved values or database ids.
             object_key = id(obj)
             if object_key in visited:
                 return  # already planned (e.g. two parents sharing one child)
@@ -190,11 +188,10 @@ class SQLiteBackend(BackendBase):
                     f"Can't save a cyclic object graph rooted at {root!r}."
                 )
             visiting.add(object_key)
-            # visit every child first, so they end up earlier in "plan"
-            if obj.child_attrs:
-                for child_list_name in obj.child_attrs:
-                    for child_obj in getattr(obj, child_list_name) or []:
-                        visit(child_obj, updates_forbidden=True)
+            # Visit every related object first, so it appears earlier in the plan and
+            # has an id by the time this object stores the relationship.
+            for related_obj in obj.iter_related_objects():
+                visit(related_obj, updates_forbidden=True)
             visiting.remove(object_key)
             visited.add(object_key)
             plan.append(
@@ -210,7 +207,9 @@ class SQLiteBackend(BackendBase):
     def _save_action(self, obj, force, updates_forbidden, existing_tables):
         """Return ``insert``, ``update``, or ``skip`` for one planned object."""
         row_exists = False
-        if obj.backend == self and obj.table_name in existing_tables:
+        # Storage identity tells us where to look. This query separately confirms
+        # that the object's exact row is present through this connection.
+        if self.shares_storage_with(obj.backend) and obj.table_name in existing_tables:
             row_exists = self.connection.execute(
                 f"SELECT 1 FROM {_quote_identifier(obj.table_name)} " 'WHERE "id" = ?',
                 (obj.id,),
@@ -260,7 +259,13 @@ class SQLiteBackend(BackendBase):
                 f'DELETE FROM {_quote_identifier(schema.name)} WHERE "id" = ?',
                 (obj.id,),
             )
+        existing_tables = self._existing_tables()
         for linker in relational.linker_table_schemas(type(obj)):
+            # A connection table can be created before its linked table is needed.
+            # Until that linked table exists, this object cannot have any rows in the
+            # connection table to replace.
+            if linker.linked_table not in existing_tables:
+                continue
             connection.execute(
                 f"DELETE FROM {_quote_identifier(linker.name)} WHERE "
                 f"{_quote_identifier(linker.owner_column)} = ?",
@@ -287,7 +292,7 @@ class SQLiteBackend(BackendBase):
             identities = getattr(obj, linker.id_attr)
             if identities is None:
                 continue
-            if not linker.is_list:
+            if not linker.many:
                 identities = [identities]
             for position, identity in enumerate(identities):
                 linked_id = self._dereference(identity)
@@ -297,6 +302,13 @@ class SQLiteBackend(BackendBase):
                         f"not the id of a row saved in {self}. Do the referenced "
                         "objects live in another backend?"
                     )
+                # `connection` is the sqlite3 connection opened by this backend.
+                # For a measurement linked to a data series, `_insert_sql()` makes:
+                # INSERT INTO "measurement_series"
+                #     ("measurement_id", "position", "data_series_id")
+                #     VALUES (?, ?, ?)
+                # The values below give SQLite the measurement id, the series's
+                # place in the measurement's list, and the data-series id.
                 connection.execute(
                     _insert_sql(
                         linker.name,
@@ -314,20 +326,23 @@ class SQLiteBackend(BackendBase):
         "measurement" could be a plain ECMeasurement or an ECMSMeasurement), so we
         check the extension/linker tables of every class that shares cls's main
         table, not just cls's own. Only the tables the row's real class wrote to
-        will actually have a row for this id; the rest are skipped. Numerical data
-        isn't loaded here - see `load_obj_data`.
+        will actually have a row for this id; the rest are skipped. The ``data``
+        column is loaded when the object's ``.data`` is first used - see
+        `load_obj_data`.
         """
-        self._ensure_tables(cls)
         main_schema = relational.main_table_schema(cls)
         extension_schemas, linker_schemas = relational.family_table_schemas(cls)
-        existing_tables = self._ensure_existing_family_tables(
-            extension_schemas + linker_schemas
+        existing_tables = self._validate_existing_tables(
+            [main_schema] + extension_schemas + linker_schemas
         )
-        # Leave ndarray columns out; `load_obj_data` gets them lazily:
+        if main_schema.name not in existing_tables:
+            raise DataBaseError(
+                f"{self} has no table for objects of type {cls.__name__}."
+            )
+        # `data` has ixdat's lazy-loading property. Other NumPy-array columns load
+        # here with the rest of the object's values.
         columns = [
-            column
-            for column in main_schema.data_columns
-            if column.dtype is not np.ndarray
+            column for column in main_schema.data_columns if column.name != "data"
         ]
         row = self.connection.execute(
             _select_sql(main_schema.name, [column.name for column in columns])
@@ -343,8 +358,8 @@ class SQLiteBackend(BackendBase):
             for column, value in zip(columns, row)
         }
         for column in main_schema.data_columns:
-            if column.dtype is np.ndarray:
-                obj_as_dict[column.name] = None  # signals lazy loading
+            if column.name == "data":
+                obj_as_dict["data"] = None  # signals lazy loading
         for schema in extension_schemas:
             if schema.name not in existing_tables:
                 continue
@@ -373,7 +388,7 @@ class SQLiteBackend(BackendBase):
             if rows:
                 linked_ids = [row[0] for row in rows]
                 obj_as_dict[linker.id_attr] = (
-                    linked_ids if linker.is_list else linked_ids[0]
+                    linked_ids if linker.many else linked_ids[0]
                 )
         obj = cls.from_dict(obj_as_dict)
         obj.set_backend(self)
@@ -382,7 +397,12 @@ class SQLiteBackend(BackendBase):
 
     def load(self, cls, name):
         """Return the most recently saved object of Saveable class cls with the name"""
-        self._ensure_tables(cls)
+        main_schema = relational.main_table_schema(cls)
+        existing_tables = self._validate_existing_tables([main_schema])
+        if main_schema.name not in existing_tables:
+            raise DataBaseError(
+                f"{self} has no table for objects of type {cls.__name__}."
+            )
         row = self.connection.execute(
             f'SELECT "id" FROM {_quote_identifier(cls.table_name)} '
             'WHERE "name" = ? '
@@ -396,15 +416,19 @@ class SQLiteBackend(BackendBase):
         return self.get(cls, row[0])
 
     def load_obj_data(self, obj):
-        """Return the numerical data of an object from its ndarray column."""
+        """Return the value stored in an object's lazy ``data`` column."""
         main_schema = relational.main_table_schema(type(obj))
-        for column in main_schema.data_columns:
-            if column.dtype is np.ndarray:
-                row = self.connection.execute(
-                    _select_sql(main_schema.name, [column.name]) + ' WHERE "id" = ?',
-                    (obj.id,),
-                ).fetchone()
-                return self._decode(column, row[0]) if row else None
+        data_column = next(
+            (column for column in main_schema.data_columns if column.name == "data"),
+            None,
+        )
+        if data_column is None:
+            return None
+        row = self.connection.execute(
+            _select_sql(main_schema.name, ["data"]) + ' WHERE "id" = ?',
+            (obj.id,),
+        ).fetchone()
+        return self._decode(data_column, row[0]) if row else None
 
     def contains(self, table_name, i):
         """Check if id `i` is already a principle key in the table named `table_name`"""
@@ -417,42 +441,57 @@ class SQLiteBackend(BackendBase):
 
     # ------- schema  ------- #
 
-    def _initialize_schema_metadata(self):
-        """Create and validate the small, backend-owned schema metadata table."""
-        metadata_table = _quote_identifier(METADATA_TABLE)
-        with self.connection as connection:
-            connection.execute(
-                f"CREATE TABLE IF NOT EXISTS {metadata_table} ("
-                '"key" TEXT PRIMARY KEY, "value" TEXT NOT NULL)'
+    def _initialize_schema_metadata(self, database_is_new):
+        """Record a new file's schema version or validate an existing file's."""
+        metadata_table = _quote_identifier(METADATA_TABLE_NAME)
+        if database_is_new:
+            with self.connection as connection:
+                connection.execute(
+                    f"CREATE TABLE {metadata_table} ("
+                    '"key" TEXT PRIMARY KEY, "value" TEXT NOT NULL)'
+                )
+                connection.execute(
+                    f'INSERT INTO {metadata_table} ("key", "value") VALUES (?, ?)',
+                    ("schema_version", str(SCHEMA_VERSION)),
+                )
+            return
+
+        if METADATA_TABLE_NAME not in self._existing_tables():
+            raise DataBaseError(
+                f"The existing database {self.db_path} has no ixdat schema version. "
+                "Copy its objects into a new database with an explicit migration."
             )
-            row = connection.execute(
+        try:
+            row = self.connection.execute(
                 f'SELECT "value" FROM {metadata_table} ' 'WHERE "key" = ?',
                 ("schema_version",),
             ).fetchone()
-            if row is None:
-                # no version stored yet: an older database, or a brand new one.
-                # Either way, _ensure_tables() will check/fix each table as it's used.
-                connection.execute(
-                    f'INSERT INTO {metadata_table} ("key", "value") ' "VALUES (?, ?)",
-                    ("schema_version", str(SCHEMA_VERSION)),
-                )
-                return
-            try:
-                database_version = int(row[0])
-            except (TypeError, ValueError):
-                raise DataBaseError(
-                    f"Invalid ixdat schema version {row[0]!r} in {self.db_path}."
-                )
-            if database_version != SCHEMA_VERSION:
-                relation = "newer" if database_version > SCHEMA_VERSION else "older"
-                raise DataBaseError(
-                    f"The database {self.db_path} uses {relation} ixdat schema "
-                    f"version {database_version}; this ixdat supports version "
-                    f"{SCHEMA_VERSION}. Migrate the database before opening it."
-                )
+        except sqlite3.DatabaseError as error:
+            raise DataBaseError(
+                f"The database {self.db_path} has invalid ixdat schema metadata."
+            ) from error
+        if row is None:
+            raise DataBaseError(
+                f"The database {self.db_path} has no ixdat schema version. "
+                "Copy its objects into a new database with an explicit migration."
+            )
+        try:
+            database_version = int(row[0])
+        except (TypeError, ValueError):
+            raise DataBaseError(
+                f"Invalid ixdat schema version {row[0]!r} in {self.db_path}."
+            )
+        if database_version != SCHEMA_VERSION:
+            relation = "newer" if database_version > SCHEMA_VERSION else "older"
+            raise DataBaseError(
+                f"The database {self.db_path} uses {relation} ixdat schema "
+                f"version {database_version}; this ixdat supports version "
+                f"{SCHEMA_VERSION}. Copy its objects into a new database using "
+                "a compatible ixdat version."
+            )
 
-    def _ensure_tables(self, cls):
-        """Create, validate, and additively migrate tables needed by ``cls``."""
+    def _ensure_tables_for_save(self, cls):
+        """Create or validate the current-version tables needed to save ``cls``."""
         # this only needs doing once per class per backend instance, since a table
         # doesn't change shape again while this backend stays open:
         if cls in self._ensured_classes:
@@ -462,7 +501,7 @@ class SQLiteBackend(BackendBase):
         with self.connection as connection:
             for schema in relational.table_schemas_of(cls):
                 if schema.name in existing_tables:
-                    self._validate_or_migrate_table(connection, schema)
+                    self._validate_table(connection, schema)
                 else:
                     connection.execute(_create_table_sql(schema))
                     existing_tables.add(schema.name)
@@ -471,32 +510,30 @@ class SQLiteBackend(BackendBase):
         self._ensured_schema_definitions.update(ensured_definitions)
         self._ensured_classes.add(cls)
 
-    def _ensure_existing_family_tables(self, schemas):
-        """Validate subclass tables and return the current table-name set.
+    def _validate_existing_tables(self, schemas):
+        """Validate existing tables without changing the database.
 
-        Called from `get()`, which - unlike `_ensure_tables()` - needs to check
-        tables belonging to *other* classes than the one it was asked for (see the
-        comment in `get()`). We track each table by its exact expected DDL here
-        rather than by class, since several classes can share one such table.
+        ``get()`` checks tables belonging to sibling classes before it knows the
+        exact class of a saved row. Missing sibling tables are fine. The caller
+        decides whether a missing main table means that the requested object type
+        has never been saved.
         """
         existing_tables = self._existing_tables()
         ensured_definitions = []
-        with self.connection as connection:
-            for schema in schemas:
-                schema_definition = (schema.name, _create_table_sql(schema))
-                if (
-                    schema.name not in existing_tables
-                    or schema_definition in self._ensured_schema_definitions
-                ):
-                    continue  # table doesn't exist yet, or was already checked
-                self._validate_or_migrate_table(connection, schema)
-                self._ensure_indexes(connection, schema)
-                ensured_definitions.append(schema_definition)
+        for schema in schemas:
+            schema_definition = (schema.name, _create_table_sql(schema))
+            if (
+                schema.name not in existing_tables
+                or schema_definition in self._ensured_schema_definitions
+            ):
+                continue  # table doesn't exist yet, or was already checked
+            self._validate_table(self.connection, schema)
+            ensured_definitions.append(schema_definition)
         self._ensured_schema_definitions.update(ensured_definitions)
         return existing_tables
 
-    def _validate_or_migrate_table(self, connection, schema):
-        """Add missing nullable columns and reject incompatible table layouts."""
+    def _validate_table(self, connection, schema):
+        """Require an existing table to match its current ixdat description."""
         table_info = {
             row[1]: {"type": row[2].upper(), "not_null": row[3], "pk": row[5]}
             for row in connection.execute(
@@ -504,8 +541,6 @@ class SQLiteBackend(BackendBase):
             ).fetchall()
         }
         if isinstance(schema, relational.LinkerTableSchema):
-            # linker tables aren't migrated column-by-column like regular tables
-            # below: if their shape is wrong at all, we just ask for a manual fix.
             expected_names = {
                 schema.owner_column,
                 "position",
@@ -555,17 +590,10 @@ class SQLiteBackend(BackendBase):
         # regular (main/extension) table: check each expected column one by one.
         for column in schema.columns:
             if column.name not in table_info:
-                if column.name == "id":
-                    self._incompatible_schema(
-                        schema.name, 'primary-key column "id" missing'
-                    )
-                # a new column is always safe to add: it's nullable, so existing
-                # rows just get NULL for it - nothing to fill in or guess at.
-                connection.execute(
-                    f"ALTER TABLE {_quote_identifier(schema.name)} ADD COLUMN "
-                    + _column_definition(column, include_primary_key=False)
+                self._incompatible_schema(
+                    schema.name,
+                    f"expected column {column.name!r} is missing",
                 )
-                continue
             actual = table_info[column.name]
             expected_type = SQLITE_TYPES.get(column.dtype, "")
             if expected_type and actual["type"] != expected_type:
@@ -693,28 +721,6 @@ class SQLiteBackend(BackendBase):
         if column.dtype in (dict, list, tuple):
             decoded = json.loads(value)
             return tuple(decoded) if column.dtype is tuple else decoded
-        return value
-
-    def _dereference(self, value):
-        """Turn a reference to another object into a plain id, for storing as a FK
-
-        An id-holding attribute (e.g. `s_ids`) can hold either a plain int id, or,
-        if the referenced object isn't in this backend yet, a `(backend, id)` pair
-        (`Saveable.short_identity`). Only the plain-int case can actually be saved
-        as a foreign key here, so this unwraps that pair and checks it points here.
-        """
-        if (
-            isinstance(value, tuple)
-            and len(value) == 2
-            and isinstance(value[0], BackendBase)
-        ):
-            backend, i = value
-            if backend is self or backend == self:
-                return i
-            raise DataBaseError(
-                f"Can't save a reference to id={i} of {backend} in {self}. "
-                "Save the referenced object here first."
-            )
         return value
 
 

--- a/src/ixdat/backends/sqlite_backend.py
+++ b/src/ixdat/backends/sqlite_backend.py
@@ -676,9 +676,9 @@ class SQLiteBackend(BackendBase):
         if isinstance(value, (dict, list, tuple, np.ndarray)):
             raise DataBaseError(
                 f"Can't save value {value!r} in the dynamically typed column "
-                f"'{column.name}'. If this column should hold dicts/lists or "
-                "numpy arrays, add it to COLUMN_TYPES in ixdat.backends.relational "
-                "as 'JSON' or 'NDARRAY', respectively."
+                f"'{column.name}'. If this column should hold dicts/lists or numpy "
+                f"arrays, give it the type 'JSON' or 'NDARRAY', respectively, in "
+                "the `column_types` of the class which defines the column."
             )
         return value
 

--- a/src/ixdat/backends/sqlite_backend.py
+++ b/src/ixdat/backends/sqlite_backend.py
@@ -227,12 +227,6 @@ class SQLiteBackend(BackendBase):
             return "skip"
         return "insert"
 
-    def add_row(self, obj):
-        """Insert the object's rows in its main, extension, and linker tables"""
-        self._ensure_tables(type(obj))
-        with self.connection as connection:
-            return self._add_row(connection, obj)
-
     def _add_row(self, connection, obj):
         """Insert one object's rows using an existing transaction."""
         main_schema = relational.main_table_schema(type(obj))
@@ -246,12 +240,6 @@ class SQLiteBackend(BackendBase):
         i = cursor.lastrowid
         self._insert_extras(connection, obj, i)
         return i
-
-    def update_row(self, obj):
-        """Update the object's rows in its main, extension, and linker tables"""
-        self._ensure_tables(type(obj))
-        with self.connection as connection:
-            self._update_row(connection, obj)
 
     def _update_row(self, connection, obj):
         """Update one object's rows using an existing transaction."""
@@ -420,16 +408,6 @@ class SQLiteBackend(BackendBase):
             f"SELECT 1 FROM {_quote_identifier(table_name)} WHERE \"id\" = ?", (i,)
         ).fetchone()
         return row is not None
-
-    def get_next_available_id(self, table_name, obj=None):
-        """Return the next available id for a given table"""
-        if table_name not in self._existing_tables():
-            return 1
-        row = self.connection.execute(
-            f"SELECT COALESCE(MAX(\"id\"), 0) + 1 "
-            f"FROM {_quote_identifier(table_name)}"
-        ).fetchone()
-        return row[0]
 
     # ------- schema  ------- #
 

--- a/src/ixdat/backends/sqlite_backend.py
+++ b/src/ixdat/backends/sqlite_backend.py
@@ -141,6 +141,8 @@ class SQLiteBackend(BackendBase):
             # insert a row, anything it points to already has its id. Doing all
             # inserts/updates on one connection makes them one transaction: if
             # anything below fails, SQLite rolls every row in "plan" back.
+            # sqlite3.Connection manages that transaction here; using `self`
+            # instead would call SQLiteBackend.__exit__() and close the backend.
             with self.connection as connection:
                 for planned_obj, action in plan:
                     if action == "skip":
@@ -417,18 +419,26 @@ class SQLiteBackend(BackendBase):
 
     def load_obj_data(self, obj):
         """Return the value stored in an object's lazy ``data`` column."""
+        from ..data_series import DataSeries
+
+        if not isinstance(obj, DataSeries):
+            raise TypeError(
+                "SQLiteBackend.load_obj_data() only accepts DataSeries objects, "
+                f"got {type(obj).__name__}."
+            )
         main_schema = relational.main_table_schema(type(obj))
         data_column = next(
-            (column for column in main_schema.data_columns if column.name == "data"),
-            None,
+            column for column in main_schema.data_columns if column.name == "data"
         )
-        if data_column is None:
-            return None
         row = self.connection.execute(
             _select_sql(main_schema.name, ["data"]) + ' WHERE "id" = ?',
             (obj.id,),
         ).fetchone()
-        return self._decode(data_column, row[0]) if row else None
+        if row is None:
+            raise DataBaseError(
+                f"{self} has no row with id={obj.id} in table '{main_schema.name}'"
+            )
+        return self._decode(data_column, row[0])
 
     def contains(self, table_name, i):
         """Check if id `i` is already a principle key in the table named `table_name`"""

--- a/src/ixdat/backends/sqlite_backend.py
+++ b/src/ixdat/backends/sqlite_backend.py
@@ -1,13 +1,13 @@
 """This module implements an SQLite database backend for ixdat
 
-The SQLite backend saves ixdat objects to, and loads them from, a proper
-relational database in a single local file. The schema is not written by hand:
-it is derived from the table metadata that every Saveable class already defines
-(see :module:`~ixdat.backends.relational`). Tables are created on demand with
-``CREATE TABLE IF NOT EXISTS``, so any Saveable class - including ones defined
-in external plugins - can be saved without registration here.
+Saves and loads ixdat objects using Python's built-in ``sqlite3`` module, so no
+extra dependency is needed. The table layout isn't written by hand - it's built
+from the same table info each Saveable class already carries (see
+:module:`~ixdat.backends.relational`). Tables are created the first time they're
+needed, so any Saveable class, including ones from external plugins, works here
+without extra setup.
 
-Use it like any other ixdat backend::
+Basic usage::
 
     from ixdat.db import change_database
 
@@ -15,22 +15,21 @@ Use it like any other ixdat backend::
     measurement.save()
     ...
     loaded = Measurement.get(1)
-    # or, by name:
-    loaded = Measurement.load("my measurement")
+    loaded = Measurement.load("my measurement")  # or, by name
 
-Numerical data (numpy arrays) is stored in NDARRAY (numpy-format blob) columns,
-which are excluded from queries until the data is actually needed - keeping
-ixdat's laziness intact: `Measurement.get()` touches only metadata, and each
-DataSeries fetches its array from the database the first time `.data` is
-accessed.
+Numeric arrays (numpy data) are stored as blobs and are only read from the
+database when ``.data`` is actually accessed, so opening an object stays fast
+even in a large project.
 
-Saving an object and all of its referenced children is one transaction. Existing
-tables are checked against a versioned schema when they are first used; new nullable
-columns are added automatically, while changes which cannot be migrated without
-ambiguity raise :class:`~ixdat.exceptions.DataBaseError`.
+Saving an object and everything it references happens in one transaction, so a
+crash partway through can't leave the database half-written. The first time a
+table is used, it's checked against what the current Saveable class expects;
+missing columns are added automatically, and anything that can't be changed
+safely raises a :class:`~ixdat.exceptions.DataBaseError` instead of silently
+doing the wrong thing.
 
-Note that an SQLiteBackend's connection belongs to the thread that created the
-backend, as is the default for python's sqlite3 module.
+Note: one SQLiteBackend belongs to the thread that created it - this is just how
+Python's sqlite3 module works. Make a separate backend instance per thread.
 """
 
 import json
@@ -144,9 +143,10 @@ class SQLiteBackend(BackendBase):
         original_states = []
         root_result = None
         try:
-            # The plan is in child-first order, so every foreign-key target is
-            # inserted before the row which refers to it. One connection context
-            # makes the complete object graph a single transaction.
+            # Children come before their parents in "plan", so by the time we
+            # insert a row, anything it points to already has its id. Doing all
+            # inserts/updates on one connection makes them one transaction: if
+            # anything below fails, SQLite rolls every row in "plan" back.
             with self.connection as connection:
                 for planned_obj, action in plan:
                     if action == "skip":
@@ -164,8 +164,9 @@ class SQLiteBackend(BackendBase):
                     if planned_obj is obj:
                         root_result = result
         except Exception:
-            # A rollback removes inserted rows; keep the corresponding in-memory
-            # objects honest by restoring their pre-save identities as well.
+            # The database rollback undoes the inserted rows; undo the matching
+            # id/backend changes on the in-memory objects too, so they don't end
+            # up claiming to be saved when they aren't.
             for saved_obj, old_backend, old_id in reversed(original_states):
                 saved_obj._backend = old_backend
                 saved_obj._id = old_id
@@ -175,19 +176,22 @@ class SQLiteBackend(BackendBase):
     def _build_save_plan(self, root, force, no_updates):
         """Return unique objects in child-first order with insert/update actions."""
         plan = []
-        visited = set()
-        visiting = set()
+        visited = set()  # objects already added to "plan"
+        visiting = set()  # objects currently being visited, i.e. above us in the walk
         existing_tables = self._existing_tables()
 
         def visit(obj, updates_forbidden):
             object_key = id(obj)
             if object_key in visited:
-                return
+                return  # already planned (e.g. two parents sharing one child)
             if object_key in visiting:
+                # we're already in the middle of visiting this object further up
+                # the call stack, i.e. it refers back to itself somewhere
                 raise DataBaseError(
                     f"Can't save a cyclic object graph rooted at {root!r}."
                 )
             visiting.add(object_key)
+            # visit every child first, so they end up earlier in "plan"
             if obj.child_attrs:
                 for child_list_name in obj.child_attrs:
                     for child_obj in getattr(obj, child_list_name) or []:
@@ -270,6 +274,8 @@ class SQLiteBackend(BackendBase):
 
     def _insert_extras(self, connection, obj, i):
         """Insert the object's rows in its extension and linker tables"""
+        # extension tables hold the extra columns of a subclass, one row per object,
+        # keyed by the same id as the main table row:
         for schema in relational.extension_table_schemas(type(obj)):
             columns = schema.data_columns
             values = [
@@ -281,6 +287,8 @@ class SQLiteBackend(BackendBase):
                 ),
                 [i] + values,
             )
+        # linker tables hold one row per reference to another object, e.g. one row
+        # per data series a measurement owns, in the order they should be read back:
         for linker in relational.linker_table_schemas(type(obj)):
             identities = getattr(obj, linker.id_attr)
             if identities is None:
@@ -308,10 +316,12 @@ class SQLiteBackend(BackendBase):
     def get(self, cls, i):
         """Return the object of Saveable class cls built from the rows with id=i
 
-        The object's attributes are collected from cls's main table and from the
-        extension and linker tables of every class sharing that main table (only
-        the tables its concrete class wrote have rows with its id). Numerical
-        data is not loaded here - it is loaded lazily via `load_obj_data`.
+        We don't know the row's exact subclass before reading it (an id=5 in
+        "measurement" could be a plain ECMeasurement or an ECMSMeasurement), so we
+        check the extension/linker tables of every class that shares cls's main
+        table, not just cls's own. Only the tables the row's real class wrote to
+        will actually have a row for this id; the rest are skipped. Numerical data
+        isn't loaded here - see `load_obj_data`.
         """
         self._ensure_tables(cls)
         main_schema = relational.main_table_schema(cls)
@@ -425,9 +435,8 @@ class SQLiteBackend(BackendBase):
                 ("schema_version",),
             ).fetchone()
             if row is None:
-                # Databases made by pre-release versions of this backend did not
-                # carry a version. Their tables are validated and additively migrated
-                # by `_ensure_tables` before use.
+                # no version stored yet: an older database, or a brand new one.
+                # Either way, _ensure_tables() will check/fix each table as it's used.
                 connection.execute(
                     f"INSERT INTO {metadata_table} (\"key\", \"value\") "
                     'VALUES (?, ?)',
@@ -450,6 +459,8 @@ class SQLiteBackend(BackendBase):
 
     def _ensure_tables(self, cls):
         """Create, validate, and additively migrate tables needed by ``cls``."""
+        # this only needs doing once per class per backend instance, since a table
+        # doesn't change shape again while this backend stays open:
         if cls in self._ensured_classes:
             return
         existing_tables = self._existing_tables()
@@ -467,7 +478,13 @@ class SQLiteBackend(BackendBase):
         self._ensured_classes.add(cls)
 
     def _ensure_existing_family_tables(self, schemas):
-        """Validate subclass tables and return the current table-name set."""
+        """Validate subclass tables and return the current table-name set.
+
+        Called from `get()`, which - unlike `_ensure_tables()` - needs to check
+        tables belonging to *other* classes than the one it was asked for (see the
+        comment in `get()`). We track each table by its exact expected DDL here
+        rather than by class, since several classes can share one such table.
+        """
         existing_tables = self._existing_tables()
         ensured_definitions = []
         with self.connection as connection:
@@ -477,7 +494,7 @@ class SQLiteBackend(BackendBase):
                     schema.name not in existing_tables
                     or schema_definition in self._ensured_schema_definitions
                 ):
-                    continue
+                    continue  # table doesn't exist yet, or was already checked
                 self._validate_or_migrate_table(connection, schema)
                 self._ensure_indexes(connection, schema)
                 ensured_definitions.append(schema_definition)
@@ -493,6 +510,8 @@ class SQLiteBackend(BackendBase):
             ).fetchall()
         }
         if isinstance(schema, relational.LinkerTableSchema):
+            # linker tables aren't migrated column-by-column like regular tables
+            # below: if their shape is wrong at all, we just ask for a manual fix.
             expected_names = {
                 schema.owner_column,
                 "position",
@@ -539,12 +558,15 @@ class SQLiteBackend(BackendBase):
             )
             return
 
+        # regular (main/extension) table: check each expected column one by one.
         for column in schema.columns:
             if column.name not in table_info:
                 if column.name == "id":
                     self._incompatible_schema(
                         schema.name, 'primary-key column "id" missing'
                     )
+                # a new column is always safe to add: it's nullable, so existing
+                # rows just get NULL for it - nothing to fill in or guess at.
                 connection.execute(
                     f"ALTER TABLE {_quote_identifier(schema.name)} ADD COLUMN "
                     + _column_definition(column, include_primary_key=False)
@@ -644,9 +666,8 @@ class SQLiteBackend(BackendBase):
             np.save(buffer, np.asarray(value), allow_pickle=False)
             return sqlite3.Binary(buffer.getvalue())
         if column.dtype == "JSON":
-            # Readers frequently expose numpy scalars and arrays in otherwise
-            # JSON-compatible metadata. Use ixdat's shared normalization so both
-            # built-in backends accept the same scientific metadata values.
+            # metadata dicts sometimes contain numpy numbers/arrays, which plain
+            # json.dumps can't handle - convert those to normal Python values first:
             from ..tools import to_jsonable
 
             return json.dumps(to_jsonable(value))
@@ -672,7 +693,13 @@ class SQLiteBackend(BackendBase):
         return value
 
     def _dereference(self, value):
-        """Turn a `short_identity` into an id, requiring that it refers to self"""
+        """Turn a reference to another object into a plain id, for storing as a FK
+
+        An id-holding attribute (e.g. `s_ids`) can hold either a plain int id, or,
+        if the referenced object isn't in this backend yet, a `(backend, id)` pair
+        (`Saveable.short_identity`). Only the plain-int case can actually be saved
+        as a foreign key here, so this unwraps that pair and checks it points here.
+        """
         if (
             isinstance(value, tuple)
             and len(value) == 2

--- a/src/ixdat/backends/sqlite_backend.py
+++ b/src/ixdat/backends/sqlite_backend.py
@@ -333,6 +333,22 @@ class SQLiteBackend(BackendBase):
         ).fetchall()
         return {row[0] for row in rows}
 
+    @staticmethod
+    def schema_report():
+        """Return the CREATE TABLE statements of all imported Saveable classes
+
+        This is the full relational schema of ixdat's data model, derived from
+        the classes' table metadata - whether or not the tables have (yet) been
+        created in this database.
+        """
+        statements = {}
+        for cls in relational.saveable_classes():
+            if not cls.table_name:
+                continue
+            for schema in relational.table_schemas_of(cls):
+                statements.setdefault(schema.name, _create_table_sql(schema))
+        return ";\n\n".join(statements.values()) + ";"
+
     # ------- value encoding  ------- #
 
     def _encode(self, column, value):

--- a/src/ixdat/backends/sqlite_backend.py
+++ b/src/ixdat/backends/sqlite_backend.py
@@ -653,12 +653,20 @@ class SQLiteBackend(BackendBase):
         This is the full relational schema of ixdat's data model, derived from
         the classes' table metadata - whether or not the tables have (yet) been
         created in this database.
+
+        A class whose own table metadata is broken is left out of the report,
+        which stays readable for every other class. Its error is raised when that
+        class is itself saved or loaded.
         """
         statements = {}
         for cls in relational.saveable_classes():
             if not cls.table_name:
                 continue
-            for schema in relational.table_schemas_of(cls):
+            try:
+                schemas = relational.table_schemas_of(cls)
+            except DataBaseError:
+                continue
+            for schema in schemas:
                 statements.setdefault(schema.name, _create_table_sql(schema))
         return ";\n\n".join(statements.values()) + ";"
 

--- a/src/ixdat/backends/sqlite_backend.py
+++ b/src/ixdat/backends/sqlite_backend.py
@@ -216,9 +216,7 @@ class SQLiteBackend(BackendBase):
             plan.append(
                 (
                     obj,
-                    self._save_action(
-                        obj, force, updates_forbidden, existing_tables
-                    ),
+                    self._save_action(obj, force, updates_forbidden, existing_tables),
                 )
             )
 
@@ -230,8 +228,7 @@ class SQLiteBackend(BackendBase):
         row_exists = False
         if obj.backend is self and obj.table_name in existing_tables:
             row_exists = self.connection.execute(
-                f"SELECT 1 FROM {_quote_identifier(obj.table_name)} "
-                'WHERE "id" = ?',
+                f"SELECT 1 FROM {_quote_identifier(obj.table_name)} " 'WHERE "id" = ?',
                 (obj.id,),
             ).fetchone()
         if row_exists:
@@ -271,12 +268,12 @@ class SQLiteBackend(BackendBase):
         )
         connection.execute(
             f"UPDATE {_quote_identifier(main_schema.name)} "
-            f"SET {assignments} WHERE \"id\" = ?",
+            f'SET {assignments} WHERE "id" = ?',
             values + [obj.id],
         )
         for schema in relational.extension_table_schemas(type(obj)):
             connection.execute(
-                f"DELETE FROM {_quote_identifier(schema.name)} WHERE \"id\" = ?",
+                f'DELETE FROM {_quote_identifier(schema.name)} WHERE "id" = ?',
                 (obj.id,),
             )
         for linker in relational.linker_table_schemas(type(obj)):
@@ -297,9 +294,7 @@ class SQLiteBackend(BackendBase):
                 self._encode(column, getattr(obj, column.name)) for column in columns
             ]
             connection.execute(
-                _insert_sql(
-                    schema.name, ["id"] + [column.name for column in columns]
-                ),
+                _insert_sql(schema.name, ["id"] + [column.name for column in columns]),
                 [i] + values,
             )
         # linker tables hold one row per reference to another object, e.g. one row
@@ -403,7 +398,7 @@ class SQLiteBackend(BackendBase):
         """Return the most recently saved object of Saveable class cls with the name"""
         self._ensure_tables(cls)
         row = self.connection.execute(
-            f"SELECT \"id\" FROM {_quote_identifier(cls.table_name)} "
+            f'SELECT "id" FROM {_quote_identifier(cls.table_name)} '
             'WHERE "name" = ? '
             'ORDER BY "id" DESC LIMIT 1',
             (name,),
@@ -430,7 +425,7 @@ class SQLiteBackend(BackendBase):
         if table_name not in self._existing_tables():
             return False
         row = self.connection.execute(
-            f"SELECT 1 FROM {_quote_identifier(table_name)} WHERE \"id\" = ?", (i,)
+            f'SELECT 1 FROM {_quote_identifier(table_name)} WHERE "id" = ?', (i,)
         ).fetchone()
         return row is not None
 
@@ -445,16 +440,14 @@ class SQLiteBackend(BackendBase):
                 '"key" TEXT PRIMARY KEY, "value" TEXT NOT NULL)'
             )
             row = connection.execute(
-                f"SELECT \"value\" FROM {metadata_table} "
-                'WHERE "key" = ?',
+                f'SELECT "value" FROM {metadata_table} ' 'WHERE "key" = ?',
                 ("schema_version",),
             ).fetchone()
             if row is None:
                 # no version stored yet: an older database, or a brand new one.
                 # Either way, _ensure_tables() will check/fix each table as it's used.
                 connection.execute(
-                    f"INSERT INTO {metadata_table} (\"key\", \"value\") "
-                    'VALUES (?, ?)',
+                    f'INSERT INTO {metadata_table} ("key", "value") ' "VALUES (?, ?)",
                     ("schema_version", str(SCHEMA_VERSION)),
                 )
                 return
@@ -736,10 +729,10 @@ def _create_table_sql(schema):
         return (
             f"CREATE TABLE IF NOT EXISTS {_quote_identifier(schema.name)} (\n"
             f"    {_quote_identifier(schema.owner_column)} INTEGER NOT NULL "
-            f"REFERENCES {_quote_identifier(schema.owner_table)}(\"id\"),\n"
+            f'REFERENCES {_quote_identifier(schema.owner_table)}("id"),\n'
             f'    "position" INTEGER NOT NULL,\n'
             f"    {_quote_identifier(schema.linked_column)} INTEGER NOT NULL "
-            f"REFERENCES {_quote_identifier(schema.linked_table)}(\"id\"),\n"
+            f'REFERENCES {_quote_identifier(schema.linked_table)}("id"),\n'
             f"    PRIMARY KEY ({_quote_identifier(schema.owner_column)}, "
             '"position")\n'
             ")"

--- a/src/ixdat/calculators/ec_calculators.py
+++ b/src/ixdat/calculators/ec_calculators.py
@@ -16,6 +16,7 @@ class ECCalibration(Calculator):
 
     calculator_type = "EC calibration"
     extra_column_attrs = {"ec_calibration": {"RE_vs_RHE", "A_el", "R_Ohm"}}
+    column_types = {"RE_vs_RHE": "REAL", "A_el": "REAL", "R_Ohm": "REAL"}
     # TODO: https://github.com/ixdat/ixdat/pull/11#discussion_r677552828
 
     def __init__(

--- a/src/ixdat/calculators/ec_calculators.py
+++ b/src/ixdat/calculators/ec_calculators.py
@@ -16,7 +16,7 @@ class ECCalibration(Calculator):
 
     calculator_type = "EC calibration"
     extra_column_attrs = {"ec_calibration": {"RE_vs_RHE", "A_el", "R_Ohm"}}
-    column_types = {"RE_vs_RHE": "REAL", "A_el": "REAL", "R_Ohm": "REAL"}
+    column_types = {"RE_vs_RHE": float, "A_el": float, "R_Ohm": float}
     # TODO: https://github.com/ixdat/ixdat/pull/11#discussion_r677552828
 
     def __init__(

--- a/src/ixdat/calculators/ms_calculators.py
+++ b/src/ixdat/calculators/ms_calculators.py
@@ -34,7 +34,7 @@ class MSConstantBackground(Saveable):
     """
 
     table_name = "ms_constant_backgrounds"
-    column_attrs = {"mass", "bg"}
+    column_attrs = {"name", "mass", "bg"}
 
     def __init__(
         self,

--- a/src/ixdat/calculators/ms_calculators.py
+++ b/src/ixdat/calculators/ms_calculators.py
@@ -35,6 +35,7 @@ class MSConstantBackground(Saveable):
 
     table_name = "ms_constant_backgrounds"
     column_attrs = {"name", "mass", "bg"}
+    column_types = {"mass": "TEXT", "bg": "REAL"}
 
     def __init__(
         self,
@@ -191,6 +192,7 @@ class MSCalResult(Saveable):
 
     table_name = "ms_cal_results"
     column_attrs = {"name", "mol", "mass", "cal_type", "F"}
+    column_types = {"mol": "TEXT", "mass": "TEXT", "cal_type": "TEXT", "F": "REAL"}
 
     def __init__(
         self,

--- a/src/ixdat/calculators/ms_calculators.py
+++ b/src/ixdat/calculators/ms_calculators.py
@@ -10,7 +10,7 @@ import json
 import numpy as np
 from ..plugins import plugins
 from ..tools import deprecate
-from ..db import Saveable, PlaceHolderObject, fill_object_list
+from ..db import Relationship, Saveable, PlaceHolderObject, fill_object_list
 from ..data_series import ValueSeries
 from ..measurement_base import Calculator
 from ..exceptions import QuantificationError, SeriesNotFoundError
@@ -58,15 +58,14 @@ class MSConstantBackground(Saveable):
 class MSBackgroundSet(Calculator):
     calculator_type = "MS background"
 
-    extra_linkers = {
-        "ms_background_constants": ("ms_constant_backgrounds", "ms_constant_bg_ids")
-        # Additional types of backgrounds would go here
+    relationships = {
+        "constant_bg_list": Relationship(
+            "ms_constant_backgrounds",
+            "ms_constant_bg_ids",
+            many=True,
+            storage_table="ms_background_constants",
+        )
     }
-    child_attrs = [
-        "constant_bg_list",
-        # Additional background types would go here.
-        # FIXME: This repeats info in extra_linkers. Should be possible to combine. #75.
-    ]
 
     def __init__(
         self,
@@ -83,9 +82,8 @@ class MSBackgroundSet(Calculator):
             name (str): Optional name of the instance
             bg_list (list of Saveable background objects): The backgrounds. Max one per
                 mass.
-            ms_constant_bg_ids (list of int): The id's of the constant backgrounds,
-                used when loading from a database instead of `bg_list`. The
-                `MSConstantBackground`s are then only loaded when they are needed.
+            ms_constant_bg_ids (list): Local ids or ``(backend, id)`` references for
+                the constant backgrounds. These are used when ``bg_list`` is absent.
             tstamp (float, optional): Absolute time at which the backgrounds were taken
             measurement (Measurement, optional): Measurement from which the backgorunds
                 were calculated.
@@ -285,10 +283,14 @@ class MSCalibration(Calculator):
 
     calculator_type = "MS calibration"
 
-    extra_linkers = {"ms_calibration_results": ("ms_cal_results", "ms_cal_result_ids")}
-    child_attrs = [
-        "ms_cal_results",
-    ]
+    relationships = {
+        "ms_cal_results": Relationship(
+            "ms_cal_results",
+            "ms_cal_result_ids",
+            many=True,
+            storage_table="ms_calibration_results",
+        )
+    }
 
     def __init__(
         self,
@@ -324,9 +326,8 @@ class MSCalibration(Calculator):
             F (float): Sensitivity factor, for a single sensitivity factor calibration
             ms_cal_results (list of MSCalResult): The mass spec calibrations, required
                unless mol, mass and F are given.
-            ms_cal_result_ids (list of int): The id's of the mass spec calibrations,
-               used when loading from a database instead of `ms_cal_results`. The
-               `MSCalResult`s are then only loaded when they are needed.
+            ms_cal_result_ids (list): Local ids or ``(backend, id)`` references for
+               the mass spec calibrations, used when ``ms_cal_results`` is absent.
             name (str): Name of the ms_calibration. Optional.
             date (str): Date of the ms_calibration. Optional.
             setup (str): Name of the setup where the ms_calibration is made. Optional.

--- a/src/ixdat/calculators/ms_calculators.py
+++ b/src/ixdat/calculators/ms_calculators.py
@@ -10,7 +10,7 @@ import json
 import numpy as np
 from ..plugins import plugins
 from ..tools import deprecate
-from ..db import Saveable
+from ..db import Saveable, PlaceHolderObject, fill_object_list
 from ..data_series import ValueSeries
 from ..measurement_base import Calculator
 from ..exceptions import QuantificationError, SeriesNotFoundError
@@ -72,6 +72,7 @@ class MSBackgroundSet(Calculator):
         self,
         name=None,
         bg_list=None,
+        ms_constant_bg_ids=None,
         technique="MS",
         tstamp=None,
         measurement=None,
@@ -82,6 +83,9 @@ class MSBackgroundSet(Calculator):
             name (str): Optional name of the instance
             bg_list (list of Saveable background objects): The backgrounds. Max one per
                 mass.
+            ms_constant_bg_ids (list of int): The id's of the constant backgrounds,
+                used when loading from a database instead of `bg_list`. The
+                `MSConstantBackground`s are then only loaded when they are needed.
             tstamp (float, optional): Absolute time at which the backgrounds were taken
             measurement (Measurement, optional): Measurement from which the backgorunds
                 were calculated.
@@ -89,10 +93,10 @@ class MSBackgroundSet(Calculator):
         super().__init__(
             name=name, technique=technique, tstamp=tstamp, measurement=measurement
         )
-        self.constant_bg_list = []
-        for bg in bg_list:
+        constant_bg_list = []
+        for bg in bg_list or []:
             if type(bg) is MSConstantBackground:
-                self.constant_bg_list.append(bg)
+                constant_bg_list.append(bg)
             # elif type(bg) is OtherBackgroundClassWhenItIsReady:
             #   self.other_bacground_list.append(bg)
             else:
@@ -100,6 +104,9 @@ class MSBackgroundSet(Calculator):
                     f"Initiating an MSBackgoundSet with a background list including {bg}"
                     ", which is not a recognized MS background type. Skipping that one."
                 )
+        self._constant_bg_list = fill_object_list(
+            constant_bg_list, ms_constant_bg_ids, cls=MSConstantBackground
+        )
 
     @classmethod
     def from_measurement_point(cls, measurement, tspan, mass_list=None):
@@ -119,8 +126,17 @@ class MSBackgroundSet(Calculator):
         return cls(bg_list=bg_list, tstamp=tstamp, measurement=measurement)
 
     @property
+    def constant_bg_list(self):
+        """List of the MSConstantBackgrounds, one per mass"""
+        for i, bg in enumerate(self._constant_bg_list):
+            if isinstance(bg, PlaceHolderObject):
+                self._constant_bg_list[i] = bg.get_object()
+        return self._constant_bg_list
+
+    @property
     def ms_constant_bg_ids(self):
-        return [cal.id for cal in self.constant_bg_list]
+        """List of the id's of the MSConstantBackgrounds, without loading any of them"""
+        return [bg.short_identity for bg in self._constant_bg_list]
 
     @property
     def bg_list(self):
@@ -284,6 +300,7 @@ class MSCalibration(Calculator):
         tstamp=None,  # FIXME: No need to have both a date and a tstamp?
         setup=None,
         ms_cal_results=None,
+        ms_cal_result_ids=None,
         technique="MS",
         measurement=None,
     ):
@@ -307,6 +324,9 @@ class MSCalibration(Calculator):
             F (float): Sensitivity factor, for a single sensitivity factor calibration
             ms_cal_results (list of MSCalResult): The mass spec calibrations, required
                unless mol, mass and F are given.
+            ms_cal_result_ids (list of int): The id's of the mass spec calibrations,
+               used when loading from a database instead of `ms_cal_results`. The
+               `MSCalResult`s are then only loaded when they are needed.
             name (str): Name of the ms_calibration. Optional.
             date (str): Date of the ms_calibration. Optional.
             setup (str): Name of the setup where the ms_calibration is made. Optional.
@@ -330,6 +350,7 @@ class MSCalibration(Calculator):
                     "mol, mass, and F, *and* a ms_cal_results list. Choose one."
                 )
             ms_cal_results = [MSCalResult(mol, mass, F)]
+        ms_cal_results = ms_cal_results or []
         for i, cal in enumerate(ms_cal_results):
             if isinstance(cal, MSCalibration):
                 warnings.warn(
@@ -347,7 +368,9 @@ class MSCalibration(Calculator):
 
         self.date = date
         self.setup = setup
-        self.ms_cal_results = ms_cal_results or []
+        self._ms_cal_results = fill_object_list(
+            ms_cal_results, ms_cal_result_ids, cls=MSCalResult
+        )
 
     @classmethod
     @deprecate(
@@ -577,8 +600,17 @@ class MSCalibration(Calculator):
         return cal
 
     @property
+    def ms_cal_results(self):
+        """List of the MSCalResults with the sensitivity factors"""
+        for i, cal in enumerate(self._ms_cal_results):
+            if isinstance(cal, PlaceHolderObject):
+                self._ms_cal_results[i] = cal.get_object()
+        return self._ms_cal_results
+
+    @property
     def ms_cal_result_ids(self):
-        return [cal.id for cal in self.ms_cal_results]
+        """List of the id's of the MSCalResults, without loading any of them"""
+        return [cal.short_identity for cal in self._ms_cal_results]
 
     @property
     def mol_list(self):

--- a/src/ixdat/calculators/ms_calculators.py
+++ b/src/ixdat/calculators/ms_calculators.py
@@ -35,7 +35,7 @@ class MSConstantBackground(Saveable):
 
     table_name = "ms_constant_backgrounds"
     column_attrs = {"name", "mass", "bg"}
-    column_types = {"mass": "TEXT", "bg": "REAL"}
+    column_types = {"mass": str, "bg": float}
 
     def __init__(
         self,
@@ -208,7 +208,7 @@ class MSCalResult(Saveable):
 
     table_name = "ms_cal_results"
     column_attrs = {"name", "mol", "mass", "cal_type", "F"}
-    column_types = {"mol": "TEXT", "mass": "TEXT", "cal_type": "TEXT", "F": "REAL"}
+    column_types = {"mol": str, "mass": str, "cal_type": str, "F": float}
 
     def __init__(
         self,

--- a/src/ixdat/data_series.py
+++ b/src/ixdat/data_series.py
@@ -7,7 +7,7 @@ case, TimeSeries, which must know its absolute (unix) timestamp.
 """
 
 import numpy as np
-from .db import Saveable
+from .db import Relationship, Saveable, same_short_identity
 from .tools import tstamp_to_string
 from .units import Unit
 from .exceptions import AxisError, BuildError
@@ -109,19 +109,22 @@ class Field(DataSeries):
     """Class for storing multi-dimensional data spanning 'axes'
 
     Characterized by a list of references to these axes, which are themselves also
-    DataSeries. This is represented in the extra linkers.
+    DataSeries. The ``axes_series`` relationship stores their ids in order.
     """
 
-    extra_linkers = {"field_axes": ("data_series", "a_ids")}
-    child_attrs = ["axes_series"]
+    relationships = {
+        "axes_series": Relationship(
+            "data_series", "a_ids", many=True, storage_table="field_axes"
+        )
+    }
     series_type = "field"
 
     def __init__(self, name, unit_name, data, a_ids=None, axes_series=None):
         """Initiate the Field and check that the supplied axes make sense.
 
         Args (in addition to those of parent, :class:`.DataSeries`):
-            a_ids (list of int): The ids of the corresponding axes DataSeries, if not
-                the series are not given directly as `axes_series`
+            a_ids (list): Local ids or ``(backend, id)`` references for the axes, if
+                the series are not given directly as ``axes_series``.
             axes_series (list of DataSeries): The DataSeries describing the axes which
                 the field's data spans, if available
         """
@@ -136,15 +139,27 @@ class Field(DataSeries):
         self._check_axes()  # raises an AxisError if something's wrong
 
     def get_axis_id(self, axis_number):
-        """Return the id of the `axis_number`'th axis of the data"""
+        """Return the backend-aware identity of one axis of the data."""
         if self._axes_series[axis_number]:
-            return self._axes_series[axis_number].id
-        return self._a_ids[axis_number]
+            return self._axes_series[axis_number].short_identity
+        identity = self._a_ids[axis_number]
+        if isinstance(identity, int):
+            backend = self.db.backend if self.backend_type == "none" else self.backend
+            return backend, identity
+        return identity
 
     def get_axis_series(self, axis_number):
         """Return the DataSeries of the `axis_number`'th axis of the data"""
         if not self._axes_series[axis_number]:
-            self._axes_series[axis_number] = DataSeries.get(i=self._a_ids[axis_number])
+            identity = self._a_ids[axis_number]
+            if isinstance(identity, int):
+                backend = (
+                    self.db.backend if self.backend_type == "none" else self.backend
+                )
+                i = identity
+            else:
+                backend, i = identity
+            self._axes_series[axis_number] = DataSeries.get(i=i, backend=backend)
             # And so as not have two id's for the axis_number'th axis:
             self._a_ids[axis_number] = None
         return self._axes_series[axis_number]
@@ -171,10 +186,18 @@ class Field(DataSeries):
                 f"{self!r} is {N}-D but initiated with {len(self._axes_series)} axes"
             )
         for n, (a_id, axis_series) in enumerate(zip(self._a_ids, self._axes_series)):
-            if a_id is not None and axis_series is not None and a_id != axis_series.id:
-                raise AxisError(
-                    f"{self!r} initiated with contradicting id's for {n}'th axis"
-                )
+            if a_id is not None and axis_series is not None:
+                if isinstance(a_id, int):
+                    same_axis = a_id == axis_series.id
+                else:
+                    backend, i = a_id
+                    same_axis = same_short_identity(
+                        (backend, i), axis_series.short_identity
+                    )
+                if not same_axis:
+                    raise AxisError(
+                        f"{self!r} initiated with contradicting id's for {n}'th axis"
+                    )
             elif a_id is None and axis_series is None:
                 raise AxisError(
                     f"{self!r} has no axis id for series or id for its {n}'th axis"
@@ -207,8 +230,9 @@ class Field(DataSeries):
 class ValueSeries(Field):
     """Class to store scalar values that are measured over time.
 
-    Characterized by a reference to the corresponding time series. This reference is
-    represented in relational databases as a row in an auxiliary linker table
+    Its one-item ``axes_series`` list points to the corresponding time series. A
+    relational backend stores this connection in the ``field_axes`` table, including
+    its position in the list.
     """
 
     series_type = "vseries"

--- a/src/ixdat/data_series.py
+++ b/src/ixdat/data_series.py
@@ -21,6 +21,7 @@ class DataSeries(Saveable):
 
     table_name = "data_series"
     column_attrs = {"name", "unit_name", "data", "series_type"}
+    column_types = {"unit_name": "TEXT", "series_type": "TEXT", "data": "NDARRAY"}
     series_type = "series"
 
     def __init__(self, name, unit_name, data):
@@ -71,6 +72,7 @@ class TimeSeries(DataSeries):
     """Class to store time data. These are characterized by having a tstamp"""
 
     extra_column_attrs = {"tstamps": {"tstamp"}}
+    column_types = {"tstamp": "REAL"}
     series_type = "tseries"
 
     def __init__(self, name, unit_name, data, tstamp):

--- a/src/ixdat/data_series.py
+++ b/src/ixdat/data_series.py
@@ -21,7 +21,7 @@ class DataSeries(Saveable):
 
     table_name = "data_series"
     column_attrs = {"name", "unit_name", "data", "series_type"}
-    column_types = {"unit_name": "TEXT", "series_type": "TEXT", "data": "NDARRAY"}
+    column_types = {"unit_name": str, "series_type": str, "data": np.ndarray}
     series_type = "series"
 
     def __init__(self, name, unit_name, data):
@@ -72,7 +72,7 @@ class TimeSeries(DataSeries):
     """Class to store time data. These are characterized by having a tstamp"""
 
     extra_column_attrs = {"tstamps": {"tstamp"}}
-    column_types = {"tstamp": "REAL"}
+    column_types = {"tstamp": float}
     series_type = "tseries"
 
     def __init__(self, name, unit_name, data, tstamp):

--- a/src/ixdat/db.py
+++ b/src/ixdat/db.py
@@ -54,6 +54,7 @@ class DataBase:
 
     def load(self, cls, name):
         """Select and return object of Saveable class cls with name=name from backend"""
+        return self.backend.load(cls, name)
 
     def load_obj_data(self, obj):
         """Load and return the numerical data (obj.data) for a Saveable object"""
@@ -406,6 +407,15 @@ class Saveable:
         old_backend = DB.backend
         DB.set_backend(backend or old_backend)
         obj = DB.get(cls, i)  # gets it from the requested backend.
+        DB.set_backend(old_backend)
+        return obj
+
+    @classmethod
+    def load(cls, name, backend=None):
+        """Open the most recently saved object of cls with the given name"""
+        old_backend = DB.backend
+        DB.set_backend(backend or old_backend)
+        obj = DB.load(cls, name)  # loads it from the requested backend.
         DB.set_backend(old_backend)
         return obj
 

--- a/src/ixdat/db.py
+++ b/src/ixdat/db.py
@@ -481,8 +481,7 @@ class Saveable:
 
     @deprecate(
         "0.3.0",
-        "`load_data` now takes the backend to load from, rather than a DataBase. "
-        "Use `backend=` instead of `db=`.",
+        "`load_data` takes the backend to load the data from. Pass it as `backend=`.",
         "0.4.0",
         kwarg_name="db",
     )

--- a/src/ixdat/db.py
+++ b/src/ixdat/db.py
@@ -21,6 +21,8 @@ Note on terminology:
     see: https://github.com/ixdat/ixdat/pull/1#discussion_r546400793
 """
 
+from contextlib import contextmanager
+
 from .exceptions import DataBaseError
 from .backends import BACKEND_CLASSES, database_backends
 from .tools import thing_is_close
@@ -45,16 +47,31 @@ class DataBase:
         """Save a Saveable object with the backend"""
         return self.backend.save(obj)
 
+    @contextmanager
+    def temporary_backend(self, backend=None):
+        """Temporarily select a backend and always restore the previous one.
+
+        Building lazy ixdat objects requires the selected backend to be active while
+        ``from_dict`` creates their placeholder children. Keeping that state change in
+        one exception-safe context prevents a failed load from changing where later
+        objects are saved or loaded.
+        """
+        old_backend = self.backend
+        self.set_backend(backend or old_backend)
+        try:
+            yield self.backend
+        finally:
+            self.set_backend(old_backend)
+
     def get(self, cls, i, backend=None):
         """Select and return object of Saveable class cls with id=i from the backend"""
-        backend = backend or self.backend
-        obj = backend.get(cls, i)
-        # obj will already have obj.id = i and obj.backend = self.backend from backend
-        return obj
+        with self.temporary_backend(backend) as selected_backend:
+            return selected_backend.get(cls, i)
 
-    def load(self, cls, name):
+    def load(self, cls, name, backend=None):
         """Select and return object of Saveable class cls with name=name from backend"""
-        return self.backend.load(cls, name)
+        with self.temporary_backend(backend) as selected_backend:
+            return selected_backend.load(cls, name)
 
     def load_obj_data(self, obj):
         """Load and return the numerical data (obj.data) for a Saveable object"""
@@ -90,7 +107,7 @@ DB = DataBase()  # initate the database. It functions as a global "constant"
 
 def change_database(db_name, **db_kwargs):
     """Change the backend specifying which database objects are saved to/loaded from"""
-    DB.set_backend(db_name, **db_kwargs)
+    return DB.set_backend(db_name, **db_kwargs)
 
 
 def get_database_name():
@@ -404,25 +421,19 @@ class Saveable:
     @classmethod
     def get(cls, i, backend=None):
         """Open an object of cls given its id (the table is cls.table_name)"""
-        old_backend = DB.backend
-        DB.set_backend(backend or old_backend)
-        obj = DB.get(cls, i)  # gets it from the requested backend.
-        DB.set_backend(old_backend)
-        return obj
+        return DB.get(cls, i, backend=backend)
 
     @classmethod
     def load(cls, name, backend=None):
         """Open the most recently saved object of cls with the given name"""
-        old_backend = DB.backend
-        DB.set_backend(backend or old_backend)
-        obj = DB.load(cls, name)  # loads it from the requested backend.
-        DB.set_backend(old_backend)
-        return obj
+        return DB.load(cls, name, backend=backend)
 
     def load_data(self, db=None):
         """Load the data of the object, if ixdat in its laziness hasn't done so yet"""
-        db = db or self.db
-        return db.load_obj_data(self)
+        # Objects remember the backend they came from. This matters when an object
+        # was loaded with ``get(..., backend=...)`` without changing the global DB.
+        data_source = db or self.backend
+        return data_source.load_obj_data(self)
 
 
 class PlaceHolderObject:

--- a/src/ixdat/db.py
+++ b/src/ixdat/db.py
@@ -52,7 +52,7 @@ class DataBase:
         """Switch to a backend for the duration of the `with` block, then switch back.
 
         Loading an object needs its backend to be the active one, since building
-        its lazy child objects happens through that global setting. Using a
+        its lazily loaded related objects happens through that global setting. Using a
         `with`-block guarantees the old backend is restored even if loading fails
         partway through, so a failed load can't leave later saves/loads pointed at
         the wrong database.
@@ -112,6 +112,60 @@ def get_database_name():
     return DB.backend.__class__.__name__
 
 
+class Relationship:
+    """Describe how a Saveable object refers to other Saveable objects.
+
+    The key in a class's ``relationships`` dictionary is the object attribute,
+    while this description connects it to the stored id attribute and table(s).
+
+    Args:
+        linked_table (str): The table containing the related object.
+        id_attr (str): The attribute which returns the related object's saved id,
+            or its ordered ids when ``many=True``.
+        many (bool): Whether the object attribute contains an ordered list.
+        storage_table (str or None): The table which stores the relationship. A
+            relationship containing many objects requires its own table of
+            connections. A relationship containing one object uses the owner's main
+            table when this is left out.
+        save_related (bool): Whether saving the owner also sends the related object
+            or objects through the backend's save process first. This gives new
+            related objects saved ids. A save with ``force=True`` also updates related
+            objects which are already saved.
+    """
+
+    def __init__(
+        self,
+        linked_table,
+        id_attr,
+        *,
+        many=False,
+        storage_table=None,
+        save_related=True,
+    ):
+        if many and not storage_table:
+            raise ValueError(
+                "A relationship containing many objects needs a storage_table."
+            )
+        self.linked_table = linked_table
+        self.id_attr = id_attr
+        self.many = many
+        self.storage_table = storage_table
+        self.save_related = save_related
+
+
+def same_short_identity(first, second):
+    """Return whether two ``(backend, id)`` references reach the same row.
+
+    A short identity contains a live backend object. Two backend objects can use
+    separate connections to the same storage, so comparing the tuples directly
+    can report a difference for references which reach the same row. The table is
+    supplied by the surrounding relationship or object class.
+    """
+    first_backend, first_id = first
+    second_backend, second_id = second
+    return first_id == second_id and first_backend.shares_storage_with(second_backend)
+
+
 class Saveable:
     """Base class for table-representing classes implementing database functionality.
 
@@ -121,18 +175,13 @@ class Saveable:
 
     At a minimum, the `table_name` and `column_attrs` class attributes need to be
     overwritten in inheriting classes to define the name and columns of the main
-    corresponding table. If an auxiliary table is needed to store lists of references
-    as rows, this should be represented in `linkers`. Sub-sub classes can use
-    `extra_column_attrs` to add extra columns via an auxiliary table without changing
-    the main table name.
+    corresponding table. Sub-sub classes can use `extra_column_attrs` to add extra
+    columns via an auxiliary table without changing the main table name.
 
     A class can also say what Python type of value each of its columns holds, with
-    `column_types`, and which columns hold the id of a row of another table, with
-    `column_references`. Relational backends need this to build their tables (see
-    :module:`~ixdat.backends.relational`); backends which just serialize each object
-    on its own, like the directory backend, ignore it. Both are optional: a column
-    which isn't in `column_types` holds whatever type its value already has, which
-    is all a plain str/int/float attribute needs.
+    `column_types`, and describe references to other Saveable objects with
+    `relationships`. SQL backends use this to build their tables (see
+    :module:`~ixdat.backends.relational`).
 
     ixdat is lazy, only loading things when needed. Correspondingly, all of the columns
     of table mentioned above should refer to (lists of) id's and not actual objects of
@@ -150,19 +199,20 @@ class Saveable:
         extra_column_attrs (dict): {table_name: {attr}} for auxiliary tables
             containing subclass attributes. Definitions are merged over the class
             ancestry, so each class only declares the tables and columns it adds.
-        extra_linkers (dict): {table_name: (reference_table, attr)} for defining
-            the connections between objects. Also merged over the class ancestry.
+        extra_linkers (dict): Older form of relationship metadata, kept so existing
+            external Saveable classes continue to work.
         column_types (dict): {attr: python_type} giving the type of the value stored
             in a column, for the columns where it matters. Supported types are
             ``int``, ``float``, ``str``, ``dict``, ``list``, ``tuple``, and
             ``numpy.ndarray``. A column left out here has no fixed type. Definitions
             are merged over the inheriting classes, so a class only declares the
             columns it adds itself.
-        column_references (dict): {attr: table_name} for the columns which hold the
-            id of a single row of another table, e.g. {"field_id": "data_series"}.
-            The column referred to is always that table's "id". Also merged over the
-            inheriting classes. This is for a column of *this* class's table; a
-            reference stored as rows of its own table goes in `extra_linkers`.
+        column_references (dict): Older form of single-reference metadata, kept so
+            existing external Saveable classes continue to work.
+        relationships (dict): {object_attr: Relationship} connecting a Python object
+            attribute to its stored id attribute. This also says whether the
+            relationship holds one object or many, which table stores its ids, and
+            whether its related objects join the same save process.
 
     Object attributes:
         backend (Backend): the backend where the object is saved. For a
@@ -180,15 +230,13 @@ class Saveable:
     table_name = None  # THIS MUST BE OVERWRITTEN IN INHERITING CLASSES
     column_attrs = None  # THIS SHOULD BE OVERWRITTEN IN INHERITING CLASSES
     extra_column_attrs = None  # THIS CAN BE OVERWRITTEN IN INHERITING CLASSES
-    extra_linkers = None  # THIS CAN BE OVERWRITTEN IN INHERITING CLASSES
+    extra_linkers = None  # LEGACY RELATIONSHIP DESCRIPTION
     # every ixdat table has a name. Inheriting classes add the types of the columns
     # they introduce themselves; get_column_types() merges them back together:
     column_types = {"name": str}
-    column_references = None  # THIS CAN BE OVERWRITTEN IN INHERITING CLASSES
-    # TODO: derive child_attrs somehow from the above class attributes, and have it in
-    #   a way where it's easy to tell which id goes with which attribute, i.e. s_ids
-    #   goes with series_list
-    child_attrs = None  # THIS SHOULD BE OVERWRITTEN IN CLASSES WITH DATA REFERENCES
+    column_references = None  # LEGACY SINGLE-REFERENCE DESCRIPTION
+    relationships = None  # THIS CAN BE OVERWRITTEN IN CLASSES WITH REFERENCES
+    child_attrs = None  # LEGACY LIST OF RELATED OBJECT ATTRIBUTES
 
     def __init__(self, backend=None, **self_as_dict):
         """Initialize a Saveable object from its dictionary serialization
@@ -228,23 +276,16 @@ class Saveable:
 
     @property
     def short_identity(self):
-        """short_identity is the backend if different from the active backend and the id
+        """Return ``(backend, id)`` so a reference says where its object lives.
 
-        FIXME: The overloaded return here is annoying and dangerous, but necessary for
-          `Measurement.from_dict(m.as_dict())` to work as a copy, since the call to
-          `fill_object_list` has to specify where the objects represented by
-          PlaceHolderObjects live. Note that calling save() on a Saveable object will
-          turn the backends into DB.backend, so this will only give id's when saving.
-        This is (usually) sufficient to tell if two objects refer to the same thing,
-        when used together with the class attribute table_name
+        Use :func:`same_short_identity` when comparing references from the same
+        table. Separate backend objects may connect to the same storage.
         """
-        if self.backend == DB.backend:
-            return self.id
         return self.backend, self.id
 
     @property
     def full_identity(self):
-        """The full immutable object short_identity as (str, str, str, int)
+        """Return the storage address, table, and id as an immutable tuple.
 
         Specifically: (backend_type, backend.address, table_name, id)
         """
@@ -294,6 +335,7 @@ class Saveable:
             exclude (list): List of attribute names to leave out of the dict
         """
         exclude = exclude or []
+        main_column_attrs = self.get_main_column_attrs()
         if self.column_attrs is None:
             raise DataBaseError(
                 f"{self!r} can't be serialized because the class "
@@ -301,7 +343,7 @@ class Saveable:
             )
         self_as_dict = {  # FIXME: probably better as loop, fix with table definitions.
             attr: getattr(self, attr)
-            for attr in self.column_attrs
+            for attr in main_column_attrs
             if attr not in exclude
         }
         return self_as_dict
@@ -309,18 +351,11 @@ class Saveable:
     def as_dict(self, exclude=None):
         """Return dict: serialization of the object main and auxiliary tables"""
 
-        # So that a new object initiated using the dictionary returned here
-        #   can find objects referenced by identities (i.e. s_ids for series_list),
-        #   we need to make sure they are saved in a real backend. Before adding the
-        #   id's to a list.
-        # FIXME: There would be a more precise and elegant way to do this if the id's
-        #   and corresponding attributes could be connected through class attributes.
-        #   To do with table definitions.
-        if self.child_attrs:
-            for child_object_list_name in self.child_attrs:
-                for child_obj in getattr(self, child_object_list_name):
-                    if child_obj.backend is database_backends["none"]:
-                        database_backends["memory"].save(child_obj)
+        # Save unsaved related objects in memory before reading their id attributes.
+        # This gives a dictionary copy enough information to find those objects again.
+        for related_obj in self.iter_related_objects():
+            if related_obj.backend is database_backends["none"]:
+                database_backends["memory"].save(related_obj)
 
         exclude = exclude or []
         self_as_dict = self.get_main_dict(exclude=exclude)
@@ -358,37 +393,49 @@ class Saveable:
         if not len(self_as_dict) == len(other_as_dict):
             # If they don't have the same number of items, they are not equal:
             return False
-        extra_linkers = self.get_extra_linkers()
-        if extra_linkers:
-            linker_id_names = {id_name for _, id_name in extra_linkers.values()}
-        else:
-            linker_id_names = []
+        linker_id_names = {id_name for _, id_name in self.get_extra_linkers().values()}
+        relationship_id_names = {
+            relationship.id_attr for relationship in self.get_relationships().values()
+        }
         for key in self_as_dict:
             # Here we go through the values
             if key not in other_as_dict:
                 # other.as_dict() must have all the keys of self.as_dict() to be equal
                 return False
-            if key in linker_id_names:
-                # So, we don't want the linker names.
-                # FIXME: Right now there's no way to figure out what the property (named
-                #   in child_attrs) is called from the id_name :( ... so we have to
-                #   pass here and do a new loop with the child_attrs.
-                pass
+            if key in linker_id_names or key in relationship_id_names:
+                continue
 
             if not thing_is_close(self_as_dict[key], other_as_dict[key]):
                 # Then the values aren't close (for floats and np arrays) or aren't
                 # equal (for all else)
                 return False
 
-        # Now we have to go through the owned Saveable objects:
-        if self.child_attrs:
-            for object_list_name in self.child_attrs:
-                object_list = getattr(self, object_list_name)
-                other_object_list = getattr(other, object_list_name)
-                # These two object lists need to have every corresponding element equal:
-                for object, other_object in zip(object_list, other_object_list):
-                    if object != other_object:
-                        return False
+        compared_attrs = set()
+        for object_attr, relationship in self.get_relationships().items():
+            compared_attrs.add(object_attr)
+            object_list = self._related_object_list(object_attr, relationship)
+            other_object_list = other._related_object_list(object_attr, relationship)
+            if len(object_list) != len(other_object_list):
+                return False
+            if any(
+                obj != other_obj
+                for obj, other_obj in zip(object_list, other_object_list)
+            ):
+                return False
+
+        # Compare objects declared with the older child_attrs metadata as well.
+        for object_attr in self.child_attrs or ():
+            if object_attr in compared_attrs:
+                continue
+            object_list = self._legacy_child_list(object_attr)
+            other_object_list = other._legacy_child_list(object_attr)
+            if len(object_list) != len(other_object_list):
+                return False
+            if any(
+                obj != other_obj
+                for obj, other_obj in zip(object_list, other_object_list)
+            ):
+                return False
 
         # If False hasn't been returned yet, then self and other are functionally equal.
         return True
@@ -403,15 +450,51 @@ class Saveable:
         db = db or self.db
         return db.save(self)
 
+    def _related_object_list(self, object_attr, relationship):
+        """Return one relationship's value as a list for traversal/comparison."""
+        value = getattr(self, object_attr)
+        if relationship.many:
+            return list(value or ())
+        return [] if value is None else [value]
+
+    def _legacy_child_list(self, object_attr):
+        """Return an older child_attrs value as a list."""
+        value = getattr(self, object_attr)
+        if value is None:
+            return []
+        if isinstance(value, (list, tuple, set)):
+            return list(value)
+        return [value]
+
+    def iter_related_objects(self):
+        """Yield objects which should be saved before this object."""
+        relationship_attrs = set()
+        for object_attr, relationship in self.get_relationships().items():
+            relationship_attrs.add(object_attr)
+            if relationship.save_related:
+                yield from self._related_object_list(object_attr, relationship)
+        for object_attr in self.child_attrs or ():
+            if object_attr not in relationship_attrs:
+                yield from self._legacy_child_list(object_attr)
+
     @classmethod
     def get_all_column_attrs(cls):
         """List all attributes of objects of cls that correspond to table columns"""
-        all_attrs = set(cls.column_attrs or ())
+        all_attrs = set(cls.get_main_column_attrs())
         for attrs in cls.get_extra_column_attrs().values():
             all_attrs.update(attrs)
         for _, attr in cls.get_extra_linkers().values():
             all_attrs.add(attr)
         return all_attrs
+
+    @classmethod
+    def get_main_column_attrs(cls):
+        """Return columns stored in the object's main table."""
+        attrs = set(cls.column_attrs or ())
+        for relationship in cls.get_relationships().values():
+            if not relationship.many and relationship.storage_table is None:
+                attrs.add(relationship.id_attr)
+        return attrs
 
     @classmethod
     def get_extra_column_attrs(cls):
@@ -429,16 +512,36 @@ class Saveable:
                 ancestor.__dict__.get("extra_column_attrs") or {}
             ).items():
                 merged.setdefault(table_name, set()).update(attrs)
+        for relationship in cls.get_relationships().values():
+            if not relationship.many and relationship.storage_table:
+                merged.setdefault(relationship.storage_table, set()).add(
+                    relationship.id_attr
+                )
         return merged
 
     @classmethod
     def get_extra_linkers(cls):
-        """Return linker-table definitions merged over ``cls``'s ancestry."""
+        """Return old and new connection-table definitions for ``cls``.
+
+        The two-item tuples are the format used by the older ``extra_linkers`` API.
+        New relationships are converted to that format for existing backend code.
+        """
         merged = {}
         for ancestor in reversed(cls.__mro__):
             if getattr(ancestor, "table_name", None) == cls.table_name:
                 merged.update(ancestor.__dict__.get("extra_linkers") or {})
+        for relationship in cls.get_relationships().values():
+            if relationship.many:
+                merged[relationship.storage_table] = (
+                    relationship.linked_table,
+                    relationship.id_attr,
+                )
         return merged
+
+    @classmethod
+    def get_relationships(cls):
+        """Return Relationship definitions merged over ``cls``'s ancestry."""
+        return cls._merged_class_dict("relationships")
 
     @classmethod
     def get_column_types(cls):
@@ -453,11 +556,16 @@ class Saveable:
 
     @classmethod
     def get_column_references(cls):
-        """Return {attr: table_name} for all of cls's columns which hold a foreign id
+        """Return {id_attr: table_name} for ids which point to another table.
 
-        Merged over the inheriting classes, exactly like `get_column_types`.
+        This combines older ``column_references`` declarations with relationships
+        containing one object.
         """
-        return cls._merged_class_dict("column_references")
+        references = cls._merged_class_dict("column_references")
+        for relationship in cls.get_relationships().values():
+            if not relationship.many:
+                references[relationship.id_attr] = relationship.linked_table
+        return references
 
     @classmethod
     def _merged_class_dict(cls, attr):
@@ -509,9 +617,9 @@ class PlaceHolderObject:
         """Initiate a PlaceHolderObject with info for loading the real obj when needed
 
         Args:
-            identity (int or tuple): The id (principle key) of the object represented OR
-                the short identity, i.e. a tuple of the id and the backend. In the later
-                case, identity[1] overrides a backend if given
+            identity (int or tuple): A local integer id or the ``(backend, id)``
+                returned by ``short_identity``. A backend in the tuple takes priority
+                over the separate ``backend`` argument.
             cls (class): Class inheriting from Saveable and thus specifiying the table
             backend (Backend, optional): by default, placeholders objects must live in
                 the active backend. This is the case if loaded with get().
@@ -534,9 +642,7 @@ class PlaceHolderObject:
 
     @property
     def short_identity(self):
-        """Placeholder also has a short_identity to check equivalence without loading"""
-        if self.backend == DB.backend:
-            return self.id
+        """Return an identity that can be checked without loading the real object."""
         return self.backend, self.id
 
 
@@ -547,20 +653,24 @@ def fill_object_list(object_list, obj_ids, cls=None):
         object_list (list of objects or None): The objects already known,
             in a list. This is the list to be appended to. If None, an empty
             list will be appended to.
-        obj_ids (list of ints or None): The id's of objects to ensure are in
-            the list. Any id in obj_ids not already represented in object_list
-            is added to the list as a PlaceHolderObject
+        obj_ids (list or None): Local ids or ``(backend, id)`` references to ensure
+            are represented. Missing references become PlaceHolderObjects.
         cls (Saveable class): the class remembered by any PlaceHolderObjects
             added to the object_list, so that eventually the right object will
             be loaded. Must be specified if object_list is empty.
     """
     cls = cls or object_list[0].__class__
     object_list = object_list or []
-    provided_series_ids = [s.id for s in object_list]
     if not obj_ids:
         return object_list
     for identity in obj_ids:
-        if identity not in provided_series_ids:
+        if isinstance(identity, int):
+            backend, i = DB.backend, identity
+        else:
+            backend, i = identity
+        if not any(
+            same_short_identity(obj.short_identity, (backend, i)) for obj in object_list
+        ):
             object_list.append(PlaceHolderObject(identity=identity, cls=cls))
     return object_list
 

--- a/src/ixdat/db.py
+++ b/src/ixdat/db.py
@@ -49,12 +49,13 @@ class DataBase:
 
     @contextmanager
     def temporary_backend(self, backend=None):
-        """Temporarily select a backend and always restore the previous one.
+        """Switch to a backend for the duration of the `with` block, then switch back.
 
-        Building lazy ixdat objects requires the selected backend to be active while
-        ``from_dict`` creates their placeholder children. Keeping that state change in
-        one exception-safe context prevents a failed load from changing where later
-        objects are saved or loaded.
+        Loading an object needs its backend to be the active one, since building
+        its lazy child objects happens through that global setting. Using a
+        `with`-block guarantees the old backend is restored even if loading fails
+        partway through, so a failed load can't leave later saves/loads pointed at
+        the wrong database.
         """
         old_backend = self.backend
         self.set_backend(backend or old_backend)
@@ -426,8 +427,8 @@ class Saveable:
 
     def load_data(self, db=None):
         """Load the data of the object, if ixdat in its laziness hasn't done so yet"""
-        # Objects remember the backend they came from. This matters when an object
-        # was loaded with ``get(..., backend=...)`` without changing the global DB.
+        # use the backend this object actually came from, not necessarily the
+        # current global one (e.g. if it was loaded with get(..., backend=...)):
         data_source = db or self.backend
         return data_source.load_obj_data(self)
 

--- a/src/ixdat/db.py
+++ b/src/ixdat/db.py
@@ -126,7 +126,7 @@ class Saveable:
     `extra_column_attrs` to add extra columns via an auxiliary table without changing
     the main table name.
 
-    A class can also say what *type* of value each of its columns holds, with
+    A class can also say what Python type of value each of its columns holds, with
     `column_types`, and which columns hold the id of a row of another table, with
     `column_references`. Relational backends need this to build their tables (see
     :module:`~ixdat.backends.relational`); backends which just serialize each object
@@ -148,21 +148,21 @@ class Saveable:
         column_attrs (set of str): {attr} where attr is the name of the column in the
             table and also the name of the attribute of the class.
         extra_column_attrs (dict): {table_name: {attr}} for auxiliary tables
-            to represent the "extra" attributes, for double-inheriting classes.
-        linkers (dict): {table_name: (reference_table, attr)} for defining
-            the connections between objects.
-        column_types (dict): {attr: type_name} giving the type of the value stored
-            in a column, for the columns where it matters. The type names are
-            "INTEGER", "REAL", "TEXT" for plain numbers and text, "JSON" for dicts
-            and lists, and "NDARRAY" for numpy arrays. A column left out here has no
-            fixed type. Unlike `extra_column_attrs`, this is *merged* over the
-            inheriting classes, so a class only declares the columns it adds itself.
+            containing subclass attributes. Definitions are merged over the class
+            ancestry, so each class only declares the tables and columns it adds.
+        extra_linkers (dict): {table_name: (reference_table, attr)} for defining
+            the connections between objects. Also merged over the class ancestry.
+        column_types (dict): {attr: python_type} giving the type of the value stored
+            in a column, for the columns where it matters. Supported types are
+            ``int``, ``float``, ``str``, ``dict``, ``list``, ``tuple``, and
+            ``numpy.ndarray``. A column left out here has no fixed type. Definitions
+            are merged over the inheriting classes, so a class only declares the
+            columns it adds itself.
         column_references (dict): {attr: table_name} for the columns which hold the
             id of a single row of another table, e.g. {"field_id": "data_series"}.
             The column referred to is always that table's "id". Also merged over the
-            inheriting classes. Note that this is for a column of *this* class's
-            table; a reference stored as rows of its own table goes in
-            `extra_linkers` instead.
+            inheriting classes. This is for a column of *this* class's table; a
+            reference stored as rows of its own table goes in `extra_linkers`.
 
     Object attributes:
         backend (Backend): the backend where the object is saved. For a
@@ -178,14 +178,12 @@ class Saveable:
 
     db = DB
     table_name = None  # THIS MUST BE OVERWRITTEN IN INHERITING CLASSES
-    # TODO: restructure column_attrs, extra_column_attrs, extra_linkers so that they are
-    #  sufficient to fully define the tables in an SQL backend
     column_attrs = None  # THIS SHOULD BE OVERWRITTEN IN INHERITING CLASSES
     extra_column_attrs = None  # THIS CAN BE OVERWRITTEN IN INHERITING CLASSES
     extra_linkers = None  # THIS CAN BE OVERWRITTEN IN INHERITING CLASSES
     # every ixdat table has a name. Inheriting classes add the types of the columns
     # they introduce themselves; get_column_types() merges them back together:
-    column_types = {"name": "TEXT"}
+    column_types = {"name": str}
     column_references = None  # THIS CAN BE OVERWRITTEN IN INHERITING CLASSES
     # TODO: derive child_attrs somehow from the above class attributes, and have it in
     #   a way where it's easy to tell which id goes with which attribute, i.e. s_ids
@@ -240,7 +238,7 @@ class Saveable:
         This is (usually) sufficient to tell if two objects refer to the same thing,
         when used together with the class attribute table_name
         """
-        if self.backend is DB.backend:
+        if self.backend == DB.backend:
             return self.id
         return self.backend, self.id
 
@@ -326,25 +324,13 @@ class Saveable:
 
         exclude = exclude or []
         self_as_dict = self.get_main_dict(exclude=exclude)
-        if self.extra_column_attrs:
-            # FIXME: comprehension best as loop. Will be redone with proper table defs.
-            aux_tables_dict = {
-                table_name: {
-                    attr: getattr(self, attr) for attr in extras if attr not in exclude
-                }
-                for table_name, extras in self.extra_column_attrs.items()
-            }
-            for aux_dict in aux_tables_dict.values():
-                self_as_dict.update(**aux_dict)
-        if self.extra_linkers:
-            # FIXME: comprehension best as loop. Will be redone with proper table defs.
-            linker_tables_dict = {
-                (table_name, linked_table_name): {attr: getattr(self, attr)}
-                for table_name, (linked_table_name, attr) in self.extra_linkers.items()
-                if attr not in exclude
-            }
-            for linked_attrs in linker_tables_dict.values():
-                self_as_dict.update(**linked_attrs)
+        for attrs in self.get_extra_column_attrs().values():
+            for attr in attrs:
+                if attr not in exclude:
+                    self_as_dict[attr] = getattr(self, attr)
+        for _, attr in self.get_extra_linkers().values():
+            if attr not in exclude:
+                self_as_dict[attr] = getattr(self, attr)
 
         return self_as_dict
 
@@ -372,14 +358,9 @@ class Saveable:
         if not len(self_as_dict) == len(other_as_dict):
             # If they don't have the same number of items, they are not equal:
             return False
-        if self.extra_linkers:
-            linker_id_names = [
-                id_name
-                for (
-                    linker_table_name,
-                    (linked_table_name, id_name),
-                ) in self.extra_linkers.items()
-            ]  # FIXME: This will be made much simpler with coming metaprogramming
+        extra_linkers = self.get_extra_linkers()
+        if extra_linkers:
+            linker_id_names = {id_name for _, id_name in extra_linkers.values()}
         else:
             linker_id_names = []
         for key in self_as_dict:
@@ -425,14 +406,39 @@ class Saveable:
     @classmethod
     def get_all_column_attrs(cls):
         """List all attributes of objects of cls that correspond to table columns"""
-        all_attrs = cls.column_attrs
-        if cls.extra_column_attrs:
-            for table, attrs in cls.extra_column_attrs.items():
-                all_attrs = all_attrs.union(attrs)
-        if cls.extra_linkers:
-            for table, (ref_table, attr) in cls.extra_linkers.items():
-                all_attrs.add(attr)
+        all_attrs = set(cls.column_attrs or ())
+        for attrs in cls.get_extra_column_attrs().values():
+            all_attrs.update(attrs)
+        for _, attr in cls.get_extra_linkers().values():
+            all_attrs.add(attr)
         return all_attrs
+
+    @classmethod
+    def get_extra_column_attrs(cls):
+        """Return extension-table columns merged over ``cls``'s ancestry.
+
+        Each class declares only the extension tables and columns it introduces.
+        Columns declared for the same table are combined. Ancestors with a different
+        main table describe a separate persistence model and are left out.
+        """
+        merged = {}
+        for ancestor in reversed(cls.__mro__):
+            if getattr(ancestor, "table_name", None) != cls.table_name:
+                continue
+            for table_name, attrs in (
+                ancestor.__dict__.get("extra_column_attrs") or {}
+            ).items():
+                merged.setdefault(table_name, set()).update(attrs)
+        return merged
+
+    @classmethod
+    def get_extra_linkers(cls):
+        """Return linker-table definitions merged over ``cls``'s ancestry."""
+        merged = {}
+        for ancestor in reversed(cls.__mro__):
+            if getattr(ancestor, "table_name", None) == cls.table_name:
+                merged.update(ancestor.__dict__.get("extra_linkers") or {})
+        return merged
 
     @classmethod
     def get_column_types(cls):
@@ -440,9 +446,8 @@ class Saveable:
 
         Each class in cls's ancestry contributes the columns it declares itself in
         `column_types`, with the more specific class winning where they disagree.
-        Merging like this means a class only has to name the columns it adds, and,
-        unlike `extra_column_attrs`, that a class inheriting from two table-defining
-        classes gets the column types of both.
+        Merging lets a class name only the columns it adds. A class inheriting from
+        two table-defining classes gets the column types of both.
         """
         return cls._merged_class_dict("column_types")
 
@@ -530,7 +535,7 @@ class PlaceHolderObject:
     @property
     def short_identity(self):
         """Placeholder also has a short_identity to check equivalence without loading"""
-        if self.backend is DB.backend:
+        if self.backend == DB.backend:
             return self.id
         return self.backend, self.id
 

--- a/src/ixdat/db.py
+++ b/src/ixdat/db.py
@@ -25,7 +25,7 @@ from contextlib import contextmanager
 
 from .exceptions import DataBaseError
 from .backends import BACKEND_CLASSES, database_backends
-from .tools import thing_is_close
+from .tools import deprecate, thing_is_close
 
 
 class DataBase:
@@ -479,12 +479,23 @@ class Saveable:
         """Open the most recently saved object of cls with the given name"""
         return DB.load(cls, name, backend=backend)
 
-    def load_data(self, db=None):
-        """Load the data of the object, if ixdat in its laziness hasn't done so yet"""
-        # use the backend this object actually came from, not necessarily the
-        # current global one (e.g. if it was loaded with get(..., backend=...)):
-        data_source = db or self.backend
-        return data_source.load_obj_data(self)
+    @deprecate(
+        "0.3.0",
+        "`load_data` now takes the backend to load from, rather than a DataBase. "
+        "Use `backend=` instead of `db=`.",
+        "0.4.0",
+        kwarg_name="db",
+    )
+    def load_data(self, backend=None, db=None):
+        """Load the data of the object, if ixdat in its laziness hasn't done so yet
+
+        Args:
+            backend (Backend): The backend to load the data from. By default, the
+                backend this object came from, which is not necessarily the active
+                one (e.g. if it was loaded with `get(..., backend=...)`).
+            db (Backend): DEPRECATED alias for `backend`.
+        """
+        return (backend or db or self.backend).load_obj_data(self)
 
 
 class PlaceHolderObject:

--- a/src/ixdat/db.py
+++ b/src/ixdat/db.py
@@ -73,10 +73,6 @@ class DataBase:
         with self.temporary_backend(backend) as selected_backend:
             return selected_backend.load(cls, name)
 
-    def load_obj_data(self, obj):
-        """Load and return the numerical data (obj.data) for a Saveable object"""
-        return self.backend.load_obj_data(obj)
-
     def set_backend(self, backend_name, **db_kwargs):
         """Change backend to the class given by backend_name initiated with db_kwargs"""
         if not isinstance(backend_name, str):

--- a/src/ixdat/db.py
+++ b/src/ixdat/db.py
@@ -126,6 +126,14 @@ class Saveable:
     `extra_column_attrs` to add extra columns via an auxiliary table without changing
     the main table name.
 
+    A class can also say what *type* of value each of its columns holds, with
+    `column_types`, and which columns hold the id of a row of another table, with
+    `column_references`. Relational backends need this to build their tables (see
+    :module:`~ixdat.backends.relational`); backends which just serialize each object
+    on its own, like the directory backend, ignore it. Both are optional: a column
+    which isn't in `column_types` holds whatever type its value already has, which
+    is all a plain str/int/float attribute needs.
+
     ixdat is lazy, only loading things when needed. Correspondingly, all of the columns
     of table mentioned above should refer to (lists of) id's and not actual objects of
     other ixdat classes.
@@ -143,6 +151,18 @@ class Saveable:
             to represent the "extra" attributes, for double-inheriting classes.
         linkers (dict): {table_name: (reference_table, attr)} for defining
             the connections between objects.
+        column_types (dict): {attr: type_name} giving the type of the value stored
+            in a column, for the columns where it matters. The type names are
+            "INTEGER", "REAL", "TEXT" for plain numbers and text, "JSON" for dicts
+            and lists, and "NDARRAY" for numpy arrays. A column left out here has no
+            fixed type. Unlike `extra_column_attrs`, this is *merged* over the
+            inheriting classes, so a class only declares the columns it adds itself.
+        column_references (dict): {attr: table_name} for the columns which hold the
+            id of a single row of another table, e.g. {"field_id": "data_series"}.
+            The column referred to is always that table's "id". Also merged over the
+            inheriting classes. Note that this is for a column of *this* class's
+            table; a reference stored as rows of its own table goes in
+            `extra_linkers` instead.
 
     Object attributes:
         backend (Backend): the backend where the object is saved. For a
@@ -163,6 +183,10 @@ class Saveable:
     column_attrs = None  # THIS SHOULD BE OVERWRITTEN IN INHERITING CLASSES
     extra_column_attrs = None  # THIS CAN BE OVERWRITTEN IN INHERITING CLASSES
     extra_linkers = None  # THIS CAN BE OVERWRITTEN IN INHERITING CLASSES
+    # every ixdat table has a name. Inheriting classes add the types of the columns
+    # they introduce themselves; get_column_types() merges them back together:
+    column_types = {"name": "TEXT"}
+    column_references = None  # THIS CAN BE OVERWRITTEN IN INHERITING CLASSES
     # TODO: derive child_attrs somehow from the above class attributes, and have it in
     #   a way where it's easy to tell which id goes with which attribute, i.e. s_ids
     #   goes with series_list
@@ -409,6 +433,36 @@ class Saveable:
             for table, (ref_table, attr) in cls.extra_linkers.items():
                 all_attrs.add(attr)
         return all_attrs
+
+    @classmethod
+    def get_column_types(cls):
+        """Return {attr: type_name} for all of cls's columns which have a fixed type
+
+        Each class in cls's ancestry contributes the columns it declares itself in
+        `column_types`, with the more specific class winning where they disagree.
+        Merging like this means a class only has to name the columns it adds, and,
+        unlike `extra_column_attrs`, that a class inheriting from two table-defining
+        classes gets the column types of both.
+        """
+        return cls._merged_class_dict("column_types")
+
+    @classmethod
+    def get_column_references(cls):
+        """Return {attr: table_name} for all of cls's columns which hold a foreign id
+
+        Merged over the inheriting classes, exactly like `get_column_types`.
+        """
+        return cls._merged_class_dict("column_references")
+
+    @classmethod
+    def _merged_class_dict(cls, attr):
+        """Return the dict class attribute `attr` merged over cls's ancestry"""
+        merged = {}
+        for ancestor in reversed(cls.__mro__):
+            # __dict__, rather than getattr, so that each ancestor contributes only
+            # what it declares itself, and the reversed order decides the winner:
+            merged.update(ancestor.__dict__.get(attr) or {})
+        return merged
 
     @classmethod
     def from_dict(cls, obj_as_dict):

--- a/src/ixdat/measurement_base.py
+++ b/src/ixdat/measurement_base.py
@@ -43,6 +43,13 @@ class Measurement(Saveable):
         "sample_name",
         "tstamp",
     }
+    column_types = {
+        "technique": "TEXT",
+        "metadata": "JSON",
+        "aliases": "JSON",
+        "sample_name": "TEXT",
+        "tstamp": "REAL",
+    }
     extra_linkers = {
         "component_measurements": ("measurement", "m_ids"),
         "measurement_calculators": ("calculator", "c_ids"),
@@ -1440,6 +1447,11 @@ class Calculator(Saveable):
     table_name = "calculator"
     calculator_type = None  # to be overwritten
     column_attrs = {"name", "technique", "tstamp", "calculator_type"}
+    column_types = {
+        "technique": "TEXT",
+        "tstamp": "REAL",
+        "calculator_type": "TEXT",
+    }
 
     def __init__(self, *, name=None, technique=None, tstamp=None, measurement=None):
         """Initiate a Calculator

--- a/src/ixdat/measurement_base.py
+++ b/src/ixdat/measurement_base.py
@@ -13,7 +13,13 @@ classes will be defined in the corresponding module in ./techniques/
 import warnings
 import json
 import numpy as np
-from .db import Saveable, PlaceHolderObject, fill_object_list
+from .db import (
+    Relationship,
+    Saveable,
+    PlaceHolderObject,
+    fill_object_list,
+    same_short_identity,
+)
 from .data_series import (
     DataSeries,
     TimeSeries,
@@ -50,13 +56,26 @@ class Measurement(Saveable):
         "sample_name": str,
         "tstamp": float,
     }
-    extra_linkers = {
-        "component_measurements": ("measurement", "m_ids"),
-        "measurement_calculators": ("calculator", "c_ids"),
-        "measurement_series": ("data_series", "s_ids"),
+    relationships = {
+        "component_measurements": Relationship(
+            "measurement",
+            "m_ids",
+            many=True,
+            storage_table="component_measurements",
+        ),
+        "calculator_list": Relationship(
+            "calculator",
+            "c_ids",
+            many=True,
+            storage_table="measurement_calculators",
+        ),
+        "series_list": Relationship(
+            "data_series",
+            "s_ids",
+            many=True,
+            storage_table="measurement_series",
+        ),
     }
-    child_attrs = ["component_measurements", "calculator_list", "series_list"]
-    # TODO: child_attrs should be derivable from extra_linkers?
 
     # ---- measurement class attributes, can be overwritten in inheriting classes ---- #
     control_technique_name = None
@@ -101,15 +120,14 @@ class Measurement(Saveable):
             name (str): The name of the measurement
             metadata (dict): Free-form measurement metadata. Must be json-compatible.
             technique (str): The measurement technique
-            s_ids (list of int): The id's of the measurement's DataSeries, if
-                to be loaded (instead of given directly in series_list)
+            s_ids (list): Local ids or ``(backend, id)`` references for the
+                measurement's DataSeries, if they are not given in ``series_list``.
             series_list (list of DataSeries): The measurement's DataSeries
-            c_ids (list of int): The id's of the measurement's calculators, if
-                to be loaded (instead of given directly in calculator_list)
+            c_ids (list): Local ids or ``(backend, id)`` references for calculators,
+                if they are not given in ``calculator_list``.
             calculator_list: The measurement's calculators
-            m_ids (list of int): The id's of the component measurements, if to be
-                loaded. None unless this is a combined measurement (typically
-                corresponding to more than one file).
+            m_ids (list): Local ids or ``(backend, id)`` references for component
+                measurements. None unless this is a combined measurement.
             component_measurements (list of Measurements): The measurements of which
                 this measurement is a combination
             aliases (dict): Alternative names for DataSeries for versatile access
@@ -491,11 +509,7 @@ class Measurement(Saveable):
 
     @property
     def m_ids(self):
-        """List of the id's of a combined measurement's component measurements
-        FIXME: m.id can be (backend, id) if it's not on the active backend.
-            This is as of now necessary to find it if you're only given self.as_dict()
-            see https://github.com/ixdat/ixdat/pull/11#discussion_r746632897
-        """
+        """Backend-aware identities of the component measurements."""
         if not self._component_measurements:
             return None
         return [m.short_identity for m in self.component_measurements]
@@ -553,11 +567,7 @@ class Measurement(Saveable):
 
     @property
     def c_ids(self):
-        """List of the id's of the measurement's calculators
-        FIXME: c.id can be (backend, id) if it's not on the active backend.
-            This is as of now necessary to find it if you're only given self.as_dict()
-             see https://github.com/ixdat/ixdat/pull/11#discussion_r746632897
-        """
+        """Backend-aware identities of the measurement's calculators."""
         return [c.short_identity for c in self.calculator_list]
 
     def add_calculator(self, calculator):
@@ -647,11 +657,7 @@ class Measurement(Saveable):
 
     @property
     def s_ids(self):
-        """List of the id's of the measurement's DataSeries
-        FIXME: m.id can be (backend, id) if it's not on the active backend.
-            This is as of now necessary to find it if you're only given self.as_dict()
-            see https://github.com/ixdat/ixdat/pull/11#discussion_r746632897
-        """
+        """Backend-aware identities of the measurement's DataSeries."""
         return [series.short_identity for series in self._series_list]
 
     @property
@@ -1081,9 +1087,10 @@ class Measurement(Saveable):
         """Return a list of id's of component measurements to which `series` belongs."""
         m_id_list = []
         for m in self.component_measurements:
-            if series.short_identity in m.s_ids:
-                # FIXME: the whole id vs short_identity issue
-                #   see https://github.com/ixdat/ixdat/pull/11#discussion_r746632897
+            if any(
+                same_short_identity((backend, i), series.short_identity)
+                for backend, i in m.s_ids
+            ):
                 m_id_list.append(m.id)
         return m_id_list
 

--- a/src/ixdat/measurement_base.py
+++ b/src/ixdat/measurement_base.py
@@ -44,11 +44,11 @@ class Measurement(Saveable):
         "tstamp",
     }
     column_types = {
-        "technique": "TEXT",
-        "metadata": "JSON",
-        "aliases": "JSON",
-        "sample_name": "TEXT",
-        "tstamp": "REAL",
+        "technique": str,
+        "metadata": dict,
+        "aliases": dict,
+        "sample_name": str,
+        "tstamp": float,
     }
     extra_linkers = {
         "component_measurements": ("measurement", "m_ids"),
@@ -1448,9 +1448,9 @@ class Calculator(Saveable):
     calculator_type = None  # to be overwritten
     column_attrs = {"name", "technique", "tstamp", "calculator_type"}
     column_types = {
-        "technique": "TEXT",
-        "tstamp": "REAL",
-        "calculator_type": "TEXT",
+        "technique": str,
+        "tstamp": float,
+        "calculator_type": str,
     }
 
     def __init__(self, *, name=None, technique=None, tstamp=None, measurement=None):

--- a/src/ixdat/measurement_base.py
+++ b/src/ixdat/measurement_base.py
@@ -44,8 +44,8 @@ class Measurement(Saveable):
         "tstamp",
     }
     extra_linkers = {
-        "component_measurements": ("measurements", "m_ids"),
-        "measurement_calculators": ("calculators", "c_ids"),
+        "component_measurements": ("measurement", "m_ids"),
+        "measurement_calculators": ("calculator", "c_ids"),
         "measurement_series": ("data_series", "s_ids"),
     }
     child_attrs = ["component_measurements", "calculator_list", "series_list"]

--- a/src/ixdat/projects/lablogs.py
+++ b/src/ixdat/projects/lablogs.py
@@ -5,7 +5,7 @@ class LabLog(Saveable):
     """TODO: flush out this class"""
 
     table_name = "lablog"
-    column_attrs = {"name": "name"}
+    column_attrs = {"name"}
 
     def __init__(self, name, metadata=None, notes=None):
         """Initiate the lablog with its name, metadata, and notes"""

--- a/src/ixdat/projects/samples.py
+++ b/src/ixdat/projects/samples.py
@@ -7,7 +7,7 @@ class Sample(Saveable):
     """TODO: flush out this class"""
 
     table_name = "sample"
-    column_attrs = {"name": "name"}
+    column_attrs = {"name"}
 
     def __init__(self, name):
         """Initate the sample with its name"""

--- a/src/ixdat/spectra.py
+++ b/src/ixdat/spectra.py
@@ -48,6 +48,13 @@ class Spectrum(Saveable):
         "sample_name",
         "field_id",
     }
+    column_types = {
+        "technique": "TEXT",
+        "metadata": "JSON",
+        "tstamp": "REAL",
+        "sample_name": "TEXT",
+    }
+    column_references = {"field_id": "data_series"}
     child_attrs = ["fields"]
     essential_series_names = []
 
@@ -359,6 +366,12 @@ class MultiSpectrum(Saveable):
         "metadata",
         "tstamp",
         "sample_name",
+    }
+    column_types = {
+        "technique": "TEXT",
+        "metadata": "JSON",
+        "tstamp": "REAL",
+        "sample_name": "TEXT",
     }
     extra_linkers = {"multispectrum_fields": ("data_series", "field_ids")}
     child_attrs = ["fields"]
@@ -854,6 +867,7 @@ def add_spectrum_series_to_measurement(measurement, spectrum_series, **kwargs):
 class SpectroMeasurement(Measurement):
     child_attrs = ["spectrum_series_list"] + Measurement.child_attrs
     extra_column_attrs = {"spectro_measurements": {"spectrum_id"}}
+    column_references = {"spectrum_id": "spectrums"}
 
     def __init__(self, *args, spectrum_series=None, spectrum_id=None, **kwargs):
         super().__init__(*args, **kwargs)

--- a/src/ixdat/spectra.py
+++ b/src/ixdat/spectra.py
@@ -49,10 +49,10 @@ class Spectrum(Saveable):
         "field_id",
     }
     column_types = {
-        "technique": "TEXT",
-        "metadata": "JSON",
-        "tstamp": "REAL",
-        "sample_name": "TEXT",
+        "technique": str,
+        "metadata": dict,
+        "tstamp": float,
+        "sample_name": str,
     }
     column_references = {"field_id": "data_series"}
     child_attrs = ["fields"]
@@ -368,10 +368,10 @@ class MultiSpectrum(Saveable):
         "sample_name",
     }
     column_types = {
-        "technique": "TEXT",
-        "metadata": "JSON",
-        "tstamp": "REAL",
-        "sample_name": "TEXT",
+        "technique": str,
+        "metadata": dict,
+        "tstamp": float,
+        "sample_name": str,
     }
     extra_linkers = {"multispectrum_fields": ("data_series", "field_ids")}
     child_attrs = ["fields"]

--- a/src/ixdat/spectra.py
+++ b/src/ixdat/spectra.py
@@ -360,7 +360,7 @@ class MultiSpectrum(Saveable):
         "tstamp",
         "sample_name",
     }
-    extra_linkers = {"multispectrum_fields": {"data_series", "field_ids"}}
+    extra_linkers = {"multispectrum_fields": ("data_series", "field_ids")}
     child_attrs = ["fields"]
 
     def __init__(

--- a/src/ixdat/spectra.py
+++ b/src/ixdat/spectra.py
@@ -413,10 +413,16 @@ class MultiSpectrum(Saveable):
         return self._fields
 
     @property
+    def field_ids(self):
+        """List of the id's of the multi-spectrum's fields"""
+        return [field.short_identity for field in self.fields]
+
+    @property
     def xseries(self):
         """The shared xseries of all the spectra in the multi-spectrum"""
         if not self._xseries:
-            self._xseries = self._fields[0].axes_series[0]
+            # note: `self.fields`, unlike `self._fields`, loads any placeholders:
+            self._xseries = self.fields[0].axes_series[0]
         return self._xseries
 
     @property

--- a/src/ixdat/spectra.py
+++ b/src/ixdat/spectra.py
@@ -14,7 +14,7 @@ to the use of "persons" and "people" as distinct plurals of the word "person". W
 
 import warnings
 import numpy as np
-from .db import Saveable, fill_object_list, PlaceHolderObject
+from .db import Relationship, Saveable, fill_object_list, PlaceHolderObject
 from .data_series import DataSeries, TimeSeries, Field, time_shifted, append_series
 from .exceptions import BuildError
 from .plotters.spectrum_plotter import SpectrumPlotter, SpectrumSeriesPlotter
@@ -46,7 +46,6 @@ class Spectrum(Saveable):
         "metadata",
         "tstamp",
         "sample_name",
-        "field_id",
     }
     column_types = {
         "technique": str,
@@ -54,8 +53,7 @@ class Spectrum(Saveable):
         "tstamp": float,
         "sample_name": str,
     }
-    column_references = {"field_id": "data_series"}
-    child_attrs = ["fields"]
+    relationships = {"field": Relationship("data_series", "field_id")}
     essential_series_names = []
 
     def __init__(
@@ -81,8 +79,8 @@ class Spectrum(Saveable):
             reader (Reader): The reader, if read from file
             tstamp (float): The unix epoch timestamp of the spectrum
             field (Field): The Field containing the data (x, y, and tstamp)
-            field_id (id): The id in the data_series table of the Field with the data,
-                if the field is not yet loaded from backend.
+            field_id (id or tuple): A local id or ``(backend, id)`` reference for the
+                Field, if it is not yet loaded.
             duration (float): Optional. The duration of the spectrum measurement in [s]
         """
         super().__init__()
@@ -187,9 +185,7 @@ class Spectrum(Saveable):
         """The data-containing objects that need to be saved when the spectrum is saved.
 
         For a field to be correctly saved and loaded, its axes_series must be saved
-        first. So there are three series in the data_objects to return
-        FIXME: with backend-specifying id's, field could check for itself whether
-        FIXME:  its axes_series are already in the database.
+        first. So there are three series in the data_objects to return.
         """
         return self.series_list
 
@@ -271,8 +267,8 @@ class Spectrum(Saveable):
 
     @property
     def field_id(self):
-        """The id of the field"""
-        return self.field.id
+        """The backend-aware identity of the field."""
+        return self.field.short_identity
 
     @property
     def xseries(self):
@@ -373,8 +369,14 @@ class MultiSpectrum(Saveable):
         "tstamp": float,
         "sample_name": str,
     }
-    extra_linkers = {"multispectrum_fields": ("data_series", "field_ids")}
-    child_attrs = ["fields"]
+    relationships = {
+        "fields": Relationship(
+            "data_series",
+            "field_ids",
+            many=True,
+            storage_table="multispectrum_fields",
+        )
+    }
 
     def __init__(
         self,
@@ -396,7 +398,7 @@ class MultiSpectrum(Saveable):
             sample_name (str): The sample name
             metadata (dict): Free-form spectrum metadata. Must be json-compatible.
             fields (list of Field): The Fields containing the data (x, y)
-            field_ids (list of int): The id's of Fields if available from the backend.
+            field_ids (list): Local ids or ``(backend, id)`` references for Fields.
         """
         super().__init__()
         self.name = name
@@ -865,9 +867,11 @@ def add_spectrum_series_to_measurement(measurement, spectrum_series, **kwargs):
 
 
 class SpectroMeasurement(Measurement):
-    child_attrs = ["spectrum_series_list"] + Measurement.child_attrs
-    extra_column_attrs = {"spectro_measurements": {"spectrum_id"}}
-    column_references = {"spectrum_id": "spectrums"}
+    relationships = {
+        "spectrum_series": Relationship(
+            "spectrums", "spectrum_id", storage_table="spectro_measurements"
+        )
+    }
 
     def __init__(self, *args, spectrum_series=None, spectrum_id=None, **kwargs):
         super().__init__(*args, **kwargs)
@@ -889,13 +893,6 @@ class SpectroMeasurement(Measurement):
             self._spectrum_series = self._spectrum_series.get_object()
             self._spectrum_series.tstamp = self.tstamp
         return self._spectrum_series
-
-    # FIXME: The attribute below is needed in order to correctly
-    #   pass the spectrum_series between objects using its id,
-    #   because "child_attrs" only works on lists.
-    @property
-    def spectrum_series_list(self):
-        return [self.spectrum_series]
 
     @property
     def spectrum_id(self):

--- a/src/ixdat/techniques/ec.py
+++ b/src/ixdat/techniques/ec.py
@@ -83,6 +83,7 @@ class ECMeasurement(Measurement):
             "ec_technique",
         }
     }
+    column_types = {"ec_technique": "TEXT"}
     control_series_name = "raw_potential"
     essential_series_names = ("t", "raw_potential", "raw_current")
     selection_series_names = ("file_number", "loop_number", "cycle number", "Ns")

--- a/src/ixdat/techniques/ec.py
+++ b/src/ixdat/techniques/ec.py
@@ -113,12 +113,11 @@ class ECMeasurement(Measurement):
         Kwargs, passed on to `Measurement.__init__` (see :class:`.Measurement`):
             metadata (dict): Free-form measurement metadata. Must be json-compatible.
             technique (str): The measurement technique
-            s_ids (list of int): The id's of the measurement's DataSeries, if
-                to be loaded (instead of given directly in series_list)
+            s_ids (list): Local ids or ``(backend, id)`` references for the
+                measurement's DataSeries.
             series_list (list of DataSeries): The measurement's DataSeries
-            m_ids (list of int): The id's of the component measurements, if to be
-                loaded. None unless this is a combined measurement (typically
-                corresponding to more than one file).
+            m_ids (list): Local ids or ``(backend, id)`` references for component
+                measurements. None unless this is a combined measurement.
             component_measurements (list of Measurements): The measurements of which
                 this measurement is a combination
             reader (Reader): The file reader (None unless read from a file)

--- a/src/ixdat/techniques/ec.py
+++ b/src/ixdat/techniques/ec.py
@@ -79,7 +79,7 @@ class ECMeasurement(Measurement):
     """
 
     extra_column_attrs = {
-        "ec_meaurements": {
+        "ec_measurements": {
             "ec_technique",
         }
     }

--- a/src/ixdat/techniques/ec.py
+++ b/src/ixdat/techniques/ec.py
@@ -83,7 +83,7 @@ class ECMeasurement(Measurement):
             "ec_technique",
         }
     }
-    column_types = {"ec_technique": "TEXT"}
+    column_types = {"ec_technique": str}
     control_series_name = "raw_potential"
     essential_series_names = ("t", "raw_potential", "raw_current")
     selection_series_names = ("file_number", "loop_number", "cycle number", "Ns")

--- a/src/ixdat/techniques/ec_ms.py
+++ b/src/ixdat/techniques/ec_ms.py
@@ -14,14 +14,9 @@ class ECMSMeasurement(ECMeasurement, MSMeasurement):
     """Class for raw EC-MS functionality. Parents: ECMeasurement and MSMeasurement"""
 
     extra_column_attrs = {
-        "ecms_measurements": {"ec_technique", "tspan_bg"},
+        "ecms_measurements": {"tspan_bg"},
     }
-    # "ec_technique" needs no entry here: it carries over from ECMeasurement
-    column_types = {"tspan_bg": "JSON"}
-    # FIXME: this fully replaces ECMeasurement's extra_column_attrs rather than
-    #  adding to it, so saving an ECMSMeasurement never writes a row to
-    #  "ec_measurements" - only to "ecms_measurements" here. See the "Known
-    #  limitation" section of docs/source/diving_deeper/backend.rst.
+    column_types = {"tspan_bg": list}
 
     default_plotter = ECMSPlotter
     default_exporter = ECMSExporter

--- a/src/ixdat/techniques/ec_ms.py
+++ b/src/ixdat/techniques/ec_ms.py
@@ -16,12 +16,10 @@ class ECMSMeasurement(ECMeasurement, MSMeasurement):
     extra_column_attrs = {
         "ecms_measurements": {"ec_technique", "tspan_bg"},
     }
-    # FIXME: It would be much more elegant if this carried over automatically from
-    #  *both* parents, by appending the table columns. Because it doesn't, this class
-    #  writes only to "ecms_measurements", never to ECMeasurement's "ec_measurements",
-    #  so a database query that joins only "ec_measurements" will miss ECMS rows. See
-    #  the "Known limitation" section in docs/source/diving_deeper/backend.rst and
-    #  https://github.com/ixdat/ixdat/pull/75 for the (still open) proper fix.
+    # FIXME: this fully replaces ECMeasurement's extra_column_attrs rather than
+    #  adding to it, so saving an ECMSMeasurement never writes a row to
+    #  "ec_measurements" - only to "ecms_measurements" here. See the "Known
+    #  limitation" section of docs/source/diving_deeper/backend.rst.
 
     default_plotter = ECMSPlotter
     default_exporter = ECMSExporter

--- a/src/ixdat/techniques/ec_ms.py
+++ b/src/ixdat/techniques/ec_ms.py
@@ -16,6 +16,8 @@ class ECMSMeasurement(ECMeasurement, MSMeasurement):
     extra_column_attrs = {
         "ecms_measurements": {"ec_technique", "tspan_bg"},
     }
+    # "ec_technique" needs no entry here: it carries over from ECMeasurement
+    column_types = {"tspan_bg": "JSON"}
     # FIXME: this fully replaces ECMeasurement's extra_column_attrs rather than
     #  adding to it, so saving an ECMSMeasurement never writes a row to
     #  "ec_measurements" - only to "ecms_measurements" here. See the "Known

--- a/src/ixdat/techniques/ec_ms.py
+++ b/src/ixdat/techniques/ec_ms.py
@@ -17,8 +17,11 @@ class ECMSMeasurement(ECMeasurement, MSMeasurement):
         "ecms_measurements": {"ec_technique", "tspan_bg"},
     }
     # FIXME: It would be much more elegant if this carried over automatically from
-    #  *both* parents, by appending the table columns...
-    #  We'll see how the problem changes with the metaprogramming work.
+    #  *both* parents, by appending the table columns. Because it doesn't, this class
+    #  writes only to "ecms_measurements", never to ECMeasurement's "ec_measurements",
+    #  so a database query that joins only "ec_measurements" will miss ECMS rows. See
+    #  the "Known limitation" section in docs/source/diving_deeper/backend.rst and
+    #  https://github.com/ixdat/ixdat/pull/75 for the (still open) proper fix.
 
     default_plotter = ECMSPlotter
     default_exporter = ECMSExporter

--- a/src/ixdat/techniques/ec_ms.py
+++ b/src/ixdat/techniques/ec_ms.py
@@ -14,7 +14,7 @@ class ECMSMeasurement(ECMeasurement, MSMeasurement):
     """Class for raw EC-MS functionality. Parents: ECMeasurement and MSMeasurement"""
 
     extra_column_attrs = {
-        "ecms_meaurements": {"ec_technique", "tspan_bg"},
+        "ecms_measurements": {"ec_technique", "tspan_bg"},
     }
     # FIXME: It would be much more elegant if this carried over automatically from
     #  *both* parents, by appending the table columns...

--- a/src/ixdat/techniques/ms.py
+++ b/src/ixdat/techniques/ms.py
@@ -321,7 +321,6 @@ class MSSpectrumSeries(SpectrumSeries):
 
 
 class MSSpectroMeasurement(MSMeasurement, SpectroMeasurement):
-    extra_column_attrs = SpectroMeasurement.extra_column_attrs
     default_plotter = MSSpectroPlotter
     default_exporter = MSSpectroExporter
 

--- a/src/ixdat/techniques/spectroelectrochemistry.py
+++ b/src/ixdat/techniques/spectroelectrochemistry.py
@@ -2,7 +2,7 @@ import numpy as np
 from scipy.interpolate import interp1d
 
 from .ec import ECMeasurement
-from ..db import PlaceHolderObject
+from ..db import PlaceHolderObject, Relationship
 from ..spectra import Spectrum, SpectroMeasurement
 from ..data_series import Field, ValueSeries
 from ..exporters import SECExporter
@@ -58,8 +58,11 @@ class ECOpticalMeasurement(SpectroECMeasurement):
 
     default_plotter = ECOpticalPlotter
 
-    extra_linkers = {"ec_optical_measurements": ("spectrums", "ref_id")}
-    child_attrs = SpectroECMeasurement.child_attrs + ["reference_spectrum_list"]
+    relationships = {
+        "reference_spectrum": Relationship(
+            "spectrums", "ref_id", storage_table="ec_optical_measurements"
+        )
+    }
 
     def __init__(self, reference_spectrum=None, ref_id=None, **kwargs):
         """Initialize an SEC measurement. All args and kwargs go to ECMeasurement."""
@@ -83,14 +86,6 @@ class ECOpticalMeasurement(SpectroECMeasurement):
         if isinstance(self._reference_spectrum, PlaceHolderObject):
             self._reference_spectrum = self._reference_spectrum.get_object()
         return self._reference_spectrum
-
-    # FIXME: The attribute below is needed in order to correctly pass the reference
-    #   spectrum between objects using its id, because "child_attrs" only works on
-    #   lists. Same as SpectroMeasurement.spectrum_series_list.
-    @property
-    def reference_spectrum_list(self):
-        """The reference spectrum in a list, or an empty list if there is none"""
-        return [self.reference_spectrum] if self._reference_spectrum else []
 
     @property
     def ref_id(self):

--- a/src/ixdat/techniques/spectroelectrochemistry.py
+++ b/src/ixdat/techniques/spectroelectrochemistry.py
@@ -60,6 +60,7 @@ class ECOpticalMeasurement(SpectroECMeasurement):
 
     extra_linkers = SpectroECMeasurement.extra_linkers.copy()
     extra_linkers.update({"ec_optical_measurements": ("spectrums", "ref_id")})
+    child_attrs = SpectroECMeasurement.child_attrs + ["reference_spectrum_list"]
 
     def __init__(self, reference_spectrum=None, ref_id=None, **kwargs):
         """Initialize an SEC measurement. All args and kwargs go to ECMeasurement."""
@@ -68,6 +69,9 @@ class ECOpticalMeasurement(SpectroECMeasurement):
             self._reference_spectrum = reference_spectrum
         elif ref_id:
             self._reference_spectrum = PlaceHolderObject(ref_id, cls=Spectrum)
+        else:
+            # a reference spectrum can also be set later, with set_reference_spectrum:
+            self._reference_spectrum = None
         self.tracked_wavelengths = []
         self.plot_waterfall = self.plotter.plot_waterfall
         self.plot_wavelengths = self.plotter.plot_wavelengths
@@ -80,6 +84,21 @@ class ECOpticalMeasurement(SpectroECMeasurement):
         if isinstance(self._reference_spectrum, PlaceHolderObject):
             self._reference_spectrum = self._reference_spectrum.get_object()
         return self._reference_spectrum
+
+    # FIXME: The attribute below is needed in order to correctly pass the reference
+    #   spectrum between objects using its id, because "child_attrs" only works on
+    #   lists. Same as SpectroMeasurement.spectrum_series_list.
+    @property
+    def reference_spectrum_list(self):
+        """The reference spectrum in a list, or an empty list if there is none"""
+        return [self.reference_spectrum] if self._reference_spectrum else []
+
+    @property
+    def ref_id(self):
+        """The id of the reference spectrum, or None if there is none"""
+        if not self._reference_spectrum:
+            return None
+        return self.reference_spectrum.short_identity
 
     def set_reference_spectrum(
         self,

--- a/src/ixdat/techniques/spectroelectrochemistry.py
+++ b/src/ixdat/techniques/spectroelectrochemistry.py
@@ -58,8 +58,7 @@ class ECOpticalMeasurement(SpectroECMeasurement):
 
     default_plotter = ECOpticalPlotter
 
-    extra_linkers = SpectroECMeasurement.extra_linkers.copy()
-    extra_linkers.update({"ec_optical_measurements": ("spectrums", "ref_id")})
+    extra_linkers = {"ec_optical_measurements": ("spectrums", "ref_id")}
     child_attrs = SpectroECMeasurement.child_attrs + ["reference_spectrum_list"]
 
     def __init__(self, reference_spectrum=None, ref_id=None, **kwargs):

--- a/src/ixdat/techniques/spectroelectrochemistry.py
+++ b/src/ixdat/techniques/spectroelectrochemistry.py
@@ -59,7 +59,7 @@ class ECOpticalMeasurement(SpectroECMeasurement):
     default_plotter = ECOpticalPlotter
 
     extra_linkers = SpectroECMeasurement.extra_linkers.copy()
-    extra_linkers.update({"ec_optical_measurements": ("spectra", "ref_id")})
+    extra_linkers.update({"ec_optical_measurements": ("spectrums", "ref_id")})
 
     def __init__(self, reference_spectrum=None, ref_id=None, **kwargs):
         """Initialize an SEC measurement. All args and kwargs go to ECMeasurement."""

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -3,10 +3,14 @@
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
+import numpy as np
 from pytest import fixture
 
-from ixdat import Measurement
+from ixdat import Measurement, Spectrum
+from ixdat.data_series import DataSeries, Field, TimeSeries
 from ixdat.db import DB, change_database
+from ixdat.spectra import SpectrumSeries
+from ixdat.techniques.spectroelectrochemistry import ECOpticalMeasurement
 
 # FIXME The size of this data file is at present one of the largest contributors to the
 # time it takes to run the test suite. We should consider cutting it down or replacing
@@ -48,3 +52,50 @@ def composed_measurement(ec_measurement):
     measurement1 = ec_measurement.select(cycle=1)
     measurement2 = ec_measurement.select(cycle=3)
     return measurement1 + measurement2
+
+
+@fixture(scope="function")
+def ec_optical_measurement():
+    """Fixture that sets up a synthetic EC-Optical measurement
+
+    Unlike the other measurements here this one is built rather than read, since
+    ixdat ships no EC-Optical data file. What makes it worth testing is that it
+    refers to two different spectrum objects: a `SpectrumSeries` with the spectra
+    and a single `Spectrum` used as the reference for optical density.
+    """
+    tseries = TimeSeries(
+        name="t", unit_name="s", data=np.array([0.0, 1.0]), tstamp=1.6e9
+    )
+    wavelength = DataSeries(
+        name="wavelength / nm", unit_name="nm", data=np.linspace(400, 700, 4)
+    )
+    spectrum_series = SpectrumSeries(
+        name="optical spectra",
+        technique="EC-Optical",
+        tstamp=1.6e9,
+        field=Field(
+            name="spectra",
+            unit_name="counts",
+            data=np.array([[1.0, 2.0, 3.0, 4.0], [2.0, 3.0, 4.0, 5.0]]),
+            axes_series=[tseries, wavelength],
+        ),
+    )
+    reference_spectrum = Spectrum(
+        name="ref spectrum",
+        technique="optical",
+        tstamp=1.6e9,
+        field=Field(
+            name="reference",
+            unit_name="counts",
+            data=np.array([1.0, 1.0, 1.0, 1.0]),
+            axes_series=[wavelength],
+        ),
+    )
+    return ECOpticalMeasurement(
+        name="synthetic EC-Optical",
+        technique="EC-Optical",
+        tstamp=1.6e9,
+        series_list=[tseries],
+        spectrum_series=spectrum_series,
+        reference_spectrum=reference_spectrum,
+    )

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -1,18 +1,11 @@
 """Fixtures used across the functional tests"""
 
 from pathlib import Path
-from tempfile import TemporaryDirectory
 
 import numpy as np
 from pytest import fixture
 
 from ixdat import Measurement, Spectrum
-from ixdat.calculators.ms_calculators import (
-    MSBackgroundSet,
-    MSCalibration,
-    MSCalResult,
-    MSConstantBackground,
-)
 from ixdat.data_series import DataSeries, Field, TimeSeries
 from ixdat.db import DB, change_database
 from ixdat.spectra import SpectrumSeries
@@ -25,25 +18,26 @@ PATH_TO_DATAFILE = Path(__file__).parent / "../../test_data/biologic/Pt_poly_cv_
 
 
 @fixture(scope="function", params=["directory", "sqlite"])
-def fresh_backend(request):
+def fresh_backend(request, tmp_path):
     """Fixture that provides each database backend in a fresh temporary directory"""
-    temporary_directory = TemporaryDirectory()
     original_backend = DB.backend
     if request.param == "directory":
         change_database(
             "directory",
-            directory=Path(temporary_directory.name),
+            directory=tmp_path,
             project_name="test_biologic_ec_measurement",
         )
     else:
-        db_path = Path(temporary_directory.name) / "test_biologic_ec_measurement.sqlite"
-        change_database("sqlite", db_path=db_path)
+        change_database(
+            "sqlite", db_path=tmp_path / "test_biologic_ec_measurement.sqlite"
+        )
     backend = DB.backend
-    yield temporary_directory
-    if hasattr(backend, "close"):
-        backend.close()
-    DB.set_backend(original_backend)
-    temporary_directory.cleanup()
+    try:
+        yield backend
+    finally:
+        if hasattr(backend, "close"):
+            backend.close()
+        DB.set_backend(original_backend)
 
 
 @fixture(scope="function")
@@ -55,79 +49,51 @@ def ec_measurement():
 @fixture(scope="function")
 def composed_measurement(ec_measurement):
     """Fixture that returns a composed measurement"""
-    measurement1 = ec_measurement.select(cycle=1)
-    measurement2 = ec_measurement.select(cycle=3)
-    return measurement1 + measurement2
+    return ec_measurement.select(cycle=1) + ec_measurement.select(cycle=3)
 
 
 @fixture(scope="function")
-def ms_calibration():
-    """Fixture that sets up an MS calibration with two sensitivity factors"""
-    return MSCalibration(
-        name="test ms calibration",
-        tstamp=1.6e9,
-        ms_cal_results=[
-            MSCalResult(name="O2 at M32", mol="O2", mass="M32", F=1.5),
-            MSCalResult(name="H2 at M2", mol="H2", mass="M2", F=3.0),
-        ],
-    )
+def ec_optical_measurement_factory():
+    """Build a synthetic EC-Optical measurement with an optional reference."""
 
+    def make_measurement(with_reference):
+        tseries = TimeSeries(
+            name="t", unit_name="s", data=np.array([0.0, 1.0]), tstamp=1.6e9
+        )
+        wavelength = DataSeries(
+            name="wavelength / nm", unit_name="nm", data=np.linspace(400, 700, 4)
+        )
+        spectrum_series = SpectrumSeries(
+            name="optical spectra",
+            technique="EC-Optical",
+            tstamp=1.6e9,
+            field=Field(
+                name="spectra",
+                unit_name="counts",
+                data=np.array([[1.0, 2.0, 3.0, 4.0], [2.0, 3.0, 4.0, 5.0]]),
+                axes_series=[tseries, wavelength],
+            ),
+        )
+        reference_spectrum = None
+        if with_reference:
+            reference_spectrum = Spectrum(
+                name="ref spectrum",
+                technique="optical",
+                tstamp=1.6e9,
+                field=Field(
+                    name="reference",
+                    unit_name="counts",
+                    data=np.ones(4),
+                    axes_series=[wavelength],
+                ),
+            )
+        return ECOpticalMeasurement(
+            name="synthetic EC-Optical",
+            technique="EC-Optical",
+            tstamp=1.6e9,
+            series_list=[tseries],
+            spectrum_series=spectrum_series,
+            reference_spectrum=reference_spectrum,
+        )
 
-@fixture(scope="function")
-def ms_background_set():
-    """Fixture that sets up a set of constant MS backgrounds"""
-    return MSBackgroundSet(
-        name="test ms backgrounds",
-        tstamp=1.6e9,
-        bg_list=[
-            MSConstantBackground(name="M32 background", mass="M32", bg=1e-12),
-            MSConstantBackground(name="M2 background", mass="M2", bg=2e-12),
-        ],
-    )
-
-
-@fixture(scope="function")
-def ec_optical_measurement():
-    """Fixture that sets up a synthetic EC-Optical measurement
-
-    Unlike the other measurements here this one is built rather than read, since
-    ixdat ships no EC-Optical data file. What makes it worth testing is that it
-    refers to two different spectrum objects: a `SpectrumSeries` with the spectra
-    and a single `Spectrum` used as the reference for optical density.
-    """
-    tseries = TimeSeries(
-        name="t", unit_name="s", data=np.array([0.0, 1.0]), tstamp=1.6e9
-    )
-    wavelength = DataSeries(
-        name="wavelength / nm", unit_name="nm", data=np.linspace(400, 700, 4)
-    )
-    spectrum_series = SpectrumSeries(
-        name="optical spectra",
-        technique="EC-Optical",
-        tstamp=1.6e9,
-        field=Field(
-            name="spectra",
-            unit_name="counts",
-            data=np.array([[1.0, 2.0, 3.0, 4.0], [2.0, 3.0, 4.0, 5.0]]),
-            axes_series=[tseries, wavelength],
-        ),
-    )
-    reference_spectrum = Spectrum(
-        name="ref spectrum",
-        technique="optical",
-        tstamp=1.6e9,
-        field=Field(
-            name="reference",
-            unit_name="counts",
-            data=np.array([1.0, 1.0, 1.0, 1.0]),
-            axes_series=[wavelength],
-        ),
-    )
-    return ECOpticalMeasurement(
-        name="synthetic EC-Optical",
-        technique="EC-Optical",
-        tstamp=1.6e9,
-        series_list=[tseries],
-        spectrum_series=spectrum_series,
-        reference_spectrum=reference_spectrum,
-    )
+    return make_measurement

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -6,7 +6,7 @@ from tempfile import TemporaryDirectory
 from pytest import fixture
 
 from ixdat import Measurement
-from ixdat.db import change_database
+from ixdat.db import DB, change_database
 
 # FIXME The size of this data file is at present one of the largest contributors to the
 # time it takes to run the test suite. We should consider cutting it down or replacing
@@ -14,17 +14,26 @@ from ixdat.db import change_database
 PATH_TO_DATAFILE = Path(__file__).parent / "../../test_data/biologic/Pt_poly_cv_CUT.mpt"
 
 
-@fixture(scope="function")
-def fresh_directory_backend():
-    """Fixture that provides a directory backend in a fresh temporary directory"""
+@fixture(scope="function", params=["directory", "sqlite"])
+def fresh_backend(request):
+    """Fixture that provides each database backend in a fresh temporary directory"""
     temporary_directory = TemporaryDirectory()
-    # Set the directory backup up to work of a temporary directory
-    change_database(
-        "directory",
-        directory=Path(temporary_directory.name),
-        project_name="test_biologic_ec_measurement",
-    )
-    return temporary_directory
+    original_backend = DB.backend
+    if request.param == "directory":
+        change_database(
+            "directory",
+            directory=Path(temporary_directory.name),
+            project_name="test_biologic_ec_measurement",
+        )
+    else:
+        db_path = Path(temporary_directory.name) / "test_biologic_ec_measurement.sqlite"
+        change_database("sqlite", db_path=db_path)
+    backend = DB.backend
+    yield temporary_directory
+    if hasattr(backend, "close"):
+        backend.close()
+    DB.set_backend(original_backend)
+    temporary_directory.cleanup()
 
 
 @fixture(scope="function")

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -7,6 +7,12 @@ import numpy as np
 from pytest import fixture
 
 from ixdat import Measurement, Spectrum
+from ixdat.calculators.ms_calculators import (
+    MSBackgroundSet,
+    MSCalibration,
+    MSCalResult,
+    MSConstantBackground,
+)
 from ixdat.data_series import DataSeries, Field, TimeSeries
 from ixdat.db import DB, change_database
 from ixdat.spectra import SpectrumSeries
@@ -52,6 +58,32 @@ def composed_measurement(ec_measurement):
     measurement1 = ec_measurement.select(cycle=1)
     measurement2 = ec_measurement.select(cycle=3)
     return measurement1 + measurement2
+
+
+@fixture(scope="function")
+def ms_calibration():
+    """Fixture that sets up an MS calibration with two sensitivity factors"""
+    return MSCalibration(
+        name="test ms calibration",
+        tstamp=1.6e9,
+        ms_cal_results=[
+            MSCalResult(name="O2 at M32", mol="O2", mass="M32", F=1.5),
+            MSCalResult(name="H2 at M2", mol="H2", mass="M2", F=3.0),
+        ],
+    )
+
+
+@fixture(scope="function")
+def ms_background_set():
+    """Fixture that sets up a set of constant MS backgrounds"""
+    return MSBackgroundSet(
+        name="test ms backgrounds",
+        tstamp=1.6e9,
+        bg_list=[
+            MSConstantBackground(name="M32 background", mass="M32", bg=1e-12),
+            MSConstantBackground(name="M2 background", mass="M2", bg=2e-12),
+        ],
+    )
 
 
 @fixture(scope="function")

--- a/tests/functional/test_backends.py
+++ b/tests/functional/test_backends.py
@@ -1,5 +1,7 @@
 """"Tests that an ECMeasurement read from test data behaves as it should"""
 
+import numpy as np
+
 from ixdat import Measurement
 
 
@@ -31,3 +33,13 @@ class TestBackends:
         ec_measurement.save()
         loaded = Measurement.load(ec_measurement.name)
         assert ec_measurement == loaded
+
+    def test_round_trip_of_ec_optical(self, ec_optical_measurement, fresh_backend):
+        """Test that both of an EC-Optical measurement's spectrum references survive"""
+        id_ = ec_optical_measurement.save()
+        loaded = Measurement.get(id_)
+        assert np.allclose(loaded.spectra.data, ec_optical_measurement.spectra.data)
+        assert loaded.reference_spectrum.name == "ref spectrum"
+        assert np.allclose(
+            loaded.reference_spectrum.y, ec_optical_measurement.reference_spectrum.y
+        )

--- a/tests/functional/test_backends.py
+++ b/tests/functional/test_backends.py
@@ -83,3 +83,44 @@ class TestBackends:
             assert np.allclose(loaded.reference_spectrum.y, np.ones(4))
         else:
             assert loaded.reference_spectrum is None
+
+    def test_force_updates_scalar_relationship(
+        self, ec_optical_measurement_factory, fresh_backend
+    ):
+        """A forced save writes changes through a one-object relationship."""
+        measurement = ec_optical_measurement_factory(with_reference=True)
+        measurement_id = measurement.save()
+
+        measurement.reference_spectrum.name = "updated reference"
+        measurement.reference_spectrum.field._data = np.full(4, 2.0)
+
+        # A normal repeated save follows ixdat's established no-update rule.
+        assert measurement.save() is None
+        loaded = Measurement.get(measurement_id)
+        assert loaded.reference_spectrum.name == "ref spectrum"
+        assert np.allclose(loaded.reference_spectrum.y, np.ones(4))
+
+        fresh_backend.save(measurement, force=True)
+        loaded = Measurement.get(measurement_id)
+        assert loaded.reference_spectrum.name == "updated reference"
+        assert np.allclose(loaded.reference_spectrum.y, np.full(4, 2.0))
+        if fresh_backend.backend_type == "directory":
+            spectrum_files = list(
+                (fresh_backend.project_directory / "spectrums").glob(
+                    f"{measurement.reference_spectrum.id}_*"
+                    f"{fresh_backend.metadata_suffix}"
+                )
+            )
+            assert len(spectrum_files) == 1
+
+        replacement = ec_optical_measurement_factory(
+            with_reference=True
+        ).reference_spectrum
+        replacement.name = "replacement reference"
+        replacement.field._data = np.full(4, 3.0)
+        measurement.set_reference_spectrum(spectrum=replacement)
+
+        fresh_backend.save(measurement, force=True)
+        loaded = Measurement.get(measurement_id)
+        assert loaded.reference_spectrum.name == "replacement reference"
+        assert np.allclose(loaded.reference_spectrum.y, np.full(4, 3.0))

--- a/tests/functional/test_backends.py
+++ b/tests/functional/test_backends.py
@@ -6,24 +6,28 @@ from ixdat import Measurement
 #  If tox crashes when trying to import matplotlib, see:
 #    https://github.com/ixdat/ixdat/issues/10
 
-# NOTE The `ec_measurement` and `fresh_directory_backend` arguments are provided by
-# shared fixtures in conftest.py in this directory
-
-# NOTE Ideally, we should add more functional tests here and make it possible to
-# parametrize over different database backends
+# NOTE The `ec_measurement` and `fresh_backend` arguments are provided by
+# shared fixtures in conftest.py in this directory. The `fresh_backend` fixture is
+# parametrized, so each test here runs once per database backend.
 
 
 class TestBackends:
     """Functional tests for the data backends"""
 
-    def test_round_trip(self, ec_measurement, fresh_directory_backend):
+    def test_round_trip(self, ec_measurement, fresh_backend):
         """Test load/save round trip of a measurement"""
         id_ = ec_measurement.save()
         reloaded_ec_measurement = Measurement.get(id_)
         assert ec_measurement == reloaded_ec_measurement
 
-    def test_round_trip_of_composed(self, composed_measurement, fresh_directory_backend):
+    def test_round_trip_of_composed(self, composed_measurement, fresh_backend):
         """Test a load/save round trip of a composed measurement"""
         id_ = composed_measurement.save()
         loaded = Measurement.get(id_)
         assert composed_measurement == loaded
+
+    def test_load_by_name(self, ec_measurement, fresh_backend):
+        """Test that a saved measurement can be loaded by its name"""
+        ec_measurement.save()
+        loaded = Measurement.load(ec_measurement.name)
+        assert ec_measurement == loaded

--- a/tests/functional/test_backends.py
+++ b/tests/functional/test_backends.py
@@ -1,9 +1,15 @@
 """"Tests that an ECMeasurement read from test data behaves as it should"""
 
 import numpy as np
+import pytest
 
 from ixdat import Measurement
-from ixdat.calculators.ms_calculators import MSBackgroundSet, MSCalibration
+from ixdat.calculators.ms_calculators import (
+    MSBackgroundSet,
+    MSCalibration,
+    MSCalResult,
+    MSConstantBackground,
+)
 from ixdat.measurement_base import Calculator
 
 
@@ -18,27 +24,28 @@ from ixdat.measurement_base import Calculator
 class TestBackends:
     """Functional tests for the data backends"""
 
-    def test_round_trip(self, ec_measurement, fresh_backend):
-        """Test load/save round trip of a measurement"""
-        id_ = ec_measurement.save()
-        reloaded_ec_measurement = Measurement.get(id_)
-        assert ec_measurement == reloaded_ec_measurement
+    def test_measurement_round_trips(
+        self, ec_measurement, composed_measurement, fresh_backend
+    ):
+        """Test id/name loading and a composed-measurement round trip."""
+        measurement_id = ec_measurement.save()
+        assert Measurement.get(measurement_id) == ec_measurement
+        assert Measurement.load(ec_measurement.name) == ec_measurement
 
-    def test_round_trip_of_composed(self, composed_measurement, fresh_backend):
-        """Test a load/save round trip of a composed measurement"""
-        id_ = composed_measurement.save()
-        loaded = Measurement.get(id_)
-        assert composed_measurement == loaded
+        composed_id = composed_measurement.save()
+        assert Measurement.get(composed_id) == composed_measurement
 
-    def test_load_by_name(self, ec_measurement, fresh_backend):
-        """Test that a saved measurement can be loaded by its name"""
-        ec_measurement.save()
-        loaded = Measurement.load(ec_measurement.name)
-        assert ec_measurement == loaded
-
-    def test_round_trip_of_ms_calibration(self, ms_calibration, fresh_backend):
+    def test_round_trip_of_ms_calibration(self, fresh_backend):
         """Test that an MS calibration's sensitivity factors survive a round trip"""
-        loaded = Calculator.get(ms_calibration.save())
+        calibration = MSCalibration(
+            name="test ms calibration",
+            tstamp=1.6e9,
+            ms_cal_results=[
+                MSCalResult(name="O2 at M32", mol="O2", mass="M32", F=1.5),
+                MSCalResult(name="H2 at M2", mol="H2", mass="M2", F=3.0),
+            ],
+        )
+        loaded = Calculator.get(calibration.save())
         assert isinstance(loaded, MSCalibration)
         assert sorted((cal.mol, cal.mass, cal.F) for cal in loaded.ms_cal_results) == [
             ("H2", "M2", 3.0),
@@ -46,21 +53,33 @@ class TestBackends:
         ]
         assert loaded.get_F("O2", "M32") == 1.5
 
-    def test_round_trip_of_ms_background_set(self, ms_background_set, fresh_backend):
+    def test_round_trip_of_ms_background_set(self, fresh_backend):
         """Test that a set of MS backgrounds survives a round trip"""
-        loaded = Calculator.get(ms_background_set.save())
+        backgrounds = MSBackgroundSet(
+            name="test ms backgrounds",
+            tstamp=1.6e9,
+            bg_list=[
+                MSConstantBackground(name="M32 background", mass="M32", bg=1e-12),
+                MSConstantBackground(name="M2 background", mass="M2", bg=2e-12),
+            ],
+        )
+        loaded = Calculator.get(backgrounds.save())
         assert isinstance(loaded, MSBackgroundSet)
         assert sorted((bg.mass, bg.bg) for bg in loaded.bg_list) == [
             ("M2", 2e-12),
             ("M32", 1e-12),
         ]
 
-    def test_round_trip_of_ec_optical(self, ec_optical_measurement, fresh_backend):
-        """Test that both of an EC-Optical measurement's spectrum references survive"""
-        id_ = ec_optical_measurement.save()
-        loaded = Measurement.get(id_)
-        assert np.allclose(loaded.spectra.data, ec_optical_measurement.spectra.data)
-        assert loaded.reference_spectrum.name == "ref spectrum"
-        assert np.allclose(
-            loaded.reference_spectrum.y, ec_optical_measurement.reference_spectrum.y
-        )
+    @pytest.mark.parametrize("with_reference", [True, False])
+    def test_round_trip_of_ec_optical(
+        self, with_reference, ec_optical_measurement_factory, fresh_backend
+    ):
+        """Test EC-Optical spectrum links with and without a reference."""
+        measurement = ec_optical_measurement_factory(with_reference)
+        loaded = Measurement.get(measurement.save())
+        assert np.allclose(loaded.spectra.data, measurement.spectra.data)
+        if with_reference:
+            assert loaded.reference_spectrum.name == "ref spectrum"
+            assert np.allclose(loaded.reference_spectrum.y, np.ones(4))
+        else:
+            assert loaded.reference_spectrum is None

--- a/tests/functional/test_backends.py
+++ b/tests/functional/test_backends.py
@@ -3,6 +3,8 @@
 import numpy as np
 
 from ixdat import Measurement
+from ixdat.calculators.ms_calculators import MSBackgroundSet, MSCalibration
+from ixdat.measurement_base import Calculator
 
 
 #  If tox crashes when trying to import matplotlib, see:
@@ -33,6 +35,25 @@ class TestBackends:
         ec_measurement.save()
         loaded = Measurement.load(ec_measurement.name)
         assert ec_measurement == loaded
+
+    def test_round_trip_of_ms_calibration(self, ms_calibration, fresh_backend):
+        """Test that an MS calibration's sensitivity factors survive a round trip"""
+        loaded = Calculator.get(ms_calibration.save())
+        assert isinstance(loaded, MSCalibration)
+        assert sorted((cal.mol, cal.mass, cal.F) for cal in loaded.ms_cal_results) == [
+            ("H2", "M2", 3.0),
+            ("O2", "M32", 1.5),
+        ]
+        assert loaded.get_F("O2", "M32") == 1.5
+
+    def test_round_trip_of_ms_background_set(self, ms_background_set, fresh_backend):
+        """Test that a set of MS backgrounds survives a round trip"""
+        loaded = Calculator.get(ms_background_set.save())
+        assert isinstance(loaded, MSBackgroundSet)
+        assert sorted((bg.mass, bg.bg) for bg in loaded.bg_list) == [
+            ("M2", 2e-12),
+            ("M32", 1e-12),
+        ]
 
     def test_round_trip_of_ec_optical(self, ec_optical_measurement, fresh_backend):
         """Test that both of an EC-Optical measurement's spectrum references survive"""

--- a/tests/unit/test_sqlite_backend.py
+++ b/tests/unit/test_sqlite_backend.py
@@ -89,6 +89,64 @@ class TestRelationalSchema:
         assert component_linker.owner_column == "measurement_id"
         assert component_linker.linked_column == "linked_measurement_id"
 
+    def test_column_types_come_from_the_declaring_class(self):
+        """Each column's type is the one declared by the class which adds it"""
+        columns = {
+            column.name: column
+            for column in relational.main_table_schema(DataSeries).columns
+        }
+        assert columns["data"].dtype == "NDARRAY"  # declared by DataSeries
+        assert columns["name"].dtype == "TEXT"  # inherited from Saveable
+
+    def test_column_types_are_merged_over_multiple_inheritance(self):
+        """Unlike extra_column_attrs, column_types of *both* parents carry over"""
+        types = ECMSMeasurement.get_column_types()
+        assert types["ec_technique"] == "TEXT"  # from ECMeasurement
+        assert types["tspan_bg"] == "JSON"  # from ECMSMeasurement itself
+        assert types["aliases"] == "JSON"  # from Measurement
+        # and a class only has to declare what it adds itself:
+        assert ECMSMeasurement.__dict__["column_types"] == {"tspan_bg": "JSON"}
+
+    def test_column_references_become_foreign_keys(self):
+        columns = {
+            column.name: column
+            for column in relational.main_table_schema(Spectrum).columns
+        }
+        assert columns["field_id"].foreign_key == ("data_series", "id")
+        # a column referring to another row always holds that row's integer id:
+        assert columns["field_id"].dtype == "INTEGER"
+
+    def test_a_class_outside_ixdat_can_declare_its_own_column_types(self):
+        """A plugin class gets its columns typed without ixdat knowing about it"""
+
+        class PluginMeasurement(Measurement):
+            extra_column_attrs = {"plugin_measurements": {"instrument_settings"}}
+            column_types = {"instrument_settings": "JSON"}
+
+        (schema,) = relational.extension_table_schemas(PluginMeasurement)
+        (column,) = schema.data_columns
+        assert column.name == "instrument_settings"
+        assert column.dtype == "JSON"
+
+    def test_unknown_column_type_is_rejected(self):
+        # a stand-in rather than a real Saveable subclass, since a class with a
+        # broken column type would stay in Saveable.__subclasses__() for the rest
+        # of the session and break the schema of every test after this one:
+        class MistypedClass:
+            table_name = "mistyped"
+            column_attrs = {"whoops"}
+
+            @classmethod
+            def get_column_types(cls):
+                return {"whoops": "NDARAY"}  # typo for "NDARRAY"
+
+            @classmethod
+            def get_column_references(cls):
+                return {}
+
+        with pytest.raises(DataBaseError, match="unknown type"):
+            relational.main_table_schema(MistypedClass)
+
     def test_family_table_schemas(self):
         """All classes sharing a main table contribute to the family schema"""
         extension_schemas, linker_schemas = relational.family_table_schemas(
@@ -236,7 +294,7 @@ class TestSQLiteBackend:
         assert sqlite_backend._encode(ColumnSchema("x"), np.float64(1.5)) == 1.5
 
     def test_dynamic_column_rejects_containers(self, sqlite_backend):
-        """Containers require a logical type registered in relational.COLUMN_TYPES"""
+        """Containers require a logical type declared in the class's column_types"""
         with pytest.raises(DataBaseError):
             sqlite_backend._encode(ColumnSchema("unregistered"), {"nested": "dict"})
 

--- a/tests/unit/test_sqlite_backend.py
+++ b/tests/unit/test_sqlite_backend.py
@@ -10,9 +10,20 @@ from ixdat.backends import relational
 from ixdat.backends.directory_backend import DirBackend
 from ixdat.backends.memory_backend import MemoryBackend
 from ixdat.backends.relational import ColumnSchema
-from ixdat.backends.sqlite_backend import METADATA_TABLE, SCHEMA_VERSION, SQLiteBackend
+from ixdat.backends.sqlite_backend import (
+    METADATA_TABLE_NAME,
+    SCHEMA_VERSION,
+    SQLiteBackend,
+)
 from ixdat.data_series import DataSeries, Field, TimeSeries, ValueSeries
-from ixdat.db import DB, PlaceHolderObject, change_database
+from ixdat.db import (
+    DB,
+    PlaceHolderObject,
+    Relationship,
+    Saveable,
+    change_database,
+    same_short_identity,
+)
 from ixdat.exceptions import DataBaseError
 from ixdat.measurement_base import Calculator
 from ixdat.calculators.ec_calculators import ECCalibration
@@ -20,6 +31,18 @@ from ixdat.calculators.ms_calculators import MSCalibration, MSCalResult
 from ixdat.spectra import MultiSpectrum
 from ixdat.techniques.ec_ms import ECMSMeasurement
 from ixdat.techniques.spectroelectrochemistry import ECOpticalMeasurement
+
+
+def create_schema_metadata(connection, version=SCHEMA_VERSION):
+    """Mark a hand-built test database as an ixdat SQLite schema."""
+    connection.execute(
+        f'CREATE TABLE "{METADATA_TABLE_NAME}" '
+        '("key" TEXT PRIMARY KEY, "value" TEXT NOT NULL)'
+    )
+    connection.execute(
+        f'INSERT INTO "{METADATA_TABLE_NAME}" VALUES (?, ?)',
+        ("schema_version", str(version)),
+    )
 
 
 @pytest.fixture
@@ -43,6 +66,19 @@ class MistypedMeasurement(Measurement):
 
     extra_column_attrs = {"mistyped_measurements": {"whoops"}}
     column_types = {"whoops": "NDARAY"}  # invalid: column types are Python types
+
+
+class ArrayColumnObject(Saveable):
+    """Plugin-like object with a NumPy-array column other than ``data``."""
+
+    table_name = "array_column_objects"
+    column_attrs = {"name", "coefficients"}
+    column_types = {"coefficients": np.ndarray}
+
+    def __init__(self, name, coefficients):
+        super().__init__()
+        self.name = name
+        self.coefficients = coefficients
 
 
 class TestRelationalSchema:
@@ -71,7 +107,7 @@ class TestRelationalSchema:
         }
         assert set(schemas) == {"ec_measurements", "ecms_measurements"}
         ecms_schema = schemas["ecms_measurements"]
-        assert ecms_schema.extends == "measurement"
+        assert ecms_schema.base_table == "measurement"
         # the extension table's id is a foreign key to the main table:
         assert ecms_schema.columns[0].name == "id"
         assert ecms_schema.columns[0].foreign_key == ("measurement", "id")
@@ -101,17 +137,75 @@ class TestRelationalSchema:
         assert series_linker.owner_column == "measurement_id"
         assert series_linker.linked_column == "data_series_id"
         assert series_linker.id_attr == "s_ids"
-        assert series_linker.is_list
+        assert series_linker.many
         # a self-referencing linker table gets distinguishable column names:
         component_linker = linkers["component_measurements"]
         assert component_linker.owner_column == "measurement_id"
         assert component_linker.linked_column == "linked_measurement_id"
-        reference_linker = {
+        optical_linkers = {
             schema.name: schema
             for schema in relational.linker_table_schemas(ECOpticalMeasurement)
-        }["ec_optical_measurements"]
-        assert reference_linker.id_attr == "ref_id"
-        assert not reference_linker.is_list
+        }
+        assert "ec_optical_measurements" not in optical_linkers
+
+    def test_scalar_relationship_in_an_extension_table(self):
+        schemas = {
+            schema.name: schema
+            for schema in relational.extension_table_schemas(ECOpticalMeasurement)
+        }
+        reference_column = {
+            column.name: column
+            for column in schemas["ec_optical_measurements"].data_columns
+        }["ref_id"]
+        assert reference_column.foreign_key == ("spectrums", "id")
+        assert "position" not in schemas["ec_optical_measurements"].column_names
+
+    def test_relationship_connects_objects_to_their_storage(self):
+        relationship = Measurement.get_relationships()["series_list"]
+        assert isinstance(relationship, Relationship)
+        assert relationship.id_attr == "s_ids"
+        assert relationship.storage_table == "measurement_series"
+        assert relationship.many
+        assert relationship.save_related
+
+    def test_relationship_many_decides_whether_ids_form_a_list(self):
+        """The id attribute's name does not decide the shape of a new relationship."""
+
+        class PluginMeasurement(Measurement):
+            relationships = {
+                "related_calculators": Relationship(
+                    "calculator",
+                    "calculator_references",
+                    many=True,
+                    storage_table="plugin_measurement_calculators",
+                )
+            }
+
+        linkers = {
+            schema.name: schema
+            for schema in relational.linker_table_schemas(PluginMeasurement)
+        }
+        assert linkers["plugin_measurement_calculators"].many
+
+    def test_legacy_linker_names_still_decide_whether_ids_form_a_list(self):
+        """Older plugin declarations keep their established ``_ids`` rule."""
+
+        class LegacyPluginMeasurement(Measurement):
+            extra_linkers = {
+                "legacy_measurement_calculators": ("calculator", "calculator_ids")
+            }
+
+        linkers = {
+            schema.name: schema
+            for schema in relational.linker_table_schemas(LegacyPluginMeasurement)
+        }
+        assert linkers["legacy_measurement_calculators"].many
+
+    def test_many_relationship_needs_a_storage_table(self):
+        with pytest.raises(
+            ValueError, match="containing many objects needs a storage_table"
+        ):
+            Relationship("calculator", "calculator_ids", many=True)
 
     def test_column_types_merge_from_the_declaring_classes(self):
         """Column types come from every declaring class in the ancestry."""
@@ -173,6 +267,15 @@ class TestRelationalSchema:
 class TestSQLiteBackend:
     """Tests saving and loading ixdat objects with the SQLite backend"""
 
+    def test_non_data_array_column_loads_with_object(self, sqlite_backend):
+        """A differently named NumPy-array column loads with its object."""
+        coefficients = np.array([1.0, 0.5, 0.25])
+        i = ArrayColumnObject("calibration", coefficients).save()
+
+        loaded = ArrayColumnObject.get(i)
+
+        assert np.array_equal(loaded.coefficients, coefficients)
+
     def test_value_series_round_trip(self, sqlite_backend):
         tseries = TimeSeries(
             name="time / s", unit_name="s", data=np.array([0.0, 1.0, 2.0]), tstamp=1.6e9
@@ -187,6 +290,7 @@ class TestSQLiteBackend:
         loaded = DataSeries.get(i)
         assert isinstance(loaded, ValueSeries)
         assert loaded.unit_name == "V"
+        assert loaded.a_ids == [(sqlite_backend, tseries.id)]
         assert loaded._data is None
         assert np.allclose(loaded.data, vseries.data)
         assert loaded._data is not None
@@ -214,6 +318,7 @@ class TestSQLiteBackend:
         i = spectrum.save()
         loaded = Spectrum.get(i)
         assert loaded == spectrum
+        assert loaded.field_id == (sqlite_backend, field.id)
         assert loaded.metadata == {"scans": 2}  # JSON column round trip
         assert np.allclose(loaded.x, spectrum.x)
         assert np.allclose(loaded.y, spectrum.y)
@@ -430,16 +535,19 @@ class TestSQLiteBackend:
             assert loaded_series._data is None
             assert np.array_equal(loaded_series.data, series.data)
 
-    def test_connections_to_one_file_share_identity_and_rows(
+    def test_connections_to_one_file_share_storage_and_rows(
         self, sqlite_backend, tmp_path
     ):
-        """Equivalent connections share ids, rows, equality, and hashing."""
+        """Separate connections recognize rows stored in the same file."""
         with SQLiteBackend(db_path=sqlite_backend.db_path) as second_backend:
             with SQLiteBackend(db_path=tmp_path / "other.sqlite") as other_backend:
-                assert {sqlite_backend, second_backend} == {sqlite_backend}
+                assert sqlite_backend is not second_backend
+                assert sqlite_backend != second_backend
+                assert sqlite_backend.shares_storage_with(second_backend)
+                assert second_backend.shares_storage_with(sqlite_backend)
+                assert not sqlite_backend.shares_storage_with(other_backend)
                 assert sqlite_backend.address == second_backend.address
-                assert len({sqlite_backend, other_backend}) == 2
-                assert {sqlite_backend: "here"}[second_backend] == "here"
+                assert len({sqlite_backend, second_backend, other_backend}) == 3
 
                 first_id = sqlite_backend.save(
                     DataSeries(name="first", unit_name="V", data=np.array([1.0]))
@@ -450,7 +558,12 @@ class TestSQLiteBackend:
                 assert first_id != second_id
                 loaded = DataSeries.get(second_id, backend=sqlite_backend)
                 assert loaded.name == "second"
-                assert loaded.short_identity == second_id
+                assert loaded.short_identity == (sqlite_backend, second_id)
+                loaded_again = DataSeries.get(second_id, backend=second_backend)
+                assert loaded.short_identity != loaded_again.short_identity
+                assert same_short_identity(
+                    loaded.short_identity, loaded_again.short_identity
+                )
                 assert second_backend.save(loaded) is None
                 assert sqlite_backend.connection.execute(
                     'SELECT COUNT(*) FROM "data_series" WHERE "id" = ?', (second_id,)
@@ -464,39 +577,93 @@ class TestSQLiteBackend:
 
     def test_in_memory_database_uses_sqlite_convention(self):
         with SQLiteBackend(db_path=":memory:") as first_backend:
-            i = first_backend.save(
-                DataSeries(name="temporary", unit_name="V", data=np.array([1.0]))
+            first_series = DataSeries(
+                name="first temporary", unit_name="V", data=np.array([1.0])
             )
-            assert DataSeries.get(i, backend=first_backend).name == "temporary"
+            first_id = first_backend.save(first_series)
+            assert (
+                DataSeries.get(first_id, backend=first_backend).name == "first temporary"
+            )
             with SQLiteBackend(db_path=":memory:") as second_backend:
-                assert first_backend != second_backend
-                assert not second_backend.contains("data_series", i)
+                assert not second_backend.contains("data_series", first_id)
+                second_series = DataSeries(
+                    name="second temporary", unit_name="A", data=np.array([2.0])
+                )
+                second_id = second_backend.save(second_series)
 
-    def test_additive_schema_migration(self, tmp_path):
-        db_path = tmp_path / "legacy.sqlite"
+                assert first_backend != second_backend
+                assert not first_backend.shares_storage_with(second_backend)
+                assert first_backend.address != second_backend.address
+                assert first_id == second_id == 1
+                assert first_series.full_identity != second_series.full_identity
+                assert not same_short_identity(
+                    first_series.short_identity, second_series.short_identity
+                )
+                assert (
+                    DataSeries.get(second_id, backend=second_backend).name
+                    == "second temporary"
+                )
+
+    def test_chimera_save_reuses_local_series_and_copies_memory_series(
+        self, sqlite_backend
+    ):
+        ec_series = DataSeries(name="EC data", unit_name="V", data=np.array([1.0]))
+        ec = Measurement(name="EC", technique="EC", series_list=[ec_series])
+        ec.save()
+        ec_series_id = ec_series.id
+
+        ms_series = DataSeries(name="MS data", unit_name="A", data=np.array([2.0]))
+        ms = Measurement(name="MS", technique="MS", series_list=[ms_series])
+        ecms = ec + ms
+
+        assert ec_series.short_identity == (sqlite_backend, ec_series_id)
+        assert ms_series.short_identity[0].backend_type == "memory"
+
+        ecms.save()
+
+        assert ec_series.short_identity == (sqlite_backend, ec_series_id)
+        assert ms_series.short_identity == (sqlite_backend, ms_series.id)
+        assert sqlite_backend.connection.execute(
+            'SELECT COUNT(*) FROM "data_series" WHERE "id" = ?', (ec_series_id,)
+        ).fetchone() == (1,)
+        assert sqlite_backend.connection.execute(
+            'SELECT COUNT(*) FROM "data_series"'
+        ).fetchone() == (2,)
+
+    def test_unversioned_database_is_rejected_without_changes(self, tmp_path):
+        db_path = tmp_path / "unversioned.sqlite"
         with sqlite3.connect(db_path) as connection:
+            connection.execute(
+                'CREATE TABLE "data_series" ' '("id" INTEGER PRIMARY KEY, "name" TEXT)'
+            )
+        schema_before = db_path.read_bytes()
+
+        with pytest.raises(DataBaseError, match="no ixdat schema version"):
+            SQLiteBackend(db_path=db_path)
+
+        assert db_path.read_bytes() == schema_before
+
+    def test_missing_columns_require_manual_migration(self, tmp_path):
+        db_path = tmp_path / "old-layout.sqlite"
+        with sqlite3.connect(db_path) as connection:
+            create_schema_metadata(connection)
             connection.execute(
                 'CREATE TABLE "data_series" ' '("id" INTEGER PRIMARY KEY, "name" TEXT)'
             )
 
         with SQLiteBackend(db_path=db_path) as backend:
-            series = DataSeries(
-                name="after migration", unit_name="A", data=np.array([1.0])
-            )
-            backend.save(series)
+            with pytest.raises(DataBaseError, match="manual database migration"):
+                backend.save(DataSeries(name="x", unit_name="V", data=np.array([1.0])))
             columns = {
                 row[1]
                 for row in backend.connection.execute('PRAGMA table_info("data_series")')
             }
-            assert {"id", "name", "unit_name", "series_type", "data"} <= columns
-            assert backend.connection.execute(
-                f'SELECT "value" FROM "{METADATA_TABLE}" WHERE "key" = ?',
-                ("schema_version",),
-            ).fetchone()[0] == str(SCHEMA_VERSION)
+            assert columns == {"id", "name"}
 
     def test_incompatible_schema_requires_manual_migration(self, tmp_path):
         db_path = tmp_path / "incompatible.sqlite"
         with sqlite3.connect(db_path) as connection:
+            create_schema_metadata(connection)
             connection.execute(
                 'CREATE TABLE "data_series" ("id" TEXT PRIMARY KEY, "name" TEXT)'
             )
@@ -505,20 +672,42 @@ class TestSQLiteBackend:
             with pytest.raises(DataBaseError, match="manual database migration"):
                 backend.save(DataSeries(name="x", unit_name="V", data=np.array([1.0])))
 
-    def test_newer_schema_version_is_rejected(self, tmp_path):
-        db_path = tmp_path / "future.sqlite"
+    @pytest.mark.parametrize(
+        ("version", "relation"),
+        [(SCHEMA_VERSION - 1, "older"), (SCHEMA_VERSION + 1, "newer")],
+    )
+    def test_other_schema_versions_are_rejected(self, tmp_path, version, relation):
+        db_path = tmp_path / f"schema-{version}.sqlite"
         with sqlite3.connect(db_path) as connection:
-            connection.execute(
-                f'CREATE TABLE "{METADATA_TABLE}" '
-                '("key" TEXT PRIMARY KEY, "value" TEXT NOT NULL)'
-            )
-            connection.execute(
-                f'INSERT INTO "{METADATA_TABLE}" VALUES (?, ?)',
-                ("schema_version", str(SCHEMA_VERSION + 1)),
-            )
+            create_schema_metadata(connection, version)
 
-        with pytest.raises(DataBaseError, match="newer ixdat schema"):
+        with pytest.raises(DataBaseError, match=f"{relation} ixdat schema"):
             SQLiteBackend(db_path=db_path)
+
+    def test_get_does_not_create_missing_tables(self, tmp_path):
+        with SQLiteBackend(db_path=tmp_path / "empty.sqlite") as backend:
+            tables_before = backend._existing_tables()
+            with pytest.raises(DataBaseError, match="has no table"):
+                DataSeries.get(1, backend=backend)
+            assert backend._existing_tables() == tables_before
+
+    def test_get_does_not_recreate_missing_indexes(self, tmp_path):
+        db_path = tmp_path / "no-read-writes.sqlite"
+        with SQLiteBackend(db_path=db_path) as backend:
+            series_id = backend.save(
+                DataSeries(name="x", unit_name="V", data=np.array([1.0]))
+            )
+            backend.connection.execute('DROP INDEX "ixdat_data_series_name_id"')
+
+        with SQLiteBackend(db_path=db_path) as backend:
+            indexes_before = backend.connection.execute(
+                'PRAGMA index_list("data_series")'
+            ).fetchall()
+            assert DataSeries.get(series_id, backend=backend).name == "x"
+            assert (
+                backend.connection.execute('PRAGMA index_list("data_series")').fetchall()
+                == indexes_before
+            )
 
     def test_failed_explicit_backend_load_restores_active_backend(
         self, sqlite_backend, tmp_path
@@ -530,7 +719,7 @@ class TestSQLiteBackend:
             assert DB.backend is original_backend
 
     def test_lookup_indexes_are_created(self, sqlite_backend):
-        sqlite_backend._ensure_tables(Measurement)
+        sqlite_backend._ensure_tables_for_save(Measurement)
         indexes = {
             row[1]
             for row in sqlite_backend.connection.execute(
@@ -582,5 +771,25 @@ def test_directory_load_uses_exact_unescaped_name(tmp_path):
             "counts": [1, 2],
             "scans": 2,
         }
+    finally:
+        DB.set_backend(original_backend)
+
+
+def test_directory_backend_stores_local_reference_ids(tmp_path):
+    original_backend = DB.backend
+    backend = DirBackend(directory=tmp_path, project_name="tuple_references")
+    DB.set_backend(backend)
+    try:
+        series = DataSeries(name="signal", unit_name="V", data=np.array([1.0]))
+        measurement = Measurement(
+            name="measurement", technique="test", series_list=[series]
+        )
+        measurement_id = measurement.save()
+
+        stored = backend.get_row_as_dict("measurement", measurement_id)
+        assert stored["s_ids"] == [series.id]
+
+        loaded = Measurement.get(measurement_id)
+        assert loaded.s_ids == [(backend, series.id)]
     finally:
         DB.set_backend(original_backend)

--- a/tests/unit/test_sqlite_backend.py
+++ b/tests/unit/test_sqlite_backend.py
@@ -426,6 +426,17 @@ class TestSQLiteBackend:
         with pytest.raises(DataBaseError):
             Measurement.get(999)
 
+    def test_load_obj_data_rejects_wrong_object_or_missing_row(self, sqlite_backend):
+        with pytest.raises(TypeError, match="only accepts DataSeries"):
+            sqlite_backend.load_obj_data(Measurement(name="wrong type"))
+
+        DataSeries(name="existing", unit_name="V", data=np.array([1.0])).save()
+        missing_series = DataSeries(name="missing", unit_name="V", data=None)
+        missing_series.set_backend(sqlite_backend)
+        missing_series.set_id(999)
+        with pytest.raises(DataBaseError, match="no row with id=999"):
+            sqlite_backend.load_obj_data(missing_series)
+
     def test_update_with_force(self, sqlite_backend):
         series = DataSeries(name="before", unit_name="V", data=np.array([1.0]))
         i = series.save()

--- a/tests/unit/test_sqlite_backend.py
+++ b/tests/unit/test_sqlite_backend.py
@@ -11,6 +11,7 @@ from ixdat.db import DB, change_database
 from ixdat.exceptions import DataBaseError
 from ixdat.measurement_base import Calculator
 from ixdat.calculators.ec_calculators import ECCalibration
+from ixdat.spectra import MultiSpectrum
 from ixdat.techniques.ec_ms import ECMSMeasurement
 
 
@@ -184,3 +185,31 @@ class TestSQLiteBackend:
         """Containers require a logical type registered in relational.COLUMN_TYPES"""
         with pytest.raises(DataBaseError):
             sqlite_backend._encode(ColumnSchema("unregistered"), {"nested": "dict"})
+
+    def test_multispectrum_round_trip(self, sqlite_backend):
+        xseries = DataSeries(
+            name="two theta / deg", unit_name="deg", data=np.linspace(20, 80, 7)
+        )
+        fields = [
+            Field(
+                name=name,
+                unit_name="counts",
+                data=np.linspace(0, 1, 7) * scale,
+                axes_series=[xseries],
+            )
+            for name, scale in (("intensity", 100.0), ("error", 10.0))
+        ]
+        multi = MultiSpectrum(
+            name="test multispectrum", technique="XRD", tstamp=1.6e9, fields=fields
+        )
+        i = multi.save()
+        loaded = MultiSpectrum.get(i)
+        assert loaded == multi
+        assert len(loaded.fields) == 2
+        assert np.allclose(loaded.x, multi.x)
+
+    def test_schema_report(self, sqlite_backend):
+        report = sqlite_backend.schema_report()
+        assert 'CREATE TABLE IF NOT EXISTS "measurement"' in report
+        assert 'CREATE TABLE IF NOT EXISTS "measurement_series"' in report
+        assert 'REFERENCES "data_series"("id")' in report

--- a/tests/unit/test_sqlite_backend.py
+++ b/tests/unit/test_sqlite_backend.py
@@ -42,7 +42,7 @@ class MistypedMeasurement(Measurement):
     """
 
     extra_column_attrs = {"mistyped_measurements": {"whoops"}}
-    column_types = {"whoops": "NDARAY"}  # typo for "NDARRAY"
+    column_types = {"whoops": "NDARAY"}  # invalid: column types are Python types
 
 
 def _ec_optical_measurement(reference_spectrum="build one"):
@@ -105,30 +105,43 @@ class TestRelationalSchema:
         assert schema.column_names[:2] == ["id", "name"]
 
     def test_extension_table(self):
-        (schema,) = relational.extension_table_schemas(ECMSMeasurement)
+        schemas = {
+            schema.name: schema
+            for schema in relational.extension_table_schemas(ECMSMeasurement)
+        }
+        schema = schemas["ecms_measurements"]
         assert schema.name == "ecms_measurements"
         assert schema.extends == "measurement"
         # the extension table's id is a foreign key to the main table:
         assert schema.columns[0].name == "id"
         assert schema.columns[0].foreign_key == ("measurement", "id")
-        assert {column.name for column in schema.data_columns} == {
-            "ec_technique",
-            "tspan_bg",
+        assert {column.name for column in schema.data_columns} == {"tspan_bg"}
+
+    def test_extension_tables_merge_over_multiple_inheritance(self):
+        """Each ancestor contributes its extension table without repeated columns."""
+        schemas = {
+            schema.name: schema
+            for schema in relational.extension_table_schemas(ECMSMeasurement)
+        }
+        assert set(schemas) == {"ec_measurements", "ecms_measurements"}
+        assert {column.name for column in schemas["ec_measurements"].data_columns} == {
+            "ec_technique"
+        }
+        assert {column.name for column in schemas["ecms_measurements"].data_columns} == {
+            "tspan_bg"
         }
 
-    def test_multiply_inheriting_class_only_gets_its_own_extension_table(self):
-        """Known limitation: `extra_column_attrs` is shadowed, not merged, across
-        multiple inheritance (see the "Known limitation" section of
-        docs/source/diving_deeper/backend.rst). `ECMSMeasurement` inherits from both
-        `ECMeasurement` and `MSMeasurement`, but its own `extra_column_attrs`
-        replaces `ECMeasurement`'s rather than adding to it, so `ec_measurements` -
-        the extension table `ECMeasurement` itself declares - is absent here.
-        """
-        extension_table_names = {
-            schema.name for schema in relational.extension_table_schemas(ECMSMeasurement)
-        }
-        assert extension_table_names == {"ecms_measurements"}
-        assert "ec_measurements" not in extension_table_names
+    def test_collecting_all_attrs_does_not_modify_main_table_metadata(self):
+        """Linker attributes stay out of the main table schema."""
+        original_column_attrs = Measurement.column_attrs.copy()
+
+        all_attrs = Measurement.get_all_column_attrs()
+
+        assert {"s_ids", "m_ids", "c_ids"} <= all_attrs
+        assert Measurement.column_attrs == original_column_attrs
+        assert not {"s_ids", "m_ids", "c_ids"} & set(
+            relational.main_table_schema(Measurement).column_names
+        )
 
     def test_linker_tables(self):
         linkers = {
@@ -151,17 +164,17 @@ class TestRelationalSchema:
             column.name: column
             for column in relational.main_table_schema(DataSeries).columns
         }
-        assert columns["data"].dtype == "NDARRAY"  # declared by DataSeries
-        assert columns["name"].dtype == "TEXT"  # inherited from Saveable
+        assert columns["data"].dtype is np.ndarray  # declared by DataSeries
+        assert columns["name"].dtype is str  # inherited from Saveable
 
     def test_column_types_are_merged_over_multiple_inheritance(self):
-        """Unlike extra_column_attrs, column_types of *both* parents carry over"""
+        """Column types from the full ancestry carry over."""
         types = ECMSMeasurement.get_column_types()
-        assert types["ec_technique"] == "TEXT"  # from ECMeasurement
-        assert types["tspan_bg"] == "JSON"  # from ECMSMeasurement itself
-        assert types["aliases"] == "JSON"  # from Measurement
+        assert types["ec_technique"] is str  # from ECMeasurement
+        assert types["tspan_bg"] is list  # from ECMSMeasurement itself
+        assert types["aliases"] is dict  # from Measurement
         # and a class only has to declare what it adds itself:
-        assert ECMSMeasurement.__dict__["column_types"] == {"tspan_bg": "JSON"}
+        assert ECMSMeasurement.__dict__["column_types"] == {"tspan_bg": list}
 
     def test_column_references_become_foreign_keys(self):
         columns = {
@@ -170,23 +183,30 @@ class TestRelationalSchema:
         }
         assert columns["field_id"].foreign_key == ("data_series", "id")
         # a column referring to another row always holds that row's integer id:
-        assert columns["field_id"].dtype == "INTEGER"
+        assert columns["field_id"].dtype is int
 
     def test_a_class_outside_ixdat_can_declare_its_own_column_types(self):
         """A plugin class gets its columns typed without ixdat knowing about it"""
 
         class PluginMeasurement(Measurement):
             extra_column_attrs = {"plugin_measurements": {"instrument_settings"}}
-            column_types = {"instrument_settings": "JSON"}
+            column_types = {"instrument_settings": dict}
 
         (schema,) = relational.extension_table_schemas(PluginMeasurement)
         (column,) = schema.data_columns
         assert column.name == "instrument_settings"
-        assert column.dtype == "JSON"
+        assert column.dtype is dict
 
     def test_unknown_column_type_is_rejected(self):
         with pytest.raises(DataBaseError, match="unknown type"):
             relational.extension_table_schemas(MistypedMeasurement)
+
+    def test_metadata_for_an_unknown_column_is_rejected(self):
+        class UnknownColumnMeasurement(Measurement):
+            column_references = {"missing_id": "calculator"}
+
+        with pytest.raises(DataBaseError, match="unknown column.*missing_id"):
+            relational.main_table_schema(UnknownColumnMeasurement)
 
     def test_a_broken_class_does_not_break_its_relatives(self):
         """Only the misdeclared class itself raises, so other rows still load
@@ -279,15 +299,10 @@ class TestSQLiteBackend:
         assert loaded.A_el == 0.196
         assert loaded.R_Ohm is None
 
-    def test_multiply_inheriting_measurement_round_trips_but_skips_parent_table(
+    def test_multiply_inheriting_measurement_populates_each_extension_table(
         self, sqlite_backend
     ):
-        """Known limitation, documented in docs/source/diving_deeper/backend.rst:
-        `ECMSMeasurement` (inherits from `ECMeasurement` and `MSMeasurement`) writes
-        only to its own extension table. Round-tripping the object is unaffected -
-        `ec_technique` survives via `ecms_measurements` - but a query joining only
-        `ec_measurements` would miss this row, since no row is written there.
-        """
+        """An EC-MS row carries its EC and EC-MS attributes in separate tables."""
         tseries = TimeSeries(
             name="t", unit_name="s", data=np.array([0.0, 1.0]), tstamp=1.6e9
         )
@@ -302,14 +317,21 @@ class TestSQLiteBackend:
 
         loaded = Measurement.get(i)
         assert isinstance(loaded, ECMSMeasurement)
-        assert loaded.ec_technique == "Cyclic Voltammetry Advanced"  # round trip OK
+        assert loaded.ec_technique == "Cyclic Voltammetry Advanced"
 
-        existing_tables = sqlite_backend._existing_tables()
-        assert "ec_measurements" not in existing_tables  # never created: no writer
-        row = sqlite_backend.connection.execute(
-            'SELECT 1 FROM "ecms_measurements" WHERE "id" = ?', (i,)
-        ).fetchone()
-        assert row is not None  # the data lives here instead
+        assert sqlite_backend.connection.execute(
+            'SELECT "ec_technique" FROM "ec_measurements" WHERE "id" = ?', (i,)
+        ).fetchone() == ("Cyclic Voltammetry Advanced",)
+        assert sqlite_backend.connection.execute(
+            'SELECT "tspan_bg" FROM "ecms_measurements" WHERE "id" = ?', (i,)
+        ).fetchone() == (None,)
+        ecms_columns = {
+            row[1]
+            for row in sqlite_backend.connection.execute(
+                'PRAGMA table_info("ecms_measurements")'
+            )
+        }
+        assert "ec_technique" not in ecms_columns
 
     def test_ms_calibration_results_are_loaded_lazily(self, sqlite_backend):
         """A loaded MS calibration knows its results' id's before loading them"""
@@ -406,15 +428,18 @@ class TestSQLiteBackend:
             Measurement.get(999)
 
     def test_codecs(self, sqlite_backend):
-        json_column = ColumnSchema("metadata", dtype="JSON")
+        json_column = ColumnSchema("metadata", dtype=dict)
         value = {"a": np.int64(1), "b": np.array([1.5, 2.5])}
         encoded = sqlite_backend._encode(json_column, value)
         assert sqlite_backend._decode(json_column, encoded) == {
             "a": 1,
             "b": [1.5, 2.5],
         }
+        tuple_column = ColumnSchema("range", dtype=tuple)
+        encoded = sqlite_backend._encode(tuple_column, (1.0, 2.0))
+        assert sqlite_backend._decode(tuple_column, encoded) == (1.0, 2.0)
 
-        array_column = ColumnSchema("data", dtype="NDARRAY")
+        array_column = ColumnSchema("data", dtype=np.ndarray)
         data = np.linspace(0, 1, 5)
         encoded = sqlite_backend._encode(array_column, data)
         assert np.array_equal(sqlite_backend._decode(array_column, encoded), data)
@@ -519,12 +544,28 @@ class TestSQLiteBackend:
                 == []
             )
 
+    def test_equivalent_connection_does_not_duplicate_a_saved_object(
+        self, sqlite_backend
+    ):
+        series = DataSeries(name="shared", unit_name="V", data=np.array([1.0]))
+        series_id = sqlite_backend.save(series)
+
+        with SQLiteBackend(db_path=sqlite_backend.db_path) as second_backend:
+            loaded = DataSeries.get(series_id, backend=second_backend)
+            assert loaded.backend == sqlite_backend
+            assert loaded.short_identity == series_id
+            assert sqlite_backend.save(loaded) is None
+            assert sqlite_backend.connection.execute(
+                'SELECT COUNT(*) FROM "data_series" WHERE "id" = ?', (series_id,)
+            ).fetchone() == (1,)
+
     def test_backends_can_be_used_in_sets_and_dicts(self, sqlite_backend, tmp_path):
         """Defining __eq__ without __hash__ would make the backend unhashable"""
         with SQLiteBackend(db_path=sqlite_backend.db_path) as same_file:
             with SQLiteBackend(db_path=tmp_path / "other.sqlite") as other_file:
                 # two connections to one file are one database, and hash alike:
                 assert {sqlite_backend, same_file} == {sqlite_backend}
+                assert sqlite_backend.address == same_file.address
                 assert len({sqlite_backend, other_file}) == 2
                 # a backend can be a dict key, e.g. to group objects by database:
                 assert {sqlite_backend: "here"}[same_file] == "here"

--- a/tests/unit/test_sqlite_backend.py
+++ b/tests/unit/test_sqlite_backend.py
@@ -15,8 +15,9 @@ from ixdat.db import DB, change_database
 from ixdat.exceptions import DataBaseError
 from ixdat.measurement_base import Calculator
 from ixdat.calculators.ec_calculators import ECCalibration
-from ixdat.spectra import MultiSpectrum
+from ixdat.spectra import MultiSpectrum, SpectrumSeries
 from ixdat.techniques.ec_ms import ECMSMeasurement
+from ixdat.techniques.spectroelectrochemistry import ECOpticalMeasurement
 
 
 @pytest.fixture
@@ -27,6 +28,47 @@ def sqlite_backend(tmp_path):
     yield DB.backend
     DB.backend.close()
     DB.set_backend(original_backend)
+
+
+def _ec_optical_measurement(reference_spectrum="build one"):
+    """Return a synthetic ECOpticalMeasurement, evt. without a reference spectrum"""
+    tseries = TimeSeries(
+        name="t", unit_name="s", data=np.array([0.0, 1.0]), tstamp=1.6e9
+    )
+    wavelength = DataSeries(
+        name="wavelength / nm", unit_name="nm", data=np.linspace(400, 700, 4)
+    )
+    spectrum_series = SpectrumSeries(
+        name="optical spectra",
+        technique="EC-Optical",
+        tstamp=1.6e9,
+        field=Field(
+            name="spectra",
+            unit_name="counts",
+            data=np.array([[1.0, 2.0, 3.0, 4.0], [2.0, 3.0, 4.0, 5.0]]),
+            axes_series=[tseries, wavelength],
+        ),
+    )
+    if reference_spectrum == "build one":
+        reference_spectrum = Spectrum(
+            name="ref spectrum",
+            technique="optical",
+            tstamp=1.6e9,
+            field=Field(
+                name="reference",
+                unit_name="counts",
+                data=np.array([1.0, 1.0, 1.0, 1.0]),
+                axes_series=[wavelength],
+            ),
+        )
+    return ECOpticalMeasurement(
+        name="synthetic EC-Optical",
+        technique="EC-Optical",
+        tstamp=1.6e9,
+        series_list=[tseries],
+        spectrum_series=spectrum_series,
+        reference_spectrum=reference_spectrum,
+    )
 
 
 class TestRelationalSchema:
@@ -255,6 +297,33 @@ class TestSQLiteBackend:
             'SELECT 1 FROM "ecms_measurements" WHERE "id" = ?', (i,)
         ).fetchone()
         assert row is not None  # the data lives here instead
+
+    def test_ec_optical_measurement_round_trip(self, sqlite_backend):
+        """The reference spectrum is a single-reference linker, not a list"""
+        measurement = _ec_optical_measurement()
+        i = measurement.save()
+
+        loaded = Measurement.get(i)
+        assert isinstance(loaded, ECOpticalMeasurement)
+        # both spectrum references survive: the spectrum series and the reference
+        assert np.allclose(loaded.spectra.data, measurement.spectra.data)
+        assert loaded.reference_spectrum.name == "ref spectrum"
+        assert np.allclose(loaded.reference_spectrum.y, [1.0, 1.0, 1.0, 1.0])
+        # the reference is stored as one row of its linker table, at position 0:
+        assert sqlite_backend.connection.execute(
+            'SELECT "position", "spectrums_id" FROM "ec_optical_measurements" '
+            'WHERE "measurement_id" = ?',
+            (i,),
+        ).fetchall() == [(0, loaded.reference_spectrum.id)]
+
+    def test_ec_optical_measurement_without_a_reference_spectrum(self, sqlite_backend):
+        """A reference spectrum can be set later, so saving without one must work"""
+        measurement = _ec_optical_measurement(reference_spectrum=None)
+        assert measurement.reference_spectrum is None
+        assert measurement.ref_id is None
+
+        loaded = Measurement.get(measurement.save())
+        assert loaded.reference_spectrum is None
 
     def test_load_returns_newest_with_name(self, sqlite_backend):
         DataSeries(name="twin", unit_name="V", data=np.array([1.0])).save()

--- a/tests/unit/test_sqlite_backend.py
+++ b/tests/unit/test_sqlite_backend.py
@@ -1,0 +1,186 @@
+"""Unit tests for the relational schema derivation and the SQLite backend"""
+
+import numpy as np
+import pytest
+
+from ixdat import Measurement, Spectrum
+from ixdat.backends import relational
+from ixdat.backends.relational import ColumnSchema
+from ixdat.data_series import DataSeries, Field, TimeSeries, ValueSeries
+from ixdat.db import DB, change_database
+from ixdat.exceptions import DataBaseError
+from ixdat.measurement_base import Calculator
+from ixdat.calculators.ec_calculators import ECCalibration
+from ixdat.techniques.ec_ms import ECMSMeasurement
+
+
+@pytest.fixture
+def sqlite_backend(tmp_path):
+    """An SQLite backend on a fresh database file, set as the active backend"""
+    original_backend = DB.backend
+    change_database("sqlite", db_path=tmp_path / "test.sqlite")
+    yield DB.backend
+    DB.backend.close()
+    DB.set_backend(original_backend)
+
+
+class TestRelationalSchema:
+    """Tests for the derivation of table descriptions from Saveable classes"""
+
+    def test_measurement_main_table(self):
+        schema = relational.main_table_schema(Measurement)
+        assert schema.name == "measurement"
+        assert set(schema.column_names) == {
+            "id",
+            "name",
+            "technique",
+            "metadata",
+            "aliases",
+            "sample_name",
+            "tstamp",
+        }
+        # deterministic order, with id and name first:
+        assert schema.column_names[:2] == ["id", "name"]
+
+    def test_extension_table(self):
+        (schema,) = relational.extension_table_schemas(ECMSMeasurement)
+        assert schema.name == "ecms_measurements"
+        assert schema.extends == "measurement"
+        # the extension table's id is a foreign key to the main table:
+        assert schema.columns[0].name == "id"
+        assert schema.columns[0].foreign_key == ("measurement", "id")
+        assert {column.name for column in schema.data_columns} == {
+            "ec_technique",
+            "tspan_bg",
+        }
+
+    def test_linker_tables(self):
+        linkers = {
+            schema.name: schema
+            for schema in relational.linker_table_schemas(Measurement)
+        }
+        series_linker = linkers["measurement_series"]
+        assert series_linker.owner_column == "measurement_id"
+        assert series_linker.linked_column == "data_series_id"
+        assert series_linker.id_attr == "s_ids"
+        assert series_linker.is_list
+        # a self-referencing linker table gets distinguishable column names:
+        component_linker = linkers["component_measurements"]
+        assert component_linker.owner_column == "measurement_id"
+        assert component_linker.linked_column == "linked_measurement_id"
+
+    def test_family_table_schemas(self):
+        """All classes sharing a main table contribute to the family schema"""
+        extension_schemas, linker_schemas = relational.family_table_schemas(
+            DataSeries
+        )
+        # TimeSeries extends the data_series table with the tstamps table:
+        assert "tstamps" in {schema.name for schema in extension_schemas}
+        # Field links data_series rows to their axes' data_series rows:
+        assert "field_axes" in {schema.name for schema in linker_schemas}
+
+
+class TestSQLiteBackend:
+    """Tests saving and loading ixdat objects with the SQLite backend"""
+
+    def test_value_series_round_trip(self, sqlite_backend):
+        tseries = TimeSeries(
+            name="time / s", unit_name="s", data=np.array([0.0, 1.0, 2.0]), tstamp=1.6e9
+        )
+        vseries = ValueSeries(
+            name="potential / V",
+            unit_name="V",
+            data=np.array([1.0, 2.0, 4.0]),
+            tseries=tseries,
+        )
+        i = vseries.save()
+        loaded = DataSeries.get(i)
+        assert isinstance(loaded, ValueSeries)
+        assert loaded.unit_name == "V"
+        assert np.allclose(loaded.data, vseries.data)
+        # the linked TimeSeries is also loaded from the database:
+        assert loaded.tseries.tstamp == tseries.tstamp
+        assert np.allclose(loaded.t, tseries.data)
+
+    def test_data_is_loaded_lazily(self, sqlite_backend):
+        tseries = TimeSeries(
+            name="time / s", unit_name="s", data=np.array([0.0, 1.0]), tstamp=1.6e9
+        )
+        i = tseries.save()
+        loaded = DataSeries.get(i)
+        assert loaded._data is None  # the array was not fetched by get()...
+        assert np.allclose(loaded.data, tseries.data)  # ...but is available on demand
+        assert loaded._data is not None
+
+    def test_spectrum_round_trip(self, sqlite_backend):
+        xseries = DataSeries(
+            name="wavelength / nm", unit_name="nm", data=np.linspace(200, 800, 5)
+        )
+        field = Field(
+            name="intensity",
+            unit_name="counts",
+            data=np.array([1.0, 2.0, 5.0, 2.0, 1.0]),
+            axes_series=[xseries],
+        )
+        spectrum = Spectrum(
+            name="test spectrum",
+            technique="spectrum",
+            tstamp=1.6e9,
+            field=field,
+            metadata={"scans": 2},
+        )
+        i = spectrum.save()
+        loaded = Spectrum.get(i)
+        assert loaded == spectrum
+        assert loaded.metadata == {"scans": 2}  # JSON column round trip
+        assert np.allclose(loaded.x, spectrum.x)
+        assert np.allclose(loaded.y, spectrum.y)
+
+    def test_calculator_round_trip(self, sqlite_backend):
+        calibration = ECCalibration(name="my calibration", RE_vs_RHE=0.72, A_el=0.196)
+        i = calibration.save()
+        loaded = Calculator.get(i)
+        # from_dict dispatches on the calculator_type column:
+        assert isinstance(loaded, ECCalibration)
+        assert loaded.RE_vs_RHE == 0.72
+        assert loaded.A_el == 0.196
+        assert loaded.R_Ohm is None
+
+    def test_load_returns_newest_with_name(self, sqlite_backend):
+        DataSeries(name="twin", unit_name="V", data=np.array([1.0])).save()
+        i_newest = DataSeries(name="twin", unit_name="A", data=np.array([2.0])).save()
+        loaded = DataSeries.load("twin")
+        assert loaded.id == i_newest
+        assert loaded.unit_name == "A"
+        with pytest.raises(DataBaseError):
+            DataSeries.load("no series has this name")
+
+    def test_update_with_force(self, sqlite_backend):
+        series = DataSeries(name="before", unit_name="V", data=np.array([1.0]))
+        i = series.save()
+        series.name = "after"
+        assert sqlite_backend.save(series, force=True) == i
+        assert DataSeries.get(i).name == "after"
+
+    def test_get_missing_row_raises(self, sqlite_backend):
+        with pytest.raises(DataBaseError):
+            Measurement.get(999)
+
+    def test_codecs(self, sqlite_backend):
+        json_column = ColumnSchema("metadata", dtype="JSON")
+        value = {"a": 1, "b": [1.5, "two"]}
+        encoded = sqlite_backend._encode(json_column, value)
+        assert sqlite_backend._decode(json_column, encoded) == value
+
+        array_column = ColumnSchema("data", dtype="NDARRAY")
+        data = np.linspace(0, 1, 5)
+        encoded = sqlite_backend._encode(array_column, data)
+        assert np.array_equal(sqlite_backend._decode(array_column, encoded), data)
+
+        # numpy scalars are stored as their python equivalents:
+        assert sqlite_backend._encode(ColumnSchema("x"), np.float64(1.5)) == 1.5
+
+    def test_dynamic_column_rejects_containers(self, sqlite_backend):
+        """Containers require a logical type registered in relational.COLUMN_TYPES"""
+        with pytest.raises(DataBaseError):
+            sqlite_backend._encode(ColumnSchema("unregistered"), {"nested": "dict"})

--- a/tests/unit/test_sqlite_backend.py
+++ b/tests/unit/test_sqlite_backend.py
@@ -112,8 +112,7 @@ class TestRelationalSchema:
         the extension table `ECMeasurement` itself declares - is absent here.
         """
         extension_table_names = {
-            schema.name
-            for schema in relational.extension_table_schemas(ECMSMeasurement)
+            schema.name for schema in relational.extension_table_schemas(ECMSMeasurement)
         }
         assert extension_table_names == {"ecms_measurements"}
         assert "ec_measurements" not in extension_table_names
@@ -193,9 +192,7 @@ class TestRelationalSchema:
 
     def test_family_table_schemas(self):
         """All classes sharing a main table contribute to the family schema"""
-        extension_schemas, linker_schemas = relational.family_table_schemas(
-            DataSeries
-        )
+        extension_schemas, linker_schemas = relational.family_table_schemas(DataSeries)
         # TimeSeries extends the data_series table with the tstamps table:
         assert "tstamps" in {schema.name for schema in extension_schemas}
         # Field links data_series rows to their axes' data_series rows:
@@ -315,13 +312,11 @@ class TestSQLiteBackend:
         )
         assert loaded.ms_cal_result_ids  # ...and not by asking for their id's...
         assert all(
-            isinstance(result, PlaceHolderObject)
-            for result in loaded._ms_cal_results
+            isinstance(result, PlaceHolderObject) for result in loaded._ms_cal_results
         )
         assert loaded.ms_cal_results[0].F == 1.5  # ...but available on demand
         assert not any(
-            isinstance(result, PlaceHolderObject)
-            for result in loaded._ms_cal_results
+            isinstance(result, PlaceHolderObject) for result in loaded._ms_cal_results
         )
 
     def test_ec_optical_measurement_round_trip(self, sqlite_backend):
@@ -437,19 +432,23 @@ class TestSQLiteBackend:
         with pytest.raises(TypeError):
             measurement.save()
 
-        assert sqlite_backend.connection.execute(
-            'SELECT COUNT(*) FROM "data_series"'
-        ).fetchone()[0] == 0
-        assert sqlite_backend.connection.execute(
-            'SELECT COUNT(*) FROM "measurement"'
-        ).fetchone()[0] == 0
+        assert (
+            sqlite_backend.connection.execute(
+                'SELECT COUNT(*) FROM "data_series"'
+            ).fetchone()[0]
+            == 0
+        )
+        assert (
+            sqlite_backend.connection.execute(
+                'SELECT COUNT(*) FROM "measurement"'
+            ).fetchone()[0]
+            == 0
+        )
         assert series._backend is original_backend
         assert series._id is original_id
 
     def test_reopen_and_lazy_load_from_inactive_backend(self, sqlite_backend):
-        series = DataSeries(
-            name="persistent", unit_name="V", data=np.array([1.0, 2.0])
-        )
+        series = DataSeries(name="persistent", unit_name="V", data=np.array([1.0, 2.0]))
         measurement = Measurement(
             name="persistent graph", technique="simple", series_list=[series]
         )
@@ -476,9 +475,10 @@ class TestSQLiteBackend:
             )
             assert first_id != second_id
             assert DataSeries.get(second_id, backend=sqlite_backend).name == "second"
-            assert sqlite_backend.connection.execute(
-                "PRAGMA foreign_key_check"
-            ).fetchall() == []
+            assert (
+                sqlite_backend.connection.execute("PRAGMA foreign_key_check").fetchall()
+                == []
+            )
 
     def test_backends_can_be_used_in_sets_and_dicts(self, sqlite_backend, tmp_path):
         """Defining __eq__ without __hash__ would make the backend unhashable"""
@@ -504,8 +504,7 @@ class TestSQLiteBackend:
         db_path = tmp_path / "legacy.sqlite"
         connection = sqlite3.connect(db_path)
         connection.execute(
-            'CREATE TABLE "data_series" '
-            '("id" INTEGER PRIMARY KEY, "name" TEXT)'
+            'CREATE TABLE "data_series" ' '("id" INTEGER PRIMARY KEY, "name" TEXT)'
         )
         connection.close()
 
@@ -515,9 +514,8 @@ class TestSQLiteBackend:
             )
             backend.save(series)
             columns = {
-                row[1] for row in backend.connection.execute(
-                    'PRAGMA table_info("data_series")'
-                )
+                row[1]
+                for row in backend.connection.execute('PRAGMA table_info("data_series")')
             }
             assert {"id", "name", "unit_name", "series_type", "data"} <= columns
             assert backend.connection.execute(
@@ -535,9 +533,7 @@ class TestSQLiteBackend:
 
         with SQLiteBackend(db_path=db_path) as backend:
             with pytest.raises(DataBaseError, match="manual database migration"):
-                backend.save(
-                    DataSeries(name="x", unit_name="V", data=np.array([1.0]))
-                )
+                backend.save(DataSeries(name="x", unit_name="V", data=np.array([1.0])))
 
     def test_newer_schema_version_is_rejected(self, tmp_path):
         db_path = tmp_path / "future.sqlite"
@@ -610,9 +606,7 @@ def test_directory_load_uses_exact_unescaped_name(tmp_path):
     backend = DirBackend(directory=tmp_path, project_name="name_collision")
     DB.set_backend(backend)
     try:
-        slash_id = DataSeries(
-            name="a/b", unit_name="V", data=np.array([1.0])
-        ).save()
+        slash_id = DataSeries(name="a/b", unit_name="V", data=np.array([1.0])).save()
         DataSeries(name="a_DIV_b", unit_name="A", data=np.array([2.0])).save()
         assert DataSeries.load("a/b").id == slash_id
 

--- a/tests/unit/test_sqlite_backend.py
+++ b/tests/unit/test_sqlite_backend.py
@@ -8,6 +8,7 @@ import pytest
 from ixdat import Measurement, Spectrum
 from ixdat.backends import relational
 from ixdat.backends.directory_backend import DirBackend
+from ixdat.backends.memory_backend import MemoryBackend
 from ixdat.backends.relational import ColumnSchema
 from ixdat.backends.sqlite_backend import METADATA_TABLE, SCHEMA_VERSION, SQLiteBackend
 from ixdat.data_series import DataSeries, Field, TimeSeries, ValueSeries
@@ -479,6 +480,16 @@ class TestSQLiteBackend:
                 "PRAGMA foreign_key_check"
             ).fetchall() == []
 
+    def test_backends_can_be_used_in_sets_and_dicts(self, sqlite_backend, tmp_path):
+        """Defining __eq__ without __hash__ would make the backend unhashable"""
+        with SQLiteBackend(db_path=sqlite_backend.db_path) as same_file:
+            with SQLiteBackend(db_path=tmp_path / "other.sqlite") as other_file:
+                # two connections to one file are one database, and hash alike:
+                assert {sqlite_backend, same_file} == {sqlite_backend}
+                assert len({sqlite_backend, other_file}) == 2
+                # a backend can be a dict key, e.g. to group objects by database:
+                assert {sqlite_backend: "here"}[same_file] == "here"
+
     def test_in_memory_database_uses_sqlite_convention(self):
         with SQLiteBackend(db_path=":memory:") as first_backend:
             i = first_backend.save(
@@ -564,6 +575,34 @@ class TestSQLiteBackend:
         }
         assert "ixdat_measurement_name_id" in indexes
         assert "ixdat_measurement_technique" in indexes
+
+
+def test_memory_backend_load_by_name():
+    """`load` is implemented for the memory backend too, not just the real ones"""
+    backend = MemoryBackend()
+    backend.save(DataSeries(name="twin", unit_name="V", data=np.array([1.0])))
+    newest = DataSeries(name="twin", unit_name="A", data=np.array([2.0]))
+    backend.save(newest)
+
+    assert backend.load(DataSeries, "twin") is newest
+    with pytest.raises(DataBaseError):
+        backend.load(DataSeries, "no series has this name")
+
+
+def test_load_data_takes_a_backend_and_deprecates_db(tmp_path):
+    """`load_data(db=...)` used to take a DataBase; it now takes a backend"""
+    original_backend = DB.backend
+    with SQLiteBackend(db_path=tmp_path / "data.sqlite") as backend:
+        DB.set_backend(backend)
+        try:
+            series = DataSeries(name="s", unit_name="V", data=np.array([1.0, 2.0]))
+            loaded = DataSeries.get(series.save())
+            assert np.array_equal(loaded.load_data(), [1.0, 2.0])
+            assert np.array_equal(loaded.load_data(backend), [1.0, 2.0])
+            with pytest.deprecated_call():
+                assert np.array_equal(loaded.load_data(db=backend), [1.0, 2.0])
+        finally:
+            DB.set_backend(original_backend)
 
 
 def test_directory_load_uses_exact_unescaped_name(tmp_path):

--- a/tests/unit/test_sqlite_backend.py
+++ b/tests/unit/test_sqlite_backend.py
@@ -1,11 +1,15 @@
 """Unit tests for the relational schema derivation and the SQLite backend"""
 
+import sqlite3
+
 import numpy as np
 import pytest
 
 from ixdat import Measurement, Spectrum
 from ixdat.backends import relational
+from ixdat.backends.directory_backend import DirBackend
 from ixdat.backends.relational import ColumnSchema
+from ixdat.backends.sqlite_backend import METADATA_TABLE, SCHEMA_VERSION, SQLiteBackend
 from ixdat.data_series import DataSeries, Field, TimeSeries, ValueSeries
 from ixdat.db import DB, change_database
 from ixdat.exceptions import DataBaseError
@@ -169,9 +173,12 @@ class TestSQLiteBackend:
 
     def test_codecs(self, sqlite_backend):
         json_column = ColumnSchema("metadata", dtype="JSON")
-        value = {"a": 1, "b": [1.5, "two"]}
+        value = {"a": np.int64(1), "b": np.array([1.5, 2.5])}
         encoded = sqlite_backend._encode(json_column, value)
-        assert sqlite_backend._decode(json_column, encoded) == value
+        assert sqlite_backend._decode(json_column, encoded) == {
+            "a": 1,
+            "b": [1.5, 2.5],
+        }
 
         array_column = ColumnSchema("data", dtype="NDARRAY")
         data = np.linspace(0, 1, 5)
@@ -213,3 +220,173 @@ class TestSQLiteBackend:
         assert 'CREATE TABLE IF NOT EXISTS "measurement"' in report
         assert 'CREATE TABLE IF NOT EXISTS "measurement_series"' in report
         assert 'REFERENCES "data_series"("id")' in report
+
+    def test_complete_graph_save_is_atomic(self, sqlite_backend):
+        series = TimeSeries(
+            name="time / s", unit_name="s", data=np.array([0.0]), tstamp=0.0
+        )
+        measurement = Measurement(
+            name="invalid metadata",
+            technique="simple",
+            metadata={"not_json": object()},
+            series_list=[series],
+        )
+        original_backend = series._backend
+        original_id = series._id
+
+        with pytest.raises(TypeError):
+            measurement.save()
+
+        assert sqlite_backend.connection.execute(
+            'SELECT COUNT(*) FROM "data_series"'
+        ).fetchone()[0] == 0
+        assert sqlite_backend.connection.execute(
+            'SELECT COUNT(*) FROM "measurement"'
+        ).fetchone()[0] == 0
+        assert series._backend is original_backend
+        assert series._id is original_id
+
+    def test_reopen_and_lazy_load_from_inactive_backend(self, sqlite_backend):
+        series = DataSeries(
+            name="persistent", unit_name="V", data=np.array([1.0, 2.0])
+        )
+        measurement = Measurement(
+            name="persistent graph", technique="simple", series_list=[series]
+        )
+        i = measurement.save()
+        db_path = sqlite_backend.db_path
+        original_active_backend = DB.backend
+        sqlite_backend.close()
+
+        with SQLiteBackend(db_path=db_path) as reopened:
+            loaded = Measurement.get(i, backend=reopened)
+            assert DB.backend is original_active_backend
+            loaded_series = loaded.series_list[0]
+            assert DB.backend is original_active_backend
+            assert loaded_series._data is None
+            assert np.array_equal(loaded_series.data, series.data)
+
+    def test_two_connections_share_a_database(self, sqlite_backend):
+        with SQLiteBackend(db_path=sqlite_backend.db_path) as second_backend:
+            first_id = sqlite_backend.save(
+                DataSeries(name="first", unit_name="V", data=np.array([1.0]))
+            )
+            second_id = second_backend.save(
+                DataSeries(name="second", unit_name="A", data=np.array([2.0]))
+            )
+            assert first_id != second_id
+            assert DataSeries.get(second_id, backend=sqlite_backend).name == "second"
+            assert sqlite_backend.connection.execute(
+                "PRAGMA foreign_key_check"
+            ).fetchall() == []
+
+    def test_in_memory_database_uses_sqlite_convention(self):
+        with SQLiteBackend(db_path=":memory:") as first_backend:
+            i = first_backend.save(
+                DataSeries(name="temporary", unit_name="V", data=np.array([1.0]))
+            )
+            assert DataSeries.get(i, backend=first_backend).name == "temporary"
+            with SQLiteBackend(db_path=":memory:") as second_backend:
+                assert first_backend != second_backend
+                assert not second_backend.contains("data_series", i)
+
+    def test_additive_schema_migration(self, tmp_path):
+        db_path = tmp_path / "legacy.sqlite"
+        connection = sqlite3.connect(db_path)
+        connection.execute(
+            'CREATE TABLE "data_series" '
+            '("id" INTEGER PRIMARY KEY, "name" TEXT)'
+        )
+        connection.close()
+
+        with SQLiteBackend(db_path=db_path) as backend:
+            series = DataSeries(
+                name="after migration", unit_name="A", data=np.array([1.0])
+            )
+            backend.save(series)
+            columns = {
+                row[1] for row in backend.connection.execute(
+                    'PRAGMA table_info("data_series")'
+                )
+            }
+            assert {"id", "name", "unit_name", "series_type", "data"} <= columns
+            assert backend.connection.execute(
+                f'SELECT "value" FROM "{METADATA_TABLE}" WHERE "key" = ?',
+                ("schema_version",),
+            ).fetchone()[0] == str(SCHEMA_VERSION)
+
+    def test_incompatible_schema_requires_manual_migration(self, tmp_path):
+        db_path = tmp_path / "incompatible.sqlite"
+        connection = sqlite3.connect(db_path)
+        connection.execute(
+            'CREATE TABLE "data_series" ("id" TEXT PRIMARY KEY, "name" TEXT)'
+        )
+        connection.close()
+
+        with SQLiteBackend(db_path=db_path) as backend:
+            with pytest.raises(DataBaseError, match="manual database migration"):
+                backend.save(
+                    DataSeries(name="x", unit_name="V", data=np.array([1.0]))
+                )
+
+    def test_newer_schema_version_is_rejected(self, tmp_path):
+        db_path = tmp_path / "future.sqlite"
+        connection = sqlite3.connect(db_path)
+        connection.execute(
+            f'CREATE TABLE "{METADATA_TABLE}" '
+            '("key" TEXT PRIMARY KEY, "value" TEXT NOT NULL)'
+        )
+        connection.execute(
+            f'INSERT INTO "{METADATA_TABLE}" VALUES (?, ?)',
+            ("schema_version", str(SCHEMA_VERSION + 1)),
+        )
+        connection.commit()
+        connection.close()
+
+        with pytest.raises(DataBaseError, match="newer ixdat schema"):
+            SQLiteBackend(db_path=db_path)
+
+    def test_failed_explicit_backend_load_restores_active_backend(
+        self, sqlite_backend, tmp_path
+    ):
+        original_backend = DB.backend
+        with SQLiteBackend(db_path=tmp_path / "other.sqlite") as other_backend:
+            with pytest.raises(DataBaseError):
+                DataSeries.load("missing", backend=other_backend)
+            assert DB.backend is original_backend
+
+    def test_lookup_indexes_are_created(self, sqlite_backend):
+        sqlite_backend._ensure_tables(Measurement)
+        indexes = {
+            row[1]
+            for row in sqlite_backend.connection.execute(
+                'PRAGMA index_list("measurement")'
+            )
+        }
+        assert "ixdat_measurement_name_id" in indexes
+        assert "ixdat_measurement_technique" in indexes
+
+
+def test_directory_load_uses_exact_unescaped_name(tmp_path):
+    original_backend = DB.backend
+    backend = DirBackend(directory=tmp_path, project_name="name_collision")
+    DB.set_backend(backend)
+    try:
+        slash_id = DataSeries(
+            name="a/b", unit_name="V", data=np.array([1.0])
+        ).save()
+        DataSeries(name="a_DIV_b", unit_name="A", data=np.array([2.0])).save()
+        assert DataSeries.load("a/b").id == slash_id
+
+        measurement = Measurement(
+            name="numpy metadata",
+            technique="simple",
+            metadata={"counts": np.array([1, 2]), "scans": np.int64(2)},
+        )
+        measurement.save()
+        assert Measurement.load(measurement.name).metadata == {
+            "counts": [1, 2],
+            "scans": 2,
+        }
+    finally:
+        DB.set_backend(original_backend)

--- a/tests/unit/test_sqlite_backend.py
+++ b/tests/unit/test_sqlite_backend.py
@@ -453,6 +453,24 @@ class TestSQLiteBackend:
         # numpy scalars are stored as their python equivalents:
         assert sqlite_backend._encode(ColumnSchema("x"), np.float64(1.5)) == 1.5
 
+    def test_string_object_array_round_trip(self, sqlite_backend):
+        """String arrays from pandas are saved safely without pickle."""
+        data = np.array(["1 µA", "10 µA", "100 µA"], dtype=object)
+        series = DataSeries(name="Current range", unit_name="A", data=data)
+
+        loaded = DataSeries.get(series.save())
+
+        assert loaded.data.dtype.kind == "U"
+        assert loaded.data.tolist() == data.tolist()
+
+    def test_non_string_object_array_is_rejected(self, sqlite_backend):
+        """SQLite does not enable pickle for arbitrary Python objects."""
+        array_column = ColumnSchema("data", dtype=np.ndarray)
+        data = np.array(["text", {"some": "object"}], dtype=object)
+
+        with pytest.raises(ValueError, match="Object arrays cannot be saved"):
+            sqlite_backend._encode(array_column, data)
+
     def test_dynamic_column_rejects_containers(self, sqlite_backend):
         """Containers require a logical type declared in the class's column_types"""
         with pytest.raises(DataBaseError):

--- a/tests/unit/test_sqlite_backend.py
+++ b/tests/unit/test_sqlite_backend.py
@@ -11,10 +11,11 @@ from ixdat.backends.directory_backend import DirBackend
 from ixdat.backends.relational import ColumnSchema
 from ixdat.backends.sqlite_backend import METADATA_TABLE, SCHEMA_VERSION, SQLiteBackend
 from ixdat.data_series import DataSeries, Field, TimeSeries, ValueSeries
-from ixdat.db import DB, change_database
+from ixdat.db import DB, PlaceHolderObject, change_database
 from ixdat.exceptions import DataBaseError
 from ixdat.measurement_base import Calculator
 from ixdat.calculators.ec_calculators import ECCalibration
+from ixdat.calculators.ms_calculators import MSCalibration, MSCalResult
 from ixdat.spectra import MultiSpectrum, SpectrumSeries
 from ixdat.techniques.ec_ms import ECMSMeasurement
 from ixdat.techniques.spectroelectrochemistry import ECOpticalMeasurement
@@ -297,6 +298,30 @@ class TestSQLiteBackend:
             'SELECT 1 FROM "ecms_measurements" WHERE "id" = ?', (i,)
         ).fetchone()
         assert row is not None  # the data lives here instead
+
+    def test_ms_calibration_results_are_loaded_lazily(self, sqlite_backend):
+        """A loaded MS calibration knows its results' id's before loading them"""
+        calibration = MSCalibration(
+            name="lazy calibration",
+            ms_cal_results=[MSCalResult(name="O2 at M32", mol="O2", mass="M32", F=1.5)],
+        )
+        i = calibration.save()
+
+        loaded = Calculator.get(i)
+        assert all(
+            isinstance(result, PlaceHolderObject)
+            for result in loaded._ms_cal_results  # not fetched by get()...
+        )
+        assert loaded.ms_cal_result_ids  # ...and not by asking for their id's...
+        assert all(
+            isinstance(result, PlaceHolderObject)
+            for result in loaded._ms_cal_results
+        )
+        assert loaded.ms_cal_results[0].F == 1.5  # ...but available on demand
+        assert not any(
+            isinstance(result, PlaceHolderObject)
+            for result in loaded._ms_cal_results
+        )
 
     def test_ec_optical_measurement_round_trip(self, sqlite_backend):
         """The reference spectrum is a single-reference linker, not a list"""

--- a/tests/unit/test_sqlite_backend.py
+++ b/tests/unit/test_sqlite_backend.py
@@ -32,6 +32,19 @@ def sqlite_backend(tmp_path):
     DB.set_backend(original_backend)
 
 
+class MistypedMeasurement(Measurement):
+    """A class whose column type is a typo, used by two tests below
+
+    Defined at module level, since a Saveable subclass stays in
+    `Saveable.__subclasses__()` for the rest of the session once it exists. That
+    is the point: the tests check that its presence leaves every other
+    measurement loadable.
+    """
+
+    extra_column_attrs = {"mistyped_measurements": {"whoops"}}
+    column_types = {"whoops": "NDARAY"}  # typo for "NDARRAY"
+
+
 def _ec_optical_measurement(reference_spectrum="build one"):
     """Return a synthetic ECOpticalMeasurement, evt. without a reference spectrum"""
     tseries = TimeSeries(
@@ -172,23 +185,24 @@ class TestRelationalSchema:
         assert column.dtype == "JSON"
 
     def test_unknown_column_type_is_rejected(self):
-        # a stand-in rather than a real Saveable subclass, since a class with a
-        # broken column type would stay in Saveable.__subclasses__() for the rest
-        # of the session and break the schema of every test after this one:
-        class MistypedClass:
-            table_name = "mistyped"
-            column_attrs = {"whoops"}
-
-            @classmethod
-            def get_column_types(cls):
-                return {"whoops": "NDARAY"}  # typo for "NDARRAY"
-
-            @classmethod
-            def get_column_references(cls):
-                return {}
-
         with pytest.raises(DataBaseError, match="unknown type"):
-            relational.main_table_schema(MistypedClass)
+            relational.extension_table_schemas(MistypedMeasurement)
+
+    def test_a_broken_class_does_not_break_its_relatives(self):
+        """Only the misdeclared class itself raises, so other rows still load
+
+        `MistypedMeasurement` shares the "measurement" main table with every
+        other measurement, and it stays in `Saveable.__subclasses__()` for the
+        rest of the session. Describing the family's tables skips it.
+        """
+        extension_schemas, _ = relational.family_table_schemas(Measurement)
+        table_names = {schema.name for schema in extension_schemas}
+        assert "mistyped_measurements" not in table_names
+        assert "ec_measurements" in table_names  # the healthy ones are all there
+
+        # ...and asking about the broken class by name still raises:
+        with pytest.raises(DataBaseError, match="unknown type"):
+            relational.family_table_schemas(MistypedMeasurement)
 
     def test_family_table_schemas(self):
         """All classes sharing a main table contribute to the family schema"""
@@ -345,6 +359,31 @@ class TestSQLiteBackend:
 
         loaded = Measurement.get(measurement.save())
         assert loaded.reference_spectrum is None
+
+    def test_a_broken_sibling_class_does_not_block_saving_or_loading(
+        self, sqlite_backend
+    ):
+        """`MistypedMeasurement` shares the "measurement" table with these rows"""
+        measurement = Measurement(
+            name="healthy",
+            technique="simple",
+            series_list=[
+                TimeSeries(
+                    name="t", unit_name="s", data=np.array([0.0, 1.0]), tstamp=1.6e9
+                )
+            ],
+        )
+        i = measurement.save()
+        assert Measurement.get(i).name == "healthy"
+        assert Measurement.load("healthy").name == "healthy"
+        # the report covers the healthy classes:
+        report = sqlite_backend.schema_report()
+        assert 'CREATE TABLE IF NOT EXISTS "measurement"' in report
+        assert "mistyped_measurements" not in report
+
+        # saving the broken class itself raises, naming it:
+        with pytest.raises(DataBaseError, match="MistypedMeasurement"):
+            MistypedMeasurement(name="broken", technique="simple").save()
 
     def test_load_returns_newest_with_name(self, sqlite_backend):
         DataSeries(name="twin", unit_name="V", data=np.array([1.0])).save()

--- a/tests/unit/test_sqlite_backend.py
+++ b/tests/unit/test_sqlite_backend.py
@@ -59,6 +59,21 @@ class TestRelationalSchema:
             "tspan_bg",
         }
 
+    def test_multiply_inheriting_class_only_gets_its_own_extension_table(self):
+        """Known limitation: `extra_column_attrs` is shadowed, not merged, across
+        multiple inheritance (see the "Known limitation" section of
+        docs/source/diving_deeper/backend.rst). `ECMSMeasurement` inherits from both
+        `ECMeasurement` and `MSMeasurement`, but its own `extra_column_attrs`
+        replaces `ECMeasurement`'s rather than adding to it, so `ec_measurements` -
+        the extension table `ECMeasurement` itself declares - is absent here.
+        """
+        extension_table_names = {
+            schema.name
+            for schema in relational.extension_table_schemas(ECMSMeasurement)
+        }
+        assert extension_table_names == {"ecms_measurements"}
+        assert "ec_measurements" not in extension_table_names
+
     def test_linker_tables(self):
         linkers = {
             schema.name: schema
@@ -150,6 +165,38 @@ class TestSQLiteBackend:
         assert loaded.RE_vs_RHE == 0.72
         assert loaded.A_el == 0.196
         assert loaded.R_Ohm is None
+
+    def test_multiply_inheriting_measurement_round_trips_but_skips_parent_table(
+        self, sqlite_backend
+    ):
+        """Known limitation, documented in docs/source/diving_deeper/backend.rst:
+        `ECMSMeasurement` (inherits from `ECMeasurement` and `MSMeasurement`) writes
+        only to its own extension table. Round-tripping the object is unaffected -
+        `ec_technique` survives via `ecms_measurements` - but a query joining only
+        `ec_measurements` would miss this row, since no row is written there.
+        """
+        tseries = TimeSeries(
+            name="t", unit_name="s", data=np.array([0.0, 1.0]), tstamp=1.6e9
+        )
+        ecms = ECMSMeasurement(
+            name="synthetic ecms",
+            technique="EC-MS",
+            tstamp=1.6e9,
+            series_list=[tseries],
+            ec_technique="Cyclic Voltammetry Advanced",
+        )
+        i = ecms.save()
+
+        loaded = Measurement.get(i)
+        assert isinstance(loaded, ECMSMeasurement)
+        assert loaded.ec_technique == "Cyclic Voltammetry Advanced"  # round trip OK
+
+        existing_tables = sqlite_backend._existing_tables()
+        assert "ec_measurements" not in existing_tables  # never created: no writer
+        row = sqlite_backend.connection.execute(
+            'SELECT 1 FROM "ecms_measurements" WHERE "id" = ?', (i,)
+        ).fetchone()
+        assert row is not None  # the data lives here instead
 
     def test_load_returns_newest_with_name(self, sqlite_backend):
         DataSeries(name="twin", unit_name="V", data=np.array([1.0])).save()

--- a/tests/unit/test_sqlite_backend.py
+++ b/tests/unit/test_sqlite_backend.py
@@ -17,7 +17,7 @@ from ixdat.exceptions import DataBaseError
 from ixdat.measurement_base import Calculator
 from ixdat.calculators.ec_calculators import ECCalibration
 from ixdat.calculators.ms_calculators import MSCalibration, MSCalResult
-from ixdat.spectra import MultiSpectrum, SpectrumSeries
+from ixdat.spectra import MultiSpectrum
 from ixdat.techniques.ec_ms import ECMSMeasurement
 from ixdat.techniques.spectroelectrochemistry import ECOpticalMeasurement
 
@@ -45,47 +45,6 @@ class MistypedMeasurement(Measurement):
     column_types = {"whoops": "NDARAY"}  # invalid: column types are Python types
 
 
-def _ec_optical_measurement(reference_spectrum="build one"):
-    """Return a synthetic ECOpticalMeasurement, evt. without a reference spectrum"""
-    tseries = TimeSeries(
-        name="t", unit_name="s", data=np.array([0.0, 1.0]), tstamp=1.6e9
-    )
-    wavelength = DataSeries(
-        name="wavelength / nm", unit_name="nm", data=np.linspace(400, 700, 4)
-    )
-    spectrum_series = SpectrumSeries(
-        name="optical spectra",
-        technique="EC-Optical",
-        tstamp=1.6e9,
-        field=Field(
-            name="spectra",
-            unit_name="counts",
-            data=np.array([[1.0, 2.0, 3.0, 4.0], [2.0, 3.0, 4.0, 5.0]]),
-            axes_series=[tseries, wavelength],
-        ),
-    )
-    if reference_spectrum == "build one":
-        reference_spectrum = Spectrum(
-            name="ref spectrum",
-            technique="optical",
-            tstamp=1.6e9,
-            field=Field(
-                name="reference",
-                unit_name="counts",
-                data=np.array([1.0, 1.0, 1.0, 1.0]),
-                axes_series=[wavelength],
-            ),
-        )
-    return ECOpticalMeasurement(
-        name="synthetic EC-Optical",
-        technique="EC-Optical",
-        tstamp=1.6e9,
-        series_list=[tseries],
-        spectrum_series=spectrum_series,
-        reference_spectrum=reference_spectrum,
-    )
-
-
 class TestRelationalSchema:
     """Tests for the derivation of table descriptions from Saveable classes"""
 
@@ -104,32 +63,22 @@ class TestRelationalSchema:
         # deterministic order, with id and name first:
         assert schema.column_names[:2] == ["id", "name"]
 
-    def test_extension_table(self):
-        schemas = {
-            schema.name: schema
-            for schema in relational.extension_table_schemas(ECMSMeasurement)
-        }
-        schema = schemas["ecms_measurements"]
-        assert schema.name == "ecms_measurements"
-        assert schema.extends == "measurement"
-        # the extension table's id is a foreign key to the main table:
-        assert schema.columns[0].name == "id"
-        assert schema.columns[0].foreign_key == ("measurement", "id")
-        assert {column.name for column in schema.data_columns} == {"tspan_bg"}
-
     def test_extension_tables_merge_over_multiple_inheritance(self):
-        """Each ancestor contributes its extension table without repeated columns."""
+        """Each ancestor contributes one extension table."""
         schemas = {
             schema.name: schema
             for schema in relational.extension_table_schemas(ECMSMeasurement)
         }
         assert set(schemas) == {"ec_measurements", "ecms_measurements"}
+        ecms_schema = schemas["ecms_measurements"]
+        assert ecms_schema.extends == "measurement"
+        # the extension table's id is a foreign key to the main table:
+        assert ecms_schema.columns[0].name == "id"
+        assert ecms_schema.columns[0].foreign_key == ("measurement", "id")
         assert {column.name for column in schemas["ec_measurements"].data_columns} == {
             "ec_technique"
         }
-        assert {column.name for column in schemas["ecms_measurements"].data_columns} == {
-            "tspan_bg"
-        }
+        assert {column.name for column in ecms_schema.data_columns} == {"tspan_bg"}
 
     def test_collecting_all_attrs_does_not_modify_main_table_metadata(self):
         """Linker attributes stay out of the main table schema."""
@@ -157,9 +106,15 @@ class TestRelationalSchema:
         component_linker = linkers["component_measurements"]
         assert component_linker.owner_column == "measurement_id"
         assert component_linker.linked_column == "linked_measurement_id"
+        reference_linker = {
+            schema.name: schema
+            for schema in relational.linker_table_schemas(ECOpticalMeasurement)
+        }["ec_optical_measurements"]
+        assert reference_linker.id_attr == "ref_id"
+        assert not reference_linker.is_list
 
-    def test_column_types_come_from_the_declaring_class(self):
-        """Each column's type is the one declared by the class which adds it"""
+    def test_column_types_merge_from_the_declaring_classes(self):
+        """Column types come from every declaring class in the ancestry."""
         columns = {
             column.name: column
             for column in relational.main_table_schema(DataSeries).columns
@@ -167,8 +122,6 @@ class TestRelationalSchema:
         assert columns["data"].dtype is np.ndarray  # declared by DataSeries
         assert columns["name"].dtype is str  # inherited from Saveable
 
-    def test_column_types_are_merged_over_multiple_inheritance(self):
-        """Column types from the full ancestry carry over."""
         types = ECMSMeasurement.get_column_types()
         assert types["ec_technique"] is str  # from ECMeasurement
         assert types["tspan_bg"] is list  # from ECMSMeasurement itself
@@ -208,22 +161,6 @@ class TestRelationalSchema:
         with pytest.raises(DataBaseError, match="unknown column.*missing_id"):
             relational.main_table_schema(UnknownColumnMeasurement)
 
-    def test_a_broken_class_does_not_break_its_relatives(self):
-        """Only the misdeclared class itself raises, so other rows still load
-
-        `MistypedMeasurement` shares the "measurement" main table with every
-        other measurement, and it stays in `Saveable.__subclasses__()` for the
-        rest of the session. Describing the family's tables skips it.
-        """
-        extension_schemas, _ = relational.family_table_schemas(Measurement)
-        table_names = {schema.name for schema in extension_schemas}
-        assert "mistyped_measurements" not in table_names
-        assert "ec_measurements" in table_names  # the healthy ones are all there
-
-        # ...and asking about the broken class by name still raises:
-        with pytest.raises(DataBaseError, match="unknown type"):
-            relational.family_table_schemas(MistypedMeasurement)
-
     def test_family_table_schemas(self):
         """All classes sharing a main table contribute to the family schema"""
         extension_schemas, linker_schemas = relational.family_table_schemas(DataSeries)
@@ -250,20 +187,12 @@ class TestSQLiteBackend:
         loaded = DataSeries.get(i)
         assert isinstance(loaded, ValueSeries)
         assert loaded.unit_name == "V"
+        assert loaded._data is None
         assert np.allclose(loaded.data, vseries.data)
+        assert loaded._data is not None
         # the linked TimeSeries is also loaded from the database:
         assert loaded.tseries.tstamp == tseries.tstamp
         assert np.allclose(loaded.t, tseries.data)
-
-    def test_data_is_loaded_lazily(self, sqlite_backend):
-        tseries = TimeSeries(
-            name="time / s", unit_name="s", data=np.array([0.0, 1.0]), tstamp=1.6e9
-        )
-        i = tseries.save()
-        loaded = DataSeries.get(i)
-        assert loaded._data is None  # the array was not fetched by get()...
-        assert np.allclose(loaded.data, tseries.data)  # ...but is available on demand
-        assert loaded._data is not None
 
     def test_spectrum_round_trip(self, sqlite_backend):
         xseries = DataSeries(
@@ -355,33 +284,6 @@ class TestSQLiteBackend:
             isinstance(result, PlaceHolderObject) for result in loaded._ms_cal_results
         )
 
-    def test_ec_optical_measurement_round_trip(self, sqlite_backend):
-        """The reference spectrum is a single-reference linker, not a list"""
-        measurement = _ec_optical_measurement()
-        i = measurement.save()
-
-        loaded = Measurement.get(i)
-        assert isinstance(loaded, ECOpticalMeasurement)
-        # both spectrum references survive: the spectrum series and the reference
-        assert np.allclose(loaded.spectra.data, measurement.spectra.data)
-        assert loaded.reference_spectrum.name == "ref spectrum"
-        assert np.allclose(loaded.reference_spectrum.y, [1.0, 1.0, 1.0, 1.0])
-        # the reference is stored as one row of its linker table, at position 0:
-        assert sqlite_backend.connection.execute(
-            'SELECT "position", "spectrums_id" FROM "ec_optical_measurements" '
-            'WHERE "measurement_id" = ?',
-            (i,),
-        ).fetchall() == [(0, loaded.reference_spectrum.id)]
-
-    def test_ec_optical_measurement_without_a_reference_spectrum(self, sqlite_backend):
-        """A reference spectrum can be set later, so saving without one must work"""
-        measurement = _ec_optical_measurement(reference_spectrum=None)
-        assert measurement.reference_spectrum is None
-        assert measurement.ref_id is None
-
-        loaded = Measurement.get(measurement.save())
-        assert loaded.reference_spectrum is None
-
     def test_a_broken_sibling_class_does_not_block_saving_or_loading(
         self, sqlite_backend
     ):
@@ -403,11 +305,12 @@ class TestSQLiteBackend:
         assert 'CREATE TABLE IF NOT EXISTS "measurement"' in report
         assert "mistyped_measurements" not in report
 
-        # saving the broken class itself raises, naming it:
+        with pytest.raises(DataBaseError, match="unknown type"):
+            relational.family_table_schemas(MistypedMeasurement)
         with pytest.raises(DataBaseError, match="MistypedMeasurement"):
             MistypedMeasurement(name="broken", technique="simple").save()
 
-    def test_load_returns_newest_with_name(self, sqlite_backend):
+    def test_missing_and_named_row_lookup(self, sqlite_backend):
         DataSeries(name="twin", unit_name="V", data=np.array([1.0])).save()
         i_newest = DataSeries(name="twin", unit_name="A", data=np.array([2.0])).save()
         loaded = DataSeries.load("twin")
@@ -415,6 +318,8 @@ class TestSQLiteBackend:
         assert loaded.unit_name == "A"
         with pytest.raises(DataBaseError):
             DataSeries.load("no series has this name")
+        with pytest.raises(DataBaseError):
+            Measurement.get(999)
 
     def test_update_with_force(self, sqlite_backend):
         series = DataSeries(name="before", unit_name="V", data=np.array([1.0]))
@@ -422,10 +327,6 @@ class TestSQLiteBackend:
         series.name = "after"
         assert sqlite_backend.save(series, force=True) == i
         assert DataSeries.get(i).name == "after"
-
-    def test_get_missing_row_raises(self, sqlite_backend):
-        with pytest.raises(DataBaseError):
-            Measurement.get(999)
 
     def test_codecs(self, sqlite_backend):
         json_column = ColumnSchema("metadata", dtype=dict)
@@ -529,46 +430,37 @@ class TestSQLiteBackend:
             assert loaded_series._data is None
             assert np.array_equal(loaded_series.data, series.data)
 
-    def test_two_connections_share_a_database(self, sqlite_backend):
-        with SQLiteBackend(db_path=sqlite_backend.db_path) as second_backend:
-            first_id = sqlite_backend.save(
-                DataSeries(name="first", unit_name="V", data=np.array([1.0]))
-            )
-            second_id = second_backend.save(
-                DataSeries(name="second", unit_name="A", data=np.array([2.0]))
-            )
-            assert first_id != second_id
-            assert DataSeries.get(second_id, backend=sqlite_backend).name == "second"
-            assert (
-                sqlite_backend.connection.execute("PRAGMA foreign_key_check").fetchall()
-                == []
-            )
-
-    def test_equivalent_connection_does_not_duplicate_a_saved_object(
-        self, sqlite_backend
+    def test_connections_to_one_file_share_identity_and_rows(
+        self, sqlite_backend, tmp_path
     ):
-        series = DataSeries(name="shared", unit_name="V", data=np.array([1.0]))
-        series_id = sqlite_backend.save(series)
-
+        """Equivalent connections share ids, rows, equality, and hashing."""
         with SQLiteBackend(db_path=sqlite_backend.db_path) as second_backend:
-            loaded = DataSeries.get(series_id, backend=second_backend)
-            assert loaded.backend == sqlite_backend
-            assert loaded.short_identity == series_id
-            assert sqlite_backend.save(loaded) is None
-            assert sqlite_backend.connection.execute(
-                'SELECT COUNT(*) FROM "data_series" WHERE "id" = ?', (series_id,)
-            ).fetchone() == (1,)
+            with SQLiteBackend(db_path=tmp_path / "other.sqlite") as other_backend:
+                assert {sqlite_backend, second_backend} == {sqlite_backend}
+                assert sqlite_backend.address == second_backend.address
+                assert len({sqlite_backend, other_backend}) == 2
+                assert {sqlite_backend: "here"}[second_backend] == "here"
 
-    def test_backends_can_be_used_in_sets_and_dicts(self, sqlite_backend, tmp_path):
-        """Defining __eq__ without __hash__ would make the backend unhashable"""
-        with SQLiteBackend(db_path=sqlite_backend.db_path) as same_file:
-            with SQLiteBackend(db_path=tmp_path / "other.sqlite") as other_file:
-                # two connections to one file are one database, and hash alike:
-                assert {sqlite_backend, same_file} == {sqlite_backend}
-                assert sqlite_backend.address == same_file.address
-                assert len({sqlite_backend, other_file}) == 2
-                # a backend can be a dict key, e.g. to group objects by database:
-                assert {sqlite_backend: "here"}[same_file] == "here"
+                first_id = sqlite_backend.save(
+                    DataSeries(name="first", unit_name="V", data=np.array([1.0]))
+                )
+                second_id = second_backend.save(
+                    DataSeries(name="second", unit_name="A", data=np.array([2.0]))
+                )
+                assert first_id != second_id
+                loaded = DataSeries.get(second_id, backend=sqlite_backend)
+                assert loaded.name == "second"
+                assert loaded.short_identity == second_id
+                assert second_backend.save(loaded) is None
+                assert sqlite_backend.connection.execute(
+                    'SELECT COUNT(*) FROM "data_series" WHERE "id" = ?', (second_id,)
+                ).fetchone() == (1,)
+                assert (
+                    sqlite_backend.connection.execute(
+                        "PRAGMA foreign_key_check"
+                    ).fetchall()
+                    == []
+                )
 
     def test_in_memory_database_uses_sqlite_convention(self):
         with SQLiteBackend(db_path=":memory:") as first_backend:
@@ -582,11 +474,10 @@ class TestSQLiteBackend:
 
     def test_additive_schema_migration(self, tmp_path):
         db_path = tmp_path / "legacy.sqlite"
-        connection = sqlite3.connect(db_path)
-        connection.execute(
-            'CREATE TABLE "data_series" ' '("id" INTEGER PRIMARY KEY, "name" TEXT)'
-        )
-        connection.close()
+        with sqlite3.connect(db_path) as connection:
+            connection.execute(
+                'CREATE TABLE "data_series" ' '("id" INTEGER PRIMARY KEY, "name" TEXT)'
+            )
 
         with SQLiteBackend(db_path=db_path) as backend:
             series = DataSeries(
@@ -605,11 +496,10 @@ class TestSQLiteBackend:
 
     def test_incompatible_schema_requires_manual_migration(self, tmp_path):
         db_path = tmp_path / "incompatible.sqlite"
-        connection = sqlite3.connect(db_path)
-        connection.execute(
-            'CREATE TABLE "data_series" ("id" TEXT PRIMARY KEY, "name" TEXT)'
-        )
-        connection.close()
+        with sqlite3.connect(db_path) as connection:
+            connection.execute(
+                'CREATE TABLE "data_series" ("id" TEXT PRIMARY KEY, "name" TEXT)'
+            )
 
         with SQLiteBackend(db_path=db_path) as backend:
             with pytest.raises(DataBaseError, match="manual database migration"):
@@ -617,17 +507,15 @@ class TestSQLiteBackend:
 
     def test_newer_schema_version_is_rejected(self, tmp_path):
         db_path = tmp_path / "future.sqlite"
-        connection = sqlite3.connect(db_path)
-        connection.execute(
-            f'CREATE TABLE "{METADATA_TABLE}" '
-            '("key" TEXT PRIMARY KEY, "value" TEXT NOT NULL)'
-        )
-        connection.execute(
-            f'INSERT INTO "{METADATA_TABLE}" VALUES (?, ?)',
-            ("schema_version", str(SCHEMA_VERSION + 1)),
-        )
-        connection.commit()
-        connection.close()
+        with sqlite3.connect(db_path) as connection:
+            connection.execute(
+                f'CREATE TABLE "{METADATA_TABLE}" '
+                '("key" TEXT PRIMARY KEY, "value" TEXT NOT NULL)'
+            )
+            connection.execute(
+                f'INSERT INTO "{METADATA_TABLE}" VALUES (?, ?)',
+                ("schema_version", str(SCHEMA_VERSION + 1)),
+            )
 
         with pytest.raises(DataBaseError, match="newer ixdat schema"):
             SQLiteBackend(db_path=db_path)
@@ -665,20 +553,14 @@ def test_memory_backend_load_by_name():
         backend.load(DataSeries, "no series has this name")
 
 
-def test_load_data_takes_a_backend_and_deprecates_db(tmp_path):
+def test_load_data_takes_a_backend_and_deprecates_db(sqlite_backend):
     """`load_data(db=...)` used to take a DataBase; it now takes a backend"""
-    original_backend = DB.backend
-    with SQLiteBackend(db_path=tmp_path / "data.sqlite") as backend:
-        DB.set_backend(backend)
-        try:
-            series = DataSeries(name="s", unit_name="V", data=np.array([1.0, 2.0]))
-            loaded = DataSeries.get(series.save())
-            assert np.array_equal(loaded.load_data(), [1.0, 2.0])
-            assert np.array_equal(loaded.load_data(backend), [1.0, 2.0])
-            with pytest.deprecated_call():
-                assert np.array_equal(loaded.load_data(db=backend), [1.0, 2.0])
-        finally:
-            DB.set_backend(original_backend)
+    series = DataSeries(name="s", unit_name="V", data=np.array([1.0, 2.0]))
+    loaded = DataSeries.get(series.save())
+    assert np.array_equal(loaded.load_data(), [1.0, 2.0])
+    assert np.array_equal(loaded.load_data(sqlite_backend), [1.0, 2.0])
+    with pytest.deprecated_call():
+        assert np.array_equal(loaded.load_data(db=sqlite_backend), [1.0, 2.0])
 
 
 def test_directory_load_uses_exact_unescaped_name(tmp_path):


### PR DESCRIPTION
## Summary

This PR lets ixdat save a complete project in one SQLite database file.

```python
from ixdat import Measurement
from ixdat.db import change_database

change_database("sqlite", db_path="my_project.sqlite")
measurement_id = measurement.save()

measurement = Measurement.get(measurement_id)
measurement = Measurement.load("my measurement")
```

SQLite is included with Python and adds zero database-package dependencies.

The database file can hold measurements, data series, spectra, calculators, calibrations, and the connections between them. Large NumPy arrays stay in the file until the user asks for their data.

## How the database layout is decided

ixdat classes already describe much of what they save:

- `table_name` says which table holds the main row.
- `column_attrs` lists the values stored in that row.
- `extra_column_attrs` lists extra values added by a more specialized class.
- `extra_linkers` lists other saved objects that belong to this object.

This PR adds two missing details:

- `column_types` says whether a value is text, a number, a dictionary, a list, a tuple, or a NumPy array.
- `column_references` says when an id points to one row in another table.

Each class describes only the information it adds. Information already described by a parent class is reused.

### How parent classes are combined

Some ixdat classes have more than one parent. `ECMSMeasurement`, for example, gets behavior and saved information from both `ECMeasurement` and `MSMeasurement`.

Python has an official order for walking through a class and its parents. This is called the **method resolution order**, usually shortened to **MRO**:

```text
ECMSMeasurement -> ECMeasurement -> MSMeasurement
                -> Measurement -> Saveable -> object
```

ixdat follows this same order when collecting information for the database. Each class in the list gets a chance to contribute the saved values it introduces. A parent that adds behavior without adding a saved value simply contributes no new column. Each actual contribution is collected once.

For an `ECMSMeasurement`:

- common values such as `name` and `technique` go in `measurement`;
- `ec_technique` goes in `ec_measurements`;
- `tspan_bg` goes in `ecms_measurements`.

All three rows use the same id, so SQLite knows that they describe one Python object.

Invalid type names and descriptions of values that do not exist raise a `DataBaseError` that names the class and value involved.

## How Python objects become tables

The new `ixdat.backends.relational` module turns the information above into a simple database blueprint (**schema**).

There are three main table shapes:

| Information in Python | Table shape | What one row means |
| --- | --- | --- |
| Values shared by one family of objects | Main table | One saved object |
| Extra values added by a specialized class | Extra table | Extra information for the same object id |
| An ordered list of connected objects | Connection table | One item and its place in the list |

A measurement produces a layout like this:

```text
measurement(
    id, name, aliases, metadata, sample_name, technique, tstamp
)

ec_measurements(
    id -> measurement.id,
    ec_technique
)

measurement_series(
    measurement_id -> measurement.id,
    position,
    data_series_id -> data_series.id
)
```

An arrow means that an id points to an existing row in another table. SQLite checks these pointers, which keeps objects from pointing to missing data.

The `position` value remembers the order of a Python list. A measurement can therefore load its data series in the same order in which they were saved. The same data series can also appear more than once in a list.

### Spectra use the same system

Spectral objects fit into the same three table shapes:

- A `Spectrum` points to one `Field` containing its numbers.
- A `Field` points to its axes in the correct order.
- A `SpectrumSeries` uses one axis for time and another for the scanned value, such as wavelength.
- A `MultiSpectrum` points to several fields in the correct order.
- A `SpectroMeasurement` points to one `SpectrumSeries`.
- An `ECOpticalMeasurement` can also point to a separate reference `Spectrum`.

SQLite makes the required tables when one of these objects is first saved. `SQLiteBackend.schema_report()` returns the exact table-building SQL for anyone who wants to inspect the full layout.

## Saving and loading

`SQLiteBackend` follows the same public interface as the existing ixdat backends:

- `save()` saves an object and everything it owns.
- `get(id)` loads one exact row.
- `load(name)` loads the newest row with that exact name.

Saving a complete group of connected objects is **all-or-nothing**. Database systems call this a transaction. If saving any part fails, SQLite removes all rows started by that save. This prevents half-saved measurements and loose child rows.

When ixdat loads a measurement, data series, or calculator, the saved kind tells ixdat which specialized Python class to rebuild. A loaded EC measurement therefore comes back with its EC behavior, and a loaded calibration comes back connected to its measurement.

NumPy arrays are stored inside the database file. Loading an object first reads its name, type, and connections. The larger numerical array is read when `.data` is accessed. This keeps the first load quick.

SQLite also checks every stored pointer and creates lookup guides for commonly searched values such as names and techniques. Database systems call these lookup guides indexes.

## Opening database files made by another ixdat version

The database file stores a layout version number.

When a future ixdat version adds a new optional value, ixdat can add an empty place for it to an older database automatically.

Changes that could alter the meaning of existing data receive a more careful response. Examples include changing text into a number or changing what an id points to. ixdat stops with a clear error so the database can be updated deliberately.

A file written with a newer layout version is also rejected. This prevents an older ixdat installation from guessing how to read a newer format.

## Relation to PR #75

[PR #75](https://github.com/ixdat/ixdat/pull/75) asked whether ixdat's Python classes could contain enough information to describe a relational database. The goal was to keep knowledge about saved values beside the classes that own those values.

A schema-generation experiment showed that the main idea worked. It also found several places where a database backend would still have to guess:

- What kind of value does each column contain?
- Which ids point to rows in another table?
- How should the two sides of a connection be named?
- How should list order be stored?
- How can every imported `Saveable` class be found?
- How should a class with several parents be handled?

This PR answers those questions and adds the SQLite backend listed as a follow-up in #75:

1. **One source for saved information.** Each `Saveable` class describes the values it owns. The SQLite backend reads that description, leaving the class information as the single source for the ixdat table layout.

2. **Familiar Python types.** Classes describe values with `int`, `float`, `str`, `dict`, `list`, `tuple`, and `numpy.ndarray`. SQLite decides how each Python type is written to the file.

3. **Clear connections between rows.** A class explicitly says when an id points to another saved object. Connection-table column names follow one simple rule based on the table names.

4. **List order is saved.** Each connection in a list receives a position. The object id and position identify that list entry.

5. **Imported classes are found automatically.** ixdat walks Python's existing list of `Saveable` child classes. Plugin classes join the same system as soon as they are imported.

6. **Classes with several parents follow Python's MRO.** Each parent contributes the saved values it introduced. All related rows share one object id.

This approach keeps the information close to the Python model. Inherited columns are stored once, and the SQLite backend reads the shared description.

## Small persistence fixes included here

Building and testing the complete database layout exposed several existing save-and-load gaps:

- Old or misspelled table references were corrected.
- `MultiSpectrum` now saves and reloads its fields and shared x-axis correctly.
- MS calibrations and background sets now reload their saved child objects only when those objects are requested.
- `ECOpticalMeasurement` now saves and reloads its reference spectrum.
- The directory backend can now write metadata containing NumPy values.
- Collecting all saved values no longer changes the class's original list.

These fixes have round-trip coverage with both the directory and SQLite backends.

## Validation

```text
python -m pytest tests/unit/test_sqlite_backend.py tests/functional/test_backends.py -q
# 44 passed

python -m pytest -q
# 228 passed; 4 existing Bruker reader setup errors also reproduce on main

invoke lint
invoke check-code-format
```

The tests cover:

- real and composed measurements;
- a basic `Spectrum`;
- an ordered `MultiSpectrum`;
- an EC-Optical measurement containing a `SpectrumSeries`;
- EC-Optical loading with and without a reference `Spectrum`;
- classes with several parents;
- calibrations and backgrounds;
- delayed loading of numerical arrays and connected child objects;
- all-or-nothing saving;
- loading by exact name;
- old and incompatible table layouts;
- several connections to one database file;
- temporary in-memory databases;
- checked pointers between tables.

The demo uses repository test data and a small made-up EC-Optical example:

```text
python development_scripts/demo_sqlite_backend.py
```

It shows an XRD `MultiSpectrum`, a time-resolved `SpectrumSeries`, its reference `Spectrum`, delayed array loading, generated tables, all-or-nothing saving, and closing and reopening the complete database.

## Review focus

The most useful areas to review are:

1. **Is each piece of information described in one place?** A class should list the new information that it saves. Information already described by a parent class should be reused. Please look for places where the same saved value is described more than once.

2. **Can ixdat save the kinds of values people normally use?** The current list covers whole numbers, decimal numbers, text, dictionaries, lists, tuples, and NumPy arrays. Please consider whether a typical ixdat plugin would need another common kind of value.

3. **Do saved objects stay connected correctly?** A measurement can point to data series, calculators, component measurements, and spectra. Some of these are ordered lists. Please check that saving and loading keeps every connection and keeps list items in the same order.

4. **What should happen when ixdat changes later?** If a future ixdat version adds a new optional value, it can add an empty place for that value to an old database automatically. If a change could alter the meaning of existing data, ixdat stops and explains that the database needs a careful manual update. Please check whether that is a sensible starting rule.
