### PR TITLE
Demo tools for sqlite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 
 # Big files from tests and docs prep
+development_scripts/**/*.sqlite
 development_scripts/**/*.png
 development_scripts/**/*.svg
 development_scripts/**/*.csv

--- a/development_scripts/reader_demonstrators/demo_autolab_reader.py
+++ b/development_scripts/reader_demonstrators/demo_autolab_reader.py
@@ -1,12 +1,9 @@
 """For use in development of the autolab reader. Requires access to sample data."""
 
-from pathlib import Path
-
+from tools_for_demos import DEMO_DATA_DIR
 from ixdat import Measurement
 
-path_to_file = Path.home() / (
-    "Dropbox/ixdat_resources/test_data/autolab/autolab_test_file.txt"
-)
+path_to_file = DEMO_DATA_DIR / "autolab/autolab_test_file.txt"
 
 meas = Measurement.read(path_to_file, reader="autolab")
 

--- a/development_scripts/reader_demonstrators/demo_avantage_reader.py
+++ b/development_scripts/reader_demonstrators/demo_avantage_reader.py
@@ -1,12 +1,9 @@
 """Sandbox script to aid in development and demo of the Avantage reader"""
 
-from pathlib import Path
-
+from tools_for_demos import DEMO_DATA_DIR
 from ixdat import Spectrum
 
-path_to_file = (
-    Path.home() / "Dropbox/ixdat_resources/test_data/avantage" / "XPS Survey.avg"
-)
+path_to_file = DEMO_DATA_DIR / "avantage/XPS Survey.avg"
 
 spectrum = Spectrum.read(path_to_file, reader="avantage")
 

--- a/development_scripts/reader_demonstrators/demo_biologic_mpr_reader.py
+++ b/development_scripts/reader_demonstrators/demo_biologic_mpr_reader.py
@@ -1,12 +1,15 @@
-from pathlib import Path
+from tools_for_demos import DEMO_DATA_DIR
 from ixdat import Measurement
 
-for data_dir in [
-    Path.home() / "Dropbox/ixdat_resources/test_data/biologic/17J04_Pt_isotope_exchange",
-    Path.home() / "Dropbox/ixdat_resources/test_data/biologic/22I27_London",
-    Path.home() / "Dropbox/ixdat_resources/test_data/biologic/22K14_Tempo",
+combined_measurement_list = []
+
+for folder in [
+    "17J04_Pt_isotope_exchange",
+    "22I27_London",
+    "22K14_Tempo",
 ]:
     combined_meas = None
+    data_dir = DEMO_DATA_DIR / "biologic" / folder
 
     for file in data_dir.iterdir():
         if not file.suffix == ".mpr":
@@ -14,7 +17,7 @@ for data_dir in [
         meas = Measurement.read(file, reader="biologic")
         print(meas)
         print("... was read successfully!\n\n")
-        meas.plot()
+        # meas.plot()
         if combined_meas:
             combined_meas = combined_meas + meas
         else:
@@ -22,3 +25,5 @@ for data_dir in [
 
     combined_meas.plot()
     combined_meas.plot(J_name="selector")
+
+    combined_measurement_list.append(combined_meas)

--- a/development_scripts/reader_demonstrators/demo_bruker_reader.py
+++ b/development_scripts/reader_demonstrators/demo_bruker_reader.py
@@ -16,7 +16,6 @@ import matplotlib.pyplot as plt
 from ixdat import Spectrum
 from ixdat.readers.bruker import ACQUS_KEYS, PROCS_KEYS
 
-
 DATA_DIR = (
     Path(__file__).parent.parent.parent
     / "test_data"

--- a/development_scripts/reader_demonstrators/demo_cinfdata_reader.py
+++ b/development_scripts/reader_demonstrators/demo_cinfdata_reader.py
@@ -1,19 +1,16 @@
 """For use in development of the cinfdata reader. Requires access to sample data."""
 
-from pathlib import Path
+from tools_for_demos import DEMO_DATA_DIR
 
 from ixdat import Measurement
 
-path_to_file = (
-    Path.home()
-    / "Dropbox/ixdat_resources/test_data/cinfdata/Trimarco2018_fig3/QMS_1.txt"
-)
+path_to_file = DEMO_DATA_DIR / "cinfdata/Trimarco2018_fig3/QMS_1.txt"
+
 ms_meas = Measurement.read(path_to_file, reader="cinfdata")
 ms_meas.plot_measurement()
 
-path_to_ec_file_start = (
-    Path.home() / "Dropbox/ixdat_resources/test_data/cinfdata/Trimarco2018_fig3/09_fig4"
-)
+path_to_ec_file_start = DEMO_DATA_DIR / "cinfdata/Trimarco2018_fig3/09_fig4"
+
 ec_meas = Measurement.read_set(path_to_ec_file_start, reader="biologic")
 ec_meas.calibrate(RE_vs_RHE=0.65, A_el=0.196)
 ec_meas.plot_measurement()

--- a/development_scripts/reader_demonstrators/demo_cinfdata_reader_TPMS.py
+++ b/development_scripts/reader_demonstrators/demo_cinfdata_reader_TPMS.py
@@ -1,0 +1,15 @@
+from tools_for_demos import DEMO_DATA_DIR
+from ixdat import Measurement
+
+data_dir = DEMO_DATA_DIR / "cinfdata/Krabbe"
+
+tpms = Measurement.read(
+    data_dir / "baratron_temp_measurement.txt.csv",
+    reader="ixdat",
+    technique="reactor",
+    aliases={"pressure": ["Reactor pressure"], "temperature": ["TC temperature"]},
+)
+
+axes = tpms.plot()
+
+axes[0].get_figure().savefig("tpms_plot.png")

--- a/development_scripts/reader_demonstrators/demo_ivium_reader.py
+++ b/development_scripts/reader_demonstrators/demo_ivium_reader.py
@@ -1,14 +1,13 @@
 """For use in development of the ivium reader. Requires access to sample data."""
 
-from pathlib import Path
+from tools_for_demos import DEMO_DATA_DIR
 import pandas as pd
 
 from ixdat import Measurement
 from ixdat.techniques import CyclicVoltammogram
 
-path_to_file = Path.home() / (
-    "Dropbox/ixdat_resources/test_data/ivium/ivium_test_dataset"
-)
+path_to_file = DEMO_DATA_DIR / "ivium/ivium_test_dataset"
+
 path_to_single_file = path_to_file.parent / (path_to_file.name + "_1")
 df = pd.read_csv(path_to_single_file, sep=r"\s+", header=1)
 

--- a/development_scripts/reader_demonstrators/demo_ixdat_csv_reader.py
+++ b/development_scripts/reader_demonstrators/demo_ixdat_csv_reader.py
@@ -2,8 +2,7 @@
 
 from ixdat import Measurement
 
-
-if True:  # test back-compatability with the ixdat v0p1 online on the tutorials page
+if False:  # test back-compatability with the ixdat v0p1 online on the tutorials page
     meas = Measurement.read_url(
         "https://raw.githubusercontent.com/ixdat/tutorials/"
         + "ixdat_v0p1/loading_appending_and_saving/co_strip.csv",

--- a/development_scripts/reader_demonstrators/demo_msrh_sec_decay_reader.py
+++ b/development_scripts/reader_demonstrators/demo_msrh_sec_decay_reader.py
@@ -2,10 +2,10 @@
 MSRH = molecular science research hub, at Imperial College London.
 """
 
-from pathlib import Path
+from tools_for_demos import DEMO_DATA_DIR
 from ixdat import Measurement
 
-data_dir = Path.home() / "Dropbox/ixdat_resources/test_data/sec"
+data_dir = DEMO_DATA_DIR / "sec"
 
 sec_meas = Measurement.read(
     # data_dir / "decay/PDtest-1.35-1OSP-SP.csv",
@@ -34,9 +34,10 @@ axes = sec_meas.plot_measurement(
 )
 # axes[0].get_figure().savefig("decay_vs_t.png")
 
-axes = sec_meas.plot_wavelengths(wavelengths=["w500", "w600", "w700", "w800"])
-
-ax_w = sec_meas.plot_waterfall()
+if False:
+    # FIXME: AttributeError: module 'matplotlib.cm' has no attribute 'get_cmap'
+    axes = sec_meas.plot_wavelengths(wavelengths=["w500", "w600", "w700", "w800"])
+    ax_w = sec_meas.plot_waterfall()
 
 # exit()
 # ax_w.get_figure().savefig("decay_waterfall.png")

--- a/development_scripts/reader_demonstrators/demo_msrh_sec_reader.py
+++ b/development_scripts/reader_demonstrators/demo_msrh_sec_reader.py
@@ -2,14 +2,14 @@
 MSRH = molecular science research hub, at Imperial College London.
 """
 
-from pathlib import Path
+from tools_for_demos import DEMO_DATA_DIR
 from ixdat import Measurement
 
 from matplotlib import pyplot as plt
 
 plt.close("all")
 
-data_dir = Path.home() / "Dropbox/ixdat_resources/test_data/sec"
+data_dir = DEMO_DATA_DIR / "sec"
 sec_meas = Measurement.read(
     data_dir / "test-7SEC.csv",
     path_to_ref_spec_file=data_dir / "WL.csv",
@@ -40,18 +40,20 @@ if True:  # test export and reload
     sec_reloaded.continuous = False
     sec_reloaded.plot_vs_potential(cmap_name="jet")
 
-axes = sec_meas.plot_measurement(
-    V_ref=0.4,
-    cmap_name="jet",
-    make_colorbar=True,
-)
+if False:
+    # FIXME: AttributeError: module 'matplotlib.cm' has no attribute 'get_cmap'
+    axes = sec_meas.plot_measurement(
+        V_ref=0.4,
+        cmap_name="jet",
+        make_colorbar=True,
+    )
 
-ax = sec_meas.plot_waterfall(
-    V_ref=0.4,
-    cmap_name="jet",
-    make_colorbar=True,
-)
-ax.get_figure().savefig("sec_waterfall.png")
+    ax = sec_meas.plot_waterfall(
+        V_ref=0.4,
+        cmap_name="jet",
+        make_colorbar=True,
+    )
+    ax.get_figure().savefig("sec_waterfall.png")
 
 axes2 = sec_meas.plot_vs_potential(V_ref=0.66, cmap_name="jet", make_colorbar=False)
 axes2 = sec_meas.plot_vs_potential(
@@ -61,8 +63,9 @@ axes2 = sec_meas.plot_vs_potential(
 ax = sec_meas.get_dOD_spectrum(V_ref=0.66, V=1.0).plot(color="b", label="species 1")
 sec_meas.get_dOD_spectrum(V_ref=1.0, V=1.45).plot(color="g", ax=ax, label="species 2")
 sec_meas.get_dOD_spectrum(V_ref=1.45, V=1.75).plot(color="r", ax=ax, label="species 3")
-
-axes = sec_meas.plot_wavelengths_vs_potential(wavelengths=["w460", "w600", "w850"])
-axes[0].set_ylabel("intense!")
+if False:
+    # FIXME: AttributeError: module 'matplotlib.cm' has no attribute 'get_cmap'
+    axes = sec_meas.plot_wavelengths_vs_potential(wavelengths=["w460", "w600", "w850"])
+    axes[0].set_ylabel("intense!")
 
 ax.legend()

--- a/development_scripts/reader_demonstrators/demo_nordic_tdms_reader.py
+++ b/development_scripts/reader_demonstrators/demo_nordic_tdms_reader.py
@@ -1,8 +1,7 @@
-from pathlib import Path
+from tools_for_demos import DEMO_DATA_DIR
 from ixdat import Measurement
 
-
-data_dir = Path.home() / "Dropbox/ixdat_resources/test_data/nordic_tdms/24B07_0_Pt"
+data_dir = DEMO_DATA_DIR / "nordic_tdms/24B07_0_Pt"
 
 c1 = Measurement.read(data_dir / "CV_101448_ 1.tdms", reader="nordic")
 
@@ -14,4 +13,7 @@ meas.plot()
 
 cv = meas.as_cv()
 cv.redefine_cycle(start_potential=0.4, redox=True)
-cv[15:30].plot_cycles()
+
+if False:
+    # FIXME AttributeError: module 'matplotlib.cm' has no attribute 'get_cmap'
+    cv[15:30].plot_cycles()

--- a/development_scripts/reader_demonstrators/demo_opus_ftir_reader.py
+++ b/development_scripts/reader_demonstrators/demo_opus_ftir_reader.py
@@ -4,7 +4,8 @@ Created on Thu Dec  7 16:20:40 2023
 
 @author: Søren
 """
-from pathlib import Path
+
+from tools_for_demos import DEMO_DATA_DIR
 from ixdat import Spectrum, Measurement
 from matplotlib import pyplot as plt
 
@@ -12,7 +13,9 @@ plt.close("all")
 
 
 data_dir = (
-    Path.home() / "Dropbox/WORKSPACES/PEOPLE_ICL/Matthew/opus_ftir/DPT files for Soren"
+    DEMO_DATA_DIR
+    / "opus_ftir/dpt_from_Matthew"
+    # Path.home() / "Dropbox/WORKSPACES/PEOPLE_ICL/Matthew/opus_ftir/DPT files for Soren"
 )
 
 
@@ -24,7 +27,9 @@ ftir = Spectrum.read(
 )
 
 ftir.heat_plot()  # heat plot
-ftir.plot_waterfall()  # waterfall plot
+if False:
+    # FIXME: AttributeError: module 'matplotlib.cm' has no attribute 'get_cmap'
+    ftir.plot_waterfall()  # waterfall plot
 ftir.plot(
     dt=1000,
     xspan=[1000, 1500],

--- a/development_scripts/reader_demonstrators/demo_pfeiffer_reader.py
+++ b/development_scripts/reader_demonstrators/demo_pfeiffer_reader.py
@@ -1,12 +1,11 @@
 """For use in development of the pfeiffer reader. Requires access to sample data."""
 
-from pathlib import Path
-
+from tools_for_demos import DEMO_DATA_DIR
 from ixdat import Measurement
 
 path_to_file = (
-    Path.home()
-    / ("Dropbox/ixdat_resources/test_data/pfeiffer")
+    DEMO_DATA_DIR
+    / "pfeiffer"
     / "MID_air, Position 1, RGA PrismaPro 200 44526001, 003-02-2021 17'41'12 - Bin.dat"
 )
 

--- a/development_scripts/reader_demonstrators/demo_qexafs_reader.py
+++ b/development_scripts/reader_demonstrators/demo_qexafs_reader.py
@@ -1,9 +1,9 @@
 """Sandbox script for use in the development of the qexafs reader"""
 
-from pathlib import Path
+from tools_for_demos import DEMO_DATA_DIR
 from ixdat import Spectrum, Measurement
 
-data_dir = Path.home() / "Dropbox/ixdat_resources/test_data/qexafs/constant potential"
+data_dir = DEMO_DATA_DIR / "qexafs/constant potential"
 
 if True:
     xas = Spectrum.read(

--- a/development_scripts/reader_demonstrators/demo_xrdml_reader.py
+++ b/development_scripts/reader_demonstrators/demo_xrdml_reader.py
@@ -1,14 +1,11 @@
 """Sandbox script to aid in development and demo of the XRDML reader"""
 
-from pathlib import Path
+from tools_for_demos import DEMO_DATA_DIR
 
 from ixdat import Spectrum
 
-path_to_file = (
-    Path.home()
-    / "Dropbox/ixdat_resources/test_data/xrdml"
-    / "GI-XRD Path 2_1 omega 0p5 step 10s.xrdml"
-)
+path_to_file = DEMO_DATA_DIR / "xrdml/GI-XRD Path 2_1 omega 0p5 step 10s.xrdml"
+
 
 spectrum = Spectrum.read(path_to_file, reader="xrdml")
 

--- a/development_scripts/reader_demonstrators/demo_zilien_reader.py
+++ b/development_scripts/reader_demonstrators/demo_zilien_reader.py
@@ -1,12 +1,10 @@
 """For use in development of the zilien reader(s). Requires access to sample data."""
 
-from pathlib import Path
-
+from tools_for_demos import DEMO_DATA_DIR
 from ixdat import Measurement
 from ixdat.techniques import MSMeasurement, ECMeasurement
 
-
-data_dir = Path.home() / "Dropbox/ixdat_resources/test_data/zilien_with_ec"
+data_dir = DEMO_DATA_DIR / "zilien_with_ec"
 
 path_to_file = data_dir / "2021-02-01 17_44_12.tsv"
 
@@ -39,7 +37,8 @@ ecms.ec_plotter.plot_vs_potential()
 ecms.ms_plotter.plot_measurement()
 
 # This plots it as a cyclic voltammagram
-
-ecms_cv = ecms.as_cv()
-ecms_cv.ec_plotter.plot_vs_potential()
-ecms_cv.plot()
+if False:
+    # FIXME: Measurement.__init__() got an unexpected keyword argument 'spectrum_id'
+    ecms_cv = ecms.as_cv()
+    ecms_cv.ec_plotter.plot_vs_potential()
+    ecms_cv.plot()

--- a/development_scripts/reader_demonstrators/demo_zilien_spectrum_reader.py
+++ b/development_scripts/reader_demonstrators/demo_zilien_spectrum_reader.py
@@ -1,10 +1,9 @@
 """For use in development of zilien spectrum reader. Requires access to sample data."""
 
-from pathlib import Path
+from tools_for_demos import DEMO_DATA_DIR
 from ixdat import Spectrum, Measurement
 
-
-data_dir = Path.home() / "Dropbox/ixdat_resources/test_data/zilien_with_spectra"
+data_dir = DEMO_DATA_DIR / "zilien_with_spectra"
 
 path_to_meas = data_dir / "2023-05-16 11_34_16 mix_cal_gas_glass_slide.tsv"
 path_to_spec = (

--- a/development_scripts/reader_demonstrators/save_all_demo_data_in_sqlite.py
+++ b/development_scripts/reader_demonstrators/save_all_demo_data_in_sqlite.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Created on Mon Aug 17 11:40:30 2026
+
+@author: soren
+"""
+
+from pathlib import Path
+from matplotlib import pyplot as plt
+from ixdat.db import change_database
+from tools_for_demos import view_tables
+
+plt.close("all")
+
+sqlite_file = Path(".") / "all_demo_data.sqlite"
+if sqlite_file.exists():
+    sqlite_file.unlink()
+
+change_database("sqlite", db_path=sqlite_file)
+
+
+# demo_asimov_reader has the objects in a main() method so can't be import from
+
+if False:
+    # FIXME: ValueError: Object arrays cannot be saved when allow_pickle=False
+    from demo_autolab_reader import meas as meas_autolab
+
+    meas_autolab.save()
+
+
+if True:
+    from demo_avantage_reader import spectrum as spec_avantage
+
+    spec_avantage.save()
+
+
+if True:
+    from demo_biologic_mpr_reader import combined_measurement_list as mm_mpr
+
+    meas_mpr = mm_mpr[0]  # One is enough.
+    meas_mpr.save()
+
+
+if True:
+    from demo_bruker_reader import fid as spec_bruker
+
+    spec_bruker.save()
+
+
+if True:
+    from demo_cinfdata_reader import ecms_meas as meas_cinfdata
+
+    meas_cinfdata.save()
+
+
+if True:
+    from demo_cinfdata_reader_TPMS import tpms as meas_tpms
+
+    meas_tpms.save()
+
+
+if False:  # requires internet
+    from demo_echemdb_reader import ref_cycle as meas_echemdb
+
+    meas_echemdb.save()
+
+
+if True:
+    from demo_ivium_reader import meas_cv as meas_ivium
+
+    meas_ivium.save()
+
+
+if True:
+    from demo_ixdat_csv_reader import meas_loaded as meas_ixdat_csv
+
+    meas_ixdat_csv.save()
+
+
+if True:
+    from demo_msrh_sec_reader import sec_meas as meas_sec
+
+    meas_sec.save()
+
+
+if True:
+    from demo_msrh_sec_decay_reader import sec_meas as meas_sec_decay
+
+    meas_sec_decay.save()
+
+
+if True:
+    from demo_nordic_tdms_reader import cv as meas_nordic
+
+    meas_nordic.save()
+
+
+if True:
+    from demo_opus_ftir_reader import ftir as spec_opus
+    from demo_opus_ftir_reader import ecftir as meas_opus_biologic
+
+    spec_opus.save()
+    meas_opus_biologic.save()  # doesn't duplicate the spectra data :)
+
+
+if False:
+    # FIXME: ValueError: Object arrays cannot be saved when allow_pickle=False
+    from demo_pfeiffer_reader import meas as meas_pfeiffer
+
+    meas_pfeiffer.save()
+
+
+if True:
+    from demo_qexafs_reader import xas_series as spec_qexafs
+    from demo_qexafs_reader import ec_xas as meas_qexafs_biologic
+
+    spec_qexafs.save()
+    meas_qexafs_biologic.save()  # doesn't duplicate the spectra data :)
+
+
+if False:  # requires internet
+    from demo_xrd_xy_reader import zsm5 as spec_xrd_xye
+    from demo_xrd_xy_reader import rutile as spec_xrd_xy
+
+    spec_xrd_xye.save()
+    spec_xrd_xy.save()
+
+
+if True:
+    from demo_xrdml_reader import spectrum as spec_xrdml
+
+    spec_xrdml.save()
+
+
+if True:
+    from demo_zilien_reader import ecms as meas_zilien
+
+    meas_zilien.save()
+
+
+if True:
+    from demo_zilien_spectrum_reader import meas_p1 as meas_zilien_spec_p1
+    from demo_zilien_spectrum_reader import meas_joined as meas_zilien_spec
+
+    meas_zilien_spec.save()
+    meas_zilien_spec_p1.save()  # doesn't re-save the already-saved spectra.
+
+view_tables(sqlite_file)

--- a/development_scripts/reader_demonstrators/tools_for_demos.py
+++ b/development_scripts/reader_demonstrators/tools_for_demos.py
@@ -1,0 +1,80 @@
+"""Save ixdat data and view the SQLite tables in a browser."""
+
+from pathlib import Path
+import html
+import sqlite3
+import webbrowser
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from urllib.parse import parse_qs
+
+DEMO_DATA_DIR = Path.home() / "PD/CHEM_research/projects/ixdat_design/test_data"
+
+
+def make_page(selected, sqlite_file):
+    db = sqlite3.connect(sqlite_file.resolve().as_uri() + "?mode=ro", uri=True)
+    tables = [
+        row[0]
+        for row in db.execute(
+            "SELECT name FROM sqlite_master "
+            "WHERE type='table' AND name NOT LIKE 'sqlite_%' ORDER BY name"
+        )
+    ]
+    table = selected if selected in tables else tables[0]
+    cursor = db.execute('SELECT * FROM "{}"'.format(table))
+    columns = [column[0] for column in cursor.description]
+    rows = cursor.fetchall()
+    db.close()
+
+    links = " ".join(
+        '<a href="/?table={0}">{0}</a>'.format(html.escape(name)) for name in tables
+    )
+    headings = "".join("<th>{}</th>".format(html.escape(name)) for name in columns)
+    body = "".join(
+        "<tr>{}</tr>".format("".join("<td>{}</td>".format(show(value)) for value in row))
+        for row in rows
+    )
+    return (
+        "<!doctype html><title>ixdat SQLite tables</title>"
+        "<style>body{{font:14px sans-serif}}a{{margin-right:1em}}"
+        "table{{border-collapse:collapse}}th,td{{border:1px solid;padding:4px}}"
+        "th{{background:#eee}}</style><h1>ixdat SQLite tables</h1>"
+        "<nav>{}</nav><h2>{}</h2><table><tr>{}</tr>{}</table>"
+    ).format(links, html.escape(table), headings, body)
+
+
+def show(value):
+    return (
+        "{} bytes".format(len(value))
+        if isinstance(value, bytes)
+        else html.escape(str(value))
+    )
+
+
+class Handler(BaseHTTPRequestHandler):
+
+    sqlite_file = None
+
+    def set_sqlite_file(self, sqlite_file):
+        self.sqlite_file = sqlite_file
+
+    def do_GET(self):
+        query = parse_qs(self.path.partition("?")[2])
+        page = make_page(
+            query.get("table", [None])[0], sqlite_file=self.sqlite_file
+        ).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "text/html; charset=utf-8")
+        self.end_headers()
+        self.wfile.write(page)
+
+
+def view_tables(sqlite_file):
+    Handler.sqlite_file = sqlite_file  # abuse of a class variable?
+    server = HTTPServer(("127.0.0.1", 0), Handler)
+    url = "http://127.0.0.1:{}".format(server.server_port)
+    print("Open {} (Ctrl+C stops the server)".format(url))
+    webbrowser.open(url)
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        server.server_close()


### PR DESCRIPTION
This is just to share a couple ideas about demo scripts and what I'm using to play around with the sqlite backend, for discussion. 
It modifies the webapp demo to a function called `view_tables`. A few minor problems came up:
- the autolab and pfeiffer readers somehow put in some object in a numpy array that can't be put into sqlite without pickling. I haven't looked into it yet.
- (not related to sql) Some of the plotters use a deprecated (now-broken) syntax for matplotlib color maps: the spectroelectrochemistry waterfall plot (which I think will be fixed in #197 ), and also `plot_cycles`.

In addition, this PR is a minor step on the way to a better demo data organization. I think the `DEMO_DATA_DIR` variable should be in a config rather than in a python script like it is now, but couldn't figure out the best way. What do you think is the best way to have large data files for testing? (We once played around with git submodules, but I think it might be easier to have people download an archive from Erda or another non-git cloud file storage service.)